### PR TITLE
Fix telemetry token extraction to use deltas instead of cumulative

### DIFF
--- a/scripts/charts.py
+++ b/scripts/charts.py
@@ -2188,22 +2188,26 @@ def chart_cache_efficiency():
 
     <div class="stats">
         <div class="stat">
-            <div class="stat-value">{sum(cache_reads)/1_000_000_000:.2f}B</div>
-            <div class="stat-label">Cache Hits</div>
+            <div class="stat-value">{sum(cache_reads)/1_000_000:.1f}M</div>
+            <div class="stat-label">Cache Hits (tokens)</div>
         </div>
         <div class="stat">
-            <div class="stat-value">{sum(cache_creates)/1_000_000:.0f}M</div>
-            <div class="stat-label">Cache Misses</div>
+            <div class="stat-value">{sum(cache_creates)/1_000_000:.1f}M</div>
+            <div class="stat-label">Cache Misses (tokens)</div>
         </div>
         <div class="stat">
             <div class="stat-value">{round(sum(cache_reads)/(sum(cache_reads)+sum(cache_creates))*100 if sum(cache_reads)+sum(cache_creates) > 0 else 0, 1)}%</div>
             <div class="stat-label">Hit Rate</div>
         </div>
         <div class="stat">
-            <div class="stat-value">{(sum(cache_reads)+sum(cache_creates))/1_000_000_000:.1f}B</div>
-            <div class="stat-label">Total Context</div>
+            <div class="stat-value">${sum(cache_reads) * 0.90 * 8 / 1_000_000:.0f}</div>
+            <div class="stat-label">Est. Savings (API)</div>
         </div>
     </div>
+    <p style="color: #666; text-align: center; font-size: 12px; margin-top: -10px;">
+        Savings estimate: cache hits × 90% discount × $8/M avg input price (blend of Opus $15 + Sonnet $3).
+        Subscription users pay flat rate but benefit from faster responses and lower latency.
+    </p>
 
     <div class="controls">
         <select id="viewSelect" onchange="switchView()">

--- a/scripts/extract_actual_tokens.py
+++ b/scripts/extract_actual_tokens.py
@@ -2,6 +2,7 @@
 """Extract actual token usage from all Claude Code transcripts.
 
 Parses .jsonl transcript files to build accurate historical token data.
+Computes DELTAS between consecutive messages (not cumulative sums).
 Backfills daily_summaries in telemetry.json with real API usage.
 
 Usage:
@@ -12,7 +13,7 @@ Usage:
 
 import json
 import argparse
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from collections import defaultdict
 import sys
@@ -22,9 +23,38 @@ TELEMETRY_FILE = Path.home() / ".claude/plugins/agent-swarm/.state/telemetry.jso
 STATE_DIR = Path.home() / ".claude/plugins/agent-swarm/.state"
 
 
-def parse_transcript(filepath: Path) -> list[dict]:
-    """Parse a single transcript file and extract usage data."""
-    entries = []
+def parse_timestamp(ts: str) -> datetime | None:
+    """Parse ISO timestamp to datetime."""
+    if not ts:
+        return None
+    try:
+        # Handle various ISO formats
+        ts = ts.replace("Z", "+00:00")
+        if "." in ts:
+            # Truncate microseconds if too long
+            parts = ts.split(".")
+            if "+" in parts[1]:
+                micro, tz = parts[1].split("+")
+                ts = f"{parts[0]}.{micro[:6]}+{tz}"
+            elif "-" in parts[1] and parts[1].count("-") == 1:
+                micro, tz = parts[1].split("-")
+                ts = f"{parts[0]}.{micro[:6]}-{tz}"
+        return datetime.fromisoformat(ts)
+    except:
+        return None
+
+
+def parse_transcript(filepath: Path) -> dict:
+    """Parse a single transcript file and extract usage data with deltas.
+
+    Returns dict with:
+        - entries: list of usage entries with delta values
+        - session_id: the session ID
+        - final_cumulative: final cumulative values (absolutes)
+        - start_time, end_time: session time bounds
+    """
+    raw_entries = []
+    session_id = None
 
     try:
         content = filepath.read_text(errors='replace')
@@ -35,42 +65,113 @@ def parse_transcript(filepath: Path) -> list[dict]:
                 data = json.loads(line)
                 msg = data.get("message", {})
 
+                # Capture session_id from any entry
+                if not session_id and data.get("sessionId"):
+                    session_id = data.get("sessionId")
+
                 # Only care about assistant messages with usage data
                 if msg.get("role") == "assistant" and "usage" in msg:
                     usage = msg["usage"]
+                    ts = data.get("timestamp", "")
 
-                    entry = {
-                        "timestamp": data.get("timestamp", ""),
+                    raw_entries.append({
+                        "timestamp": ts,
+                        "parsed_ts": parse_timestamp(ts),
                         "model": msg.get("model", "unknown"),
                         "input_tokens": usage.get("input_tokens", 0),
                         "output_tokens": usage.get("output_tokens", 0),
                         "cache_read": usage.get("cache_read_input_tokens", 0),
                         "cache_create": usage.get("cache_creation_input_tokens", 0),
                         "agent_id": data.get("agentId", "main"),
-                        "session_id": data.get("sessionId", ""),
+                        "session_id": data.get("sessionId", session_id or "unknown"),
                         "git_branch": data.get("gitBranch", ""),
-                    }
-
-                    # Calculate total tokens
-                    entry["total_tokens"] = (
-                        entry["input_tokens"] +
-                        entry["output_tokens"] +
-                        entry["cache_read"] +
-                        entry["cache_create"]
-                    )
-
-                    entries.append(entry)
+                    })
             except json.JSONDecodeError:
                 continue
     except Exception as e:
         print(f"  Warning: Could not parse {filepath.name}: {e}", file=sys.stderr)
+        return {"entries": [], "session_id": None}
 
-    return entries
+    if not raw_entries:
+        return {"entries": [], "session_id": session_id}
+
+    # Sort by timestamp within this transcript
+    raw_entries.sort(key=lambda x: x["timestamp"])
+
+    # Compute deltas between consecutive entries
+    delta_entries = []
+    prev = {"input_tokens": 0, "output_tokens": 0, "cache_read": 0, "cache_create": 0}
+
+    for entry in raw_entries:
+        # Calculate delta from previous entry
+        delta = {
+            "timestamp": entry["timestamp"],
+            "parsed_ts": entry["parsed_ts"],
+            "model": entry["model"],
+            "agent_id": entry["agent_id"],
+            "session_id": entry["session_id"],
+            "git_branch": entry["git_branch"],
+            # Delta values (incremental)
+            "input_tokens": max(0, entry["input_tokens"] - prev["input_tokens"]),
+            "output_tokens": max(0, entry["output_tokens"] - prev["output_tokens"]),
+            "cache_read": max(0, entry["cache_read"] - prev["cache_read"]),
+            "cache_create": max(0, entry["cache_create"] - prev["cache_create"]),
+            # Also store cumulative for reference
+            "cumulative_input": entry["input_tokens"],
+            "cumulative_output": entry["output_tokens"],
+            "cumulative_cache_read": entry["cache_read"],
+            "cumulative_cache_create": entry["cache_create"],
+        }
+
+        # Total delta
+        delta["total_tokens"] = (
+            delta["input_tokens"] +
+            delta["output_tokens"] +
+            delta["cache_read"] +
+            delta["cache_create"]
+        )
+
+        delta_entries.append(delta)
+        prev = {
+            "input_tokens": entry["input_tokens"],
+            "output_tokens": entry["output_tokens"],
+            "cache_read": entry["cache_read"],
+            "cache_create": entry["cache_create"],
+        }
+
+    # Get final cumulative values (absolutes)
+    final = raw_entries[-1] if raw_entries else {}
+    final_cumulative = {
+        "input_tokens": final.get("input_tokens", 0),
+        "output_tokens": final.get("output_tokens", 0),
+        "cache_read": final.get("cache_read", 0),
+        "cache_create": final.get("cache_create", 0),
+        "total_tokens": (
+            final.get("input_tokens", 0) +
+            final.get("output_tokens", 0) +
+            final.get("cache_read", 0) +
+            final.get("cache_create", 0)
+        ),
+    }
+
+    # Get time bounds
+    start_time = raw_entries[0]["parsed_ts"] if raw_entries else None
+    end_time = raw_entries[-1]["parsed_ts"] if raw_entries else None
+
+    return {
+        "entries": delta_entries,
+        "session_id": session_id,
+        "final_cumulative": final_cumulative,
+        "start_time": start_time,
+        "end_time": end_time,
+        "call_count": len(delta_entries),
+    }
 
 
 def extract_all_usage() -> dict:
     """Extract usage from all transcript files."""
     all_entries = []
+    sessions = {}  # session_id -> session metadata
     files_processed = 0
     files_with_data = 0
 
@@ -82,30 +183,56 @@ def extract_all_usage() -> dict:
         if (i + 1) % 200 == 0:
             print(f"  Processing {i + 1}/{len(transcript_files)}...")
 
-        entries = parse_transcript(filepath)
+        result = parse_transcript(filepath)
+        entries = result["entries"]
+
         if entries:
             all_entries.extend(entries)
             files_with_data += 1
+
+            # Track session metadata
+            sid = result["session_id"] or filepath.stem
+            if sid not in sessions or (result["end_time"] and
+                (sessions[sid].get("end_time") is None or
+                 result["end_time"] > sessions[sid]["end_time"])):
+                sessions[sid] = {
+                    "start_time": result["start_time"],
+                    "end_time": result["end_time"],
+                    "final_cumulative": result["final_cumulative"],
+                    "call_count": result["call_count"],
+                }
         files_processed += 1
 
     print(f"Processed {files_processed} files, {files_with_data} had usage data")
-    print(f"Extracted {len(all_entries)} API call records")
+    print(f"Extracted {len(all_entries)} API call records (delta-based)")
+    print(f"Found {len(sessions)} unique sessions")
 
-    return {"entries": all_entries, "files_processed": files_processed}
+    return {
+        "entries": all_entries,
+        "sessions": sessions,
+        "files_processed": files_processed,
+    }
 
 
-def aggregate_by_day(entries: list[dict]) -> dict:
-    """Aggregate entries by date."""
+def aggregate_by_day(entries: list[dict], sessions: dict) -> dict:
+    """Aggregate entries by date with both incremental and absolute values."""
     daily = defaultdict(lambda: {
+        # Incremental (delta-based) - actual work done
         "calls": 0,
         "input_tokens": 0,
         "output_tokens": 0,
         "cache_read": 0,
         "cache_create": 0,
         "total_tokens": 0,
+        # Session tracking for work hours
+        "session_times": [],  # list of (start, end) tuples
+        "work_hours": 0,
+        # Breakdowns
         "by_model": defaultdict(lambda: {"calls": 0, "tokens": 0}),
         "by_agent": defaultdict(lambda: {"calls": 0, "tokens": 0}),
-        "by_session": defaultdict(lambda: {"calls": 0, "tokens": 0, "start": None, "end": None}),
+        "by_session": defaultdict(lambda: {
+            "calls": 0, "tokens": 0, "start": None, "end": None
+        }),
     })
 
     for entry in entries:
@@ -115,10 +242,7 @@ def aggregate_by_day(entries: list[dict]) -> dict:
 
         # Parse date from ISO timestamp
         try:
-            if "T" in ts:
-                date = ts.split("T")[0]
-            else:
-                date = ts[:10]
+            date = ts.split("T")[0] if "T" in ts else ts[:10]
         except:
             continue
 
@@ -140,71 +264,120 @@ def aggregate_by_day(entries: list[dict]) -> dict:
         day["by_agent"][agent]["calls"] += 1
         day["by_agent"][agent]["tokens"] += entry["total_tokens"]
 
-        # By session
+        # By session - track time bounds
         session = entry.get("session_id", "unknown") or "unknown"
         day["by_session"][session]["calls"] += 1
         day["by_session"][session]["tokens"] += entry["total_tokens"]
-        # Track session time range
-        if day["by_session"][session]["start"] is None or ts < day["by_session"][session]["start"]:
-            day["by_session"][session]["start"] = ts
-        if day["by_session"][session]["end"] is None or ts > day["by_session"][session]["end"]:
-            day["by_session"][session]["end"] = ts
 
-    # Convert defaultdicts to regular dicts for JSON serialization
+        parsed_ts = entry.get("parsed_ts")
+        if parsed_ts:
+            if day["by_session"][session]["start"] is None or ts < day["by_session"][session]["start"]:
+                day["by_session"][session]["start"] = ts
+            if day["by_session"][session]["end"] is None or ts > day["by_session"][session]["end"]:
+                day["by_session"][session]["end"] = ts
+
+    # Calculate work hours per day from session time spans
+    for date, data in daily.items():
+        total_hours = 0
+        for sid, sdata in data["by_session"].items():
+            if sdata["start"] and sdata["end"]:
+                start = parse_timestamp(sdata["start"])
+                end = parse_timestamp(sdata["end"])
+                if start and end and end > start:
+                    hours = (end - start).total_seconds() / 3600
+                    total_hours += hours
+        data["work_hours"] = round(total_hours, 2)
+
+    # Convert defaultdicts and add normalized metrics
     result = {}
     for date, data in daily.items():
+        work_hours = data["work_hours"] or 1  # Avoid division by zero
+        calls = data["calls"] or 1
+
         result[date] = {
+            # Incremental (actual work)
             "calls": data["calls"],
             "input_tokens": data["input_tokens"],
             "output_tokens": data["output_tokens"],
             "cache_read": data["cache_read"],
             "cache_create": data["cache_create"],
             "total_tokens": data["total_tokens"],
+            # Time tracking
+            "work_hours": data["work_hours"],
+            "sessions": len(data["by_session"]),
+            # Normalized metrics (for comparison)
+            "tokens_per_hour": round(data["total_tokens"] / work_hours),
+            "tokens_per_call": round(data["total_tokens"] / calls),
+            "calls_per_hour": round(calls / work_hours, 1),
+            # Breakdowns
             "by_model": dict(data["by_model"]),
             "by_agent": dict(data["by_agent"]),
-            "by_session": dict(data["by_session"]),
+            "by_session": {k: dict(v) for k, v in data["by_session"].items()},
         }
 
     return result
 
 
-def print_summary(daily_data: dict):
+def calculate_session_absolutes(sessions: dict) -> dict:
+    """Calculate absolute totals from session final values."""
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read": 0,
+        "cache_create": 0,
+        "total_tokens": 0,
+        "sessions": len(sessions),
+    }
+
+    for sid, sdata in sessions.items():
+        final = sdata.get("final_cumulative", {})
+        totals["input_tokens"] += final.get("input_tokens", 0)
+        totals["output_tokens"] += final.get("output_tokens", 0)
+        totals["cache_read"] += final.get("cache_read", 0)
+        totals["cache_create"] += final.get("cache_create", 0)
+        totals["total_tokens"] += final.get("total_tokens", 0)
+
+    return totals
+
+
+def print_summary(daily_data: dict, session_absolutes: dict):
     """Print a summary of the extracted data."""
-    print("\n" + "=" * 80)
-    print("DAILY TOKEN USAGE SUMMARY (Actual API Data)")
-    print("=" * 80)
+    print("\n" + "=" * 100)
+    print("DAILY TOKEN USAGE SUMMARY (Delta-based Incremental)")
+    print("=" * 100)
 
     total_tokens = 0
     total_calls = 0
-    total_sessions = 0
+    total_hours = 0
+
+    header = f"{'Date':<12} {'Tokens':>14} {'Calls':>7} {'Hours':>6} {'Tok/Hr':>10} {'Tok/Call':>10} {'Sessions':>8}"
+    print(header)
+    print("-" * 100)
 
     for date in sorted(daily_data.keys()):
         data = daily_data[date]
         total_tokens += data["total_tokens"]
         total_calls += data["calls"]
-        sessions = len(data.get("by_session", {}))
-        total_sessions += sessions
+        total_hours += data["work_hours"]
 
-        # Format numbers with commas
-        tokens_fmt = f"{data['total_tokens']:,}"
-        calls_fmt = f"{data['calls']:,}"
+        print(f"{date:<12} {data['total_tokens']:>14,} {data['calls']:>7,} "
+              f"{data['work_hours']:>6.1f} {data['tokens_per_hour']:>10,} "
+              f"{data['tokens_per_call']:>10,} {data['sessions']:>8}")
 
-        # Model breakdown
-        models = ", ".join(f"{m}: {d['calls']}" for m, d in sorted(data["by_model"].items()))
+    print("-" * 100)
+    avg_tok_hr = round(total_tokens / total_hours) if total_hours > 0 else 0
+    avg_tok_call = round(total_tokens / total_calls) if total_calls > 0 else 0
+    print(f"{'TOTAL':<12} {total_tokens:>14,} {total_calls:>7,} "
+          f"{total_hours:>6.1f} {avg_tok_hr:>10,} {avg_tok_call:>10,}")
+    print("=" * 100)
 
-        print(f"{date}: {tokens_fmt:>15} tokens | {calls_fmt:>6} calls | {sessions:>3} sessions | {models}")
-
-    print("-" * 80)
-    print(f"TOTAL:     {total_tokens:>15,} tokens | {total_calls:>6,} calls | {total_sessions:>3} sessions")
-    print("=" * 80)
-
-    # Cache efficiency
-    total_cache_read = sum(d["cache_read"] for d in daily_data.values())
-    total_cache_create = sum(d["cache_create"] for d in daily_data.values())
+    # Token breakdown
     total_input = sum(d["input_tokens"] for d in daily_data.values())
     total_output = sum(d["output_tokens"] for d in daily_data.values())
+    total_cache_read = sum(d["cache_read"] for d in daily_data.values())
+    total_cache_create = sum(d["cache_create"] for d in daily_data.values())
 
-    print(f"\nToken Breakdown:")
+    print(f"\nIncremental Token Breakdown (Delta-based):")
     print(f"  Input tokens:        {total_input:>15,}")
     print(f"  Output tokens:       {total_output:>15,}")
     print(f"  Cache read (hits):   {total_cache_read:>15,}")
@@ -212,45 +385,60 @@ def print_summary(daily_data: dict):
 
     if total_cache_read + total_cache_create > 0:
         cache_hit_rate = total_cache_read / (total_cache_read + total_cache_create) * 100
-        print(f"\n  Cache hit rate: {cache_hit_rate:.1f}%")
+        print(f"  Cache hit rate:      {cache_hit_rate:>14.1f}%")
+
+    # Session absolutes (cumulative final values)
+    print(f"\nSession Absolutes (Final cumulative per session):")
+    print(f"  Sessions:            {session_absolutes['sessions']:>15,}")
+    print(f"  Total tokens:        {session_absolutes['total_tokens']:>15,}")
+    print(f"  Input tokens:        {session_absolutes['input_tokens']:>15,}")
+    print(f"  Output tokens:       {session_absolutes['output_tokens']:>15,}")
+    print(f"  Cache read:          {session_absolutes['cache_read']:>15,}")
+    print(f"  Cache create:        {session_absolutes['cache_create']:>15,}")
 
 
-def update_telemetry(daily_data: dict):
+def update_telemetry(daily_data: dict, session_absolutes: dict):
     """Update telemetry.json with actual historical data."""
     if TELEMETRY_FILE.exists():
         telemetry = json.loads(TELEMETRY_FILE.read_text())
     else:
         telemetry = {"events": [], "daily_summaries": {}, "aggregates": {}}
 
-    # Create new daily_summaries_actual section
-    telemetry["daily_summaries_actual"] = {}
+    # Store both incremental and absolute data
+    telemetry["daily_summaries_incremental"] = {}
+    telemetry["session_absolutes"] = session_absolutes
 
     for date, data in daily_data.items():
-        telemetry["daily_summaries_actual"][date] = {
+        telemetry["daily_summaries_incremental"][date] = {
             "calls": data["calls"],
             "tokens": data["total_tokens"],
             "input_tokens": data["input_tokens"],
             "output_tokens": data["output_tokens"],
             "cache_read": data["cache_read"],
             "cache_create": data["cache_create"],
+            "work_hours": data["work_hours"],
+            "sessions": data["sessions"],
+            "tokens_per_hour": data["tokens_per_hour"],
+            "tokens_per_call": data["tokens_per_call"],
+            "calls_per_hour": data["calls_per_hour"],
             "by_model": data["by_model"],
             "by_agent": data["by_agent"],
-            "by_session": data["by_session"],
         }
 
-    # Also update the regular daily_summaries with total_tokens
+    # Update the regular daily_summaries with incremental values
     for date, data in daily_data.items():
-        if date not in telemetry.get("daily_summaries", {}):
-            telemetry.setdefault("daily_summaries", {})[date] = {
-                "calls": data["calls"],
-                "tokens": data["total_tokens"],
-                "errors": 0,
-                "duration_ms": 0
-            }
-        else:
-            # Update tokens with actual value
-            telemetry["daily_summaries"][date]["tokens"] = data["total_tokens"]
-            telemetry["daily_summaries"][date]["calls"] = data["calls"]
+        telemetry.setdefault("daily_summaries", {})[date] = {
+            "calls": data["calls"],
+            "tokens": data["total_tokens"],
+            "input_tokens": data.get("input_tokens", 0),
+            "output_tokens": data.get("output_tokens", 0),
+            "cache_read": data.get("cache_read", 0),
+            "cache_create": data.get("cache_create", 0),
+            "work_hours": data["work_hours"],
+            "tokens_per_hour": data["tokens_per_hour"],
+            "errors": telemetry.get("daily_summaries", {}).get(date, {}).get("errors", 0),
+            "duration_ms": telemetry.get("daily_summaries", {}).get(date, {}).get("duration_ms", 0),
+        }
 
     # Save
     TELEMETRY_FILE.write_text(json.dumps(telemetry, indent=2))
@@ -258,14 +446,19 @@ def update_telemetry(daily_data: dict):
 
 
 def export_csv(daily_data: dict):
-    """Export to CSV file."""
+    """Export to CSV file with normalized metrics."""
     csv_file = STATE_DIR / "token_usage_history.csv"
 
-    lines = ["date,calls,total_tokens,input_tokens,output_tokens,cache_read,cache_create"]
+    lines = ["date,calls,total_tokens,input_tokens,output_tokens,cache_read,cache_create,work_hours,tokens_per_hour,tokens_per_call,calls_per_hour,sessions"]
 
     for date in sorted(daily_data.keys()):
-        data = daily_data[date]
-        lines.append(f"{date},{data['calls']},{data['total_tokens']},{data['input_tokens']},{data['output_tokens']},{data['cache_read']},{data['cache_create']}")
+        d = daily_data[date]
+        lines.append(
+            f"{date},{d['calls']},{d['total_tokens']},{d['input_tokens']},"
+            f"{d['output_tokens']},{d['cache_read']},{d['cache_create']},"
+            f"{d['work_hours']},{d['tokens_per_hour']},{d['tokens_per_call']},"
+            f"{d['calls_per_hour']},{d['sessions']}"
+        )
 
     csv_file.write_text("\n".join(lines))
     print(f"\n✅ Exported to {csv_file}")
@@ -278,25 +471,30 @@ def main():
     args = parser.parse_args()
 
     print("Extracting token usage from Claude Code transcripts...")
+    print("(Computing deltas between consecutive messages per session)")
     print()
 
     # Extract all usage data
     result = extract_all_usage()
     entries = result["entries"]
+    sessions = result["sessions"]
 
     if not entries:
         print("No usage data found!")
         return
 
-    # Aggregate by day
-    daily_data = aggregate_by_day(entries)
+    # Aggregate by day (incremental/delta-based)
+    daily_data = aggregate_by_day(entries, sessions)
+
+    # Calculate session absolutes
+    session_absolutes = calculate_session_absolutes(sessions)
 
     # Print summary
-    print_summary(daily_data)
+    print_summary(daily_data, session_absolutes)
 
     # Update telemetry if requested
     if args.update:
-        update_telemetry(daily_data)
+        update_telemetry(daily_data, session_absolutes)
 
     # Export CSV if requested
     if args.export:


### PR DESCRIPTION
## Summary
- Fixed token extraction bug that inflated numbers by ~32x
- Transcript extraction was summing cumulative API usage values instead of computing deltas between messages
- Added normalized metrics (tokens/hour, tokens/call, work_hours) for comparing productivity across sessions
- Updated cache efficiency chart with realistic API savings estimate

## Before/After
| Metric | Before (Bug) | After (Fixed) |
|--------|-------------|---------------|
| Total tokens | 3.86B | 121M |
| Tokens/call | ~79K | ~2.5K |
| Cache hit rate | 95.6% | 57.5% |
| Est. API savings | $60K | $482 |

## Test plan
- [x] Run `python3 scripts/extract_actual_tokens.py` - shows correct delta-based numbers
- [x] Run `python3 scripts/charts.py dashboard` - generates charts with accurate data
- [ ] Verify charts display correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)