### PR TITLE
Add ORCHESTRATE phase to iterate workflow

### DIFF
--- a/lib/iterate_workflow.py
+++ b/lib/iterate_workflow.py
@@ -83,12 +83,17 @@ def _reset_logger() -> None:
 class Phase(Enum):
     """TDD workflow phases.
 
+    Orchestration mode (main agent):
+        ORCHESTRATE - Coordinate subagents, never advance
+
     Optional discovery phases (before TDD loop):
         INTAKE -> DESIGN -> [TDD loop]
 
     TDD loop:
         TEST_WRITING -> IMPLEMENT -> TEST -> REVIEW -> DONE
     """
+    # Orchestration phase (main agent only - never leaves until complete)
+    ORCHESTRATE = "orchestrate"    # Coordinate subagents, manage queue
     # Optional discovery phases
     INTAKE = "intake"              # Gather requirements (no editing)
     DESIGN = "design"              # Write spec, decompose into task_queue
@@ -102,6 +107,12 @@ class Phase(Enum):
 
 # Tools allowed in each phase
 PHASE_TOOLS = {
+    Phase.ORCHESTRATE: {
+        # Orchestrate phase: coordinate workers, read queue state, spawn subagents
+        # NO editing, NO bash (orchestrator doesn't execute - it delegates)
+        "allowed": {"Read", "Task", "TodoWrite", "TaskOutput", "Glob", "Grep"},
+        "blocked": {"Edit", "Write", "NotebookEdit", "Bash"},
+    },
     Phase.INTAKE: {
         # Intake phase: gather requirements, research, no editing
         "allowed": {"Read", "Glob", "Grep", "WebSearch", "WebFetch", "Task"},
@@ -113,11 +124,11 @@ PHASE_TOOLS = {
         "blocked": set(),
     },
     Phase.TEST_WRITING: {
-        "allowed": {"Read", "Glob", "Grep", "Edit", "Write", "Bash", "Task"},
+        "allowed": {"Read", "Glob", "Grep", "Edit", "Write", "Bash"},
         "blocked": set(),
     },
     Phase.IMPLEMENT: {
-        "allowed": {"Read", "Glob", "Grep", "Edit", "Write", "Bash", "Task"},
+        "allowed": {"Read", "Glob", "Grep", "Edit", "Write", "Bash"},
         "blocked": set(),
     },
     Phase.TEST: {
@@ -127,7 +138,7 @@ PHASE_TOOLS = {
     },
     Phase.REVIEW: {
         # Review phase: fix issues from Greptile comments
-        "allowed": {"Read", "Glob", "Grep", "Edit", "Write", "Bash", "Task"},
+        "allowed": {"Read", "Glob", "Grep", "Edit", "Write", "Bash"},
         "blocked": set(),
     },
     Phase.DONE: {
@@ -159,6 +170,7 @@ def start(
     max_iterations: int = 5,
     needs_intake: bool = False,
     needs_design: bool = False,
+    orchestrate_mode: bool = False,
 ) -> dict:
     """Start a new iterate workflow.
 
@@ -167,11 +179,14 @@ def start(
         max_iterations: Max loops before requiring user checkpoint
         needs_intake: Start with intake phase (gather requirements)
         needs_design: Include design phase (write spec, create task_queue)
+        orchestrate_mode: Use orchestration mode (main agent coordinates workers)
 
     Returns:
         Current state
 
     Phase flow based on flags:
+        - orchestrate_mode=True:
+            ORCHESTRATE (permanent - never advances until workflow complete)
         - needs_intake=True, needs_design=True:
             intake -> design -> test_writing -> ...
         - needs_intake=True, needs_design=False:
@@ -182,7 +197,10 @@ def start(
             test_writing -> ...
     """
     # Determine initial phase
-    if needs_intake:
+    # orchestrate_mode takes precedence - main agent stays in ORCHESTRATE
+    if orchestrate_mode:
+        initial_phase = Phase.ORCHESTRATE
+    elif needs_intake:
         initial_phase = Phase.INTAKE
     elif needs_design:
         initial_phase = Phase.DESIGN
@@ -195,6 +213,8 @@ def start(
         "phase": initial_phase.value,
         "iteration": 0,
         "max_iterations": max_iterations,
+        # Mode flags
+        "orchestrate_mode": orchestrate_mode,
         # Discovery phase flags
         "needs_intake": needs_intake,
         "needs_design": needs_design,
@@ -209,7 +229,7 @@ def start(
     }
     _save_state(state)
     _log("info", "Workflow started", task=task, max_iterations=max_iterations,
-         needs_intake=needs_intake, needs_design=needs_design)
+         orchestrate_mode=orchestrate_mode, needs_intake=needs_intake, needs_design=needs_design)
     return state
 
 
@@ -831,6 +851,44 @@ def refresh_review_status(pr_number: Optional[int] = None) -> int:
 
     _log("info", "Review status refreshed", pr=pr_number, added=added)
     return added
+
+
+def is_orchestration_complete() -> bool:
+    """Check if orchestration is complete.
+
+    Returns True when:
+    1. Workflow is active AND in ORCHESTRATE phase, AND
+    2. Task queue has no pending tasks, AND
+    3. No active workers
+
+    This is the exit condition for ORCHESTRATE phase.
+
+    Returns:
+        True if orchestration is complete, False otherwise.
+    """
+    if not is_active():
+        return False
+
+    phase = get_phase()
+    if phase != Phase.ORCHESTRATE:
+        return False
+
+    # Check worker pool status
+    try:
+        from worker_pool import is_complete as worker_pool_is_complete
+
+        # Load queue to check if empty
+        wq = _get_workflow_queue()
+        queue_empty = wq.all_done()
+
+        return worker_pool_is_complete(queue_empty=queue_empty)
+    except ImportError:
+        # worker_pool not available - check queue only
+        wq = _get_workflow_queue()
+        return wq.all_done()
+    except Exception:
+        # Graceful degradation - return False if any error
+        return False
 
 
 # CLI interface

--- a/skills/iterate/SKILL.md
+++ b/skills/iterate/SKILL.md
@@ -6,6 +6,14 @@ TDD development loop with phase gates. Works autonomously until exit conditions 
 
 ## Flow
 
+**With ORCHESTRATE (main agent coordinates workers):**
+```
+ORCHESTRATE ──┬──→ [spawn subagents] ──→ queue empty? ──→ done
+              │                              ↓
+              └──────────── no ←─────────────┘
+```
+
+**Subagents (TDD loop):**
 ```
 test_writing → implement → test → review → done
       ↑            ↑         |       |
@@ -17,27 +25,33 @@ test_writing → implement → test → review → done
 
 | Phase | Purpose | Allowed Tools |
 |-------|---------|---------------|
-| **test_writing** | Write tests first (spec) | Read, Glob, Grep, Edit, Write, Bash, Task |
-| **implement** | Make tests pass | Read, Glob, Grep, Edit, Write, Bash, Task |
+| **orchestrate** | Main agent coordinates workers | Read, Task, TaskOutput, TodoWrite (NO Edit/Write/Bash!) |
+| **test_writing** | Write tests first (spec) | Read, Glob, Grep, Edit, Write, Bash |
+| **implement** | Make tests pass | Read, Glob, Grep, Edit, Write, Bash |
 | **test** | Run pytest, lint, coverage | Read, Glob, Grep, Bash (no editing!) |
-| **review** | Fix Greptile issues | Read, Glob, Grep, Edit, Write, Bash, Task |
+| **review** | Fix Greptile issues | Read, Glob, Grep, Edit, Write, Bash |
 
 ## Orchestrator Role
 
-**The orchestrator (you) NEVER does implementation tasks. Always spawn agents.**
+**When in ORCHESTRATE phase, you NEVER do implementation tasks. Edit/Write/Bash are BLOCKED.**
 
+The ORCHESTRATE phase enforces the orchestrator role through tool restrictions:
+- ✅ Read, Task, TaskOutput, TodoWrite - coordination tools
+- ❌ Edit, Write, NotebookEdit, Bash - blocked, spawn agents instead
+
+### Rules
 - 1 task → spawn 1 agent
 - 5 tasks → spawn 5 agents in parallel
-- No exceptions
+- No exceptions - you cannot edit code yourself
 
-### Orchestrator responsibilities
-- Plan and decompose work
-- Spawn subagents for ALL coding work
-- Monitor progress
-- Handle phase transitions
-- Aggregate results
+### Orchestrator responsibilities (ORCHESTRATE phase)
+- Read specs/queue files
+- Spawn subagents via Task tool
+- Monitor completions via TaskOutput
+- Track progress via TodoWrite
+- Check completion: `is_orchestration_complete()` → queue empty AND no workers
 
-### Subagent responsibilities
+### Subagent responsibilities (TDD loop phases)
 - Write tests (test_writing phase)
 - Write/modify code (implement phase)
 - Fix review issues (review phase)
@@ -201,7 +215,8 @@ After each agent completes:
 
 | Condition | Trigger |
 |-----------|---------|
-| `review_approved` | Review clean, workflow complete |
+| `orchestration_complete` | Queue empty AND no active workers (ORCHESTRATE mode) |
+| `review_approved` | Review clean, workflow complete (TDD loop) |
 | `max_iterations` | Hit iteration limit (default: 5) |
 | `user_stopped` | Manual `/iterate stop` |
 
@@ -209,6 +224,7 @@ After each agent completes:
 
 - Skip phases (workflow enforces order)
 - Use Edit/Write in test phase (blocked by hook)
+- Use Edit/Write/Bash in ORCHESTRATE phase (blocked - spawn agents instead)
 - Ignore kick-back (follow the loop)
 - Bypass test verification
 - Do implementation work yourself (ALWAYS spawn agents)

--- a/tests/test_iterate_workflow.py
+++ b/tests/test_iterate_workflow.py
@@ -581,3 +581,118 @@ class TestGhCliIntegration:
 
         added = refresh_review_status()
         assert added >= 0  # May be 0 if comment already exists
+
+
+class TestOrchestratePhase:
+    """Tests for ORCHESTRATE phase - main agent coordination."""
+
+    def test_orchestrate_phase_exists(self):
+        """ORCHESTRATE phase should exist in Phase enum."""
+        assert Phase.ORCHESTRATE.value == "orchestrate"
+
+    def test_orchestrate_phase_tools_blocks_editing(self):
+        """ORCHESTRATE phase should block Edit and Write."""
+        assert "Edit" in PHASE_TOOLS[Phase.ORCHESTRATE]["blocked"]
+        assert "Write" in PHASE_TOOLS[Phase.ORCHESTRATE]["blocked"]
+
+    def test_orchestrate_phase_tools_blocks_bash(self):
+        """ORCHESTRATE phase should block Bash (orchestrator doesn't run commands)."""
+        assert "Bash" in PHASE_TOOLS[Phase.ORCHESTRATE]["blocked"]
+
+    def test_orchestrate_phase_allows_read(self):
+        """ORCHESTRATE phase should allow Read."""
+        assert "Read" in PHASE_TOOLS[Phase.ORCHESTRATE]["allowed"]
+
+    def test_orchestrate_phase_allows_task(self):
+        """ORCHESTRATE phase should allow Task (for spawning subagents)."""
+        assert "Task" in PHASE_TOOLS[Phase.ORCHESTRATE]["allowed"]
+
+    def test_orchestrate_phase_allows_todowrite(self):
+        """ORCHESTRATE phase should allow TodoWrite."""
+        assert "TodoWrite" in PHASE_TOOLS[Phase.ORCHESTRATE]["allowed"]
+
+
+class TestOrchestrateStart:
+    """Tests for starting workflow in orchestrate mode."""
+
+    def test_start_with_orchestrate_mode(self):
+        """start() with orchestrate_mode=True should begin in ORCHESTRATE phase."""
+        start("Test task", orchestrate_mode=True)
+        assert get_phase() == Phase.ORCHESTRATE
+
+    def test_start_orchestrate_sets_flag(self):
+        """start() with orchestrate_mode should set orchestrate_mode flag in state."""
+        start("Test task", orchestrate_mode=True)
+        state = get_state()
+        assert state.get("orchestrate_mode") is True
+
+    def test_orchestrate_overrides_needs_intake(self):
+        """orchestrate_mode should take precedence over needs_intake."""
+        start("Test task", needs_intake=True, orchestrate_mode=True)
+        assert get_phase() == Phase.ORCHESTRATE
+
+    def test_orchestrate_overrides_needs_design(self):
+        """orchestrate_mode should take precedence over needs_design."""
+        start("Test task", needs_design=True, orchestrate_mode=True)
+        assert get_phase() == Phase.ORCHESTRATE
+
+
+class TestOrchestrateCompletion:
+    """Tests for orchestration completion detection."""
+
+    def test_is_orchestration_complete_function_exists(self):
+        """is_orchestration_complete function should be importable."""
+        from iterate_workflow import is_orchestration_complete
+        assert callable(is_orchestration_complete)
+
+    def test_is_orchestration_complete_false_when_inactive(self):
+        """is_orchestration_complete returns False when workflow not active."""
+        from iterate_workflow import is_orchestration_complete
+        # No workflow started
+        assert is_orchestration_complete() is False
+
+    def test_is_orchestration_complete_false_with_active_workers(self, monkeypatch):
+        """is_orchestration_complete returns False when workers are active."""
+        from iterate_workflow import is_orchestration_complete
+        import sys
+        from pathlib import Path
+
+        # Mock worker_pool.is_complete to return False (workers active)
+        worker_pool_path = Path(__file__).parent.parent / "lib"
+        sys.path.insert(0, str(worker_pool_path))
+
+        def mock_is_complete(queue_empty):
+            return False  # Workers still active
+
+        import worker_pool
+        monkeypatch.setattr(worker_pool, "is_complete", mock_is_complete)
+
+        start("Test task", orchestrate_mode=True)
+        assert is_orchestration_complete() is False
+
+    def test_is_orchestration_complete_true_when_done(self, monkeypatch):
+        """is_orchestration_complete returns True when queue empty and no workers."""
+        from iterate_workflow import is_orchestration_complete
+        import sys
+        from pathlib import Path
+
+        # Mock worker_pool.is_complete to return True (all done)
+        worker_pool_path = Path(__file__).parent.parent / "lib"
+        sys.path.insert(0, str(worker_pool_path))
+
+        def mock_is_complete(queue_empty):
+            return queue_empty  # Done if queue is empty
+
+        import worker_pool
+        monkeypatch.setattr(worker_pool, "is_complete", mock_is_complete)
+
+        # Also mock _get_workflow_queue to return a queue that reports all_done
+        class MockQueue:
+            def all_done(self):
+                return True
+
+        monkeypatch.setattr("iterate_workflow._get_workflow_queue", lambda: MockQueue())
+
+        start("Test task", orchestrate_mode=True)
+        # With empty queue and mocked completion, should be complete
+        assert is_orchestration_complete() is True


### PR DESCRIPTION
## Summary
- Adds ORCHESTRATE phase to iterate workflow for main agent coordination
- Enforces tool restrictions: Read/Task/TaskOutput/TodoWrite allowed; Edit/Write/Bash blocked
- Main agent stays in ORCHESTRATE permanently, spawning subagents for all work
- Exit condition: task queue empty AND no active workers

## Changes
- `lib/iterate_workflow.py`: Added ORCHESTRATE phase, `orchestrate_mode` parameter, `is_orchestration_complete()` function
- `tests/test_iterate_workflow.py`: Added 14 tests for ORCHESTRATE functionality
- `skills/iterate/SKILL.md`: Updated documentation with orchestrator flow and restrictions

## Test plan
- [x] All 14 ORCHESTRATE phase tests pass
- [x] Lint passes for new code
- [ ] Integration test with actual subagent spawning

🤖 Generated with [Claude Code](https://claude.com/claude-code)