### PR TITLE
fix: block subagents from modifying workflow state

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -19,6 +19,11 @@
             "type": "command",
             "command": "python3 /home/fearsidhe/.claude/plugins/agent-swarm/hooks/iterate-enforcement.py",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/fearsidhe/.claude/plugins/agent-swarm/hooks/workflow-state-enforcement.py",
+            "timeout": 3
           }
         ]
       },

--- a/hooks/workflow-state-enforcement.py
+++ b/hooks/workflow-state-enforcement.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Workflow state modification enforcement hook.
+
+This hook prevents subagents from modifying workflow state directly.
+Only the orchestrator (main session without agentId) should control
+workflow transitions.
+
+Blocked for subagents:
+- workflow_start, workflow_stop, workflow_update
+- workflow_set_state, workflow_set_value
+
+Allowed for subagents:
+- workflow_get_state, workflow_get_value, workflow_is_active (read-only)
+- agent_set_state (only for their own agent state)
+"""
+
+import sys
+import json
+
+# Workflow state modification tools that subagents cannot use
+WORKFLOW_MODIFY_TOOLS = {
+    # Base names
+    "workflow_start",
+    "workflow_stop",
+    "workflow_update",
+    "workflow_set_state",
+    "workflow_set_value",
+    # With workflow__ prefix (MCP format)
+    "workflow__workflow_start",
+    "workflow__workflow_stop",
+    "workflow__workflow_update",
+    "workflow__workflow_set_state",
+    "workflow__workflow_set_value",
+}
+
+# Agent state modification tool
+AGENT_SET_STATE_TOOLS = {
+    "agent_set_state",
+    "workflow__agent_set_state",
+}
+
+
+def normalize_tool_name(tool_name: str) -> str:
+    """Remove mcp__router__ prefix if present."""
+    if tool_name.startswith("mcp__router__"):
+        return tool_name[len("mcp__router__"):]
+    return tool_name
+
+
+def allow(reason: str = "") -> dict:
+    """Return allow decision."""
+    result = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow"
+        }
+    }
+    if reason:
+        result["hookSpecificOutput"]["permissionDecisionReason"] = reason
+    return result
+
+
+def block(reason: str) -> dict:
+    """Return block decision."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    }
+
+
+def main():
+    """Main enforcement logic."""
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError:
+        print(json.dumps(allow()))
+        return
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    agent_id = input_data.get("agentId")  # Present if this is a subagent
+
+    # Normalize tool name
+    normalized_tool = normalize_tool_name(tool_name)
+
+    # If not a subagent (no agentId), allow everything
+    if not agent_id:
+        print(json.dumps(allow()))
+        return
+
+    # Subagent context - check for blocked tools
+
+    # Block workflow state modification tools
+    if normalized_tool in WORKFLOW_MODIFY_TOOLS:
+        print(json.dumps(block(
+            f"[SUBAGENT BLOCKED] {normalized_tool}: Subagents cannot modify workflow state. "
+            f"Only the orchestrator controls workflow transitions."
+        )))
+        return
+
+    # For agent_set_state, only allow if modifying own state
+    if normalized_tool in AGENT_SET_STATE_TOOLS:
+        target_agent_id = tool_input.get("agent_id", "")
+        if target_agent_id != agent_id:
+            print(json.dumps(block(
+                f"[SUBAGENT BLOCKED] {normalized_tool}: Subagent '{agent_id}' cannot modify "
+                f"another agent's state ('{target_agent_id}'). Subagents can only modify their own state."
+            )))
+            return
+
+    # All other tools are allowed
+    print(json.dumps(allow()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_workflow_state_enforcement.py
+++ b/tests/test_workflow_state_enforcement.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Tests for workflow state modification enforcement.
+
+Verifies that subagents (identified by agentId) cannot modify workflow state.
+Only the orchestrator should be able to control workflow transitions.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+import pytest
+import importlib.util
+
+
+def load_hook_module(hook_name: str):
+    """Load a hook script as a module."""
+    hook_path = Path(__file__).parent.parent / "hooks" / f"{hook_name}.py"
+    spec = importlib.util.spec_from_file_location(hook_name, hook_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[hook_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Workflow state modification tools that should be blocked for subagents
+WORKFLOW_STATE_TOOLS = [
+    "workflow__workflow_start",
+    "workflow__workflow_stop",
+    "workflow__workflow_update",
+    "workflow__workflow_set_state",
+    "workflow__workflow_set_value",
+    # With mcp__router__ prefix
+    "mcp__router__workflow__workflow_start",
+    "mcp__router__workflow__workflow_stop",
+    "mcp__router__workflow__workflow_update",
+    "mcp__router__workflow__workflow_set_state",
+    "mcp__router__workflow__workflow_set_value",
+]
+
+
+class TestSubagentCannotModifyWorkflowState:
+    """Test that subagents cannot call workflow state modification tools."""
+
+    @pytest.mark.parametrize("tool_name", WORKFLOW_STATE_TOOLS)
+    def test_subagent_blocked_from_workflow_state_tools(self, tool_name):
+        """Subagents (with agentId) should be blocked from modifying workflow state."""
+        hook = load_hook_module('workflow-state-enforcement')
+
+        hook_input = {
+            "tool_name": tool_name,
+            "tool_input": {"workflow_id": "iterate"},
+            "agentId": "sub-abc12345",
+        }
+
+        with patch('sys.stdin', Mock(read=lambda: json.dumps(hook_input))):
+            with patch('builtins.print') as mock_print:
+                hook.main()
+
+        output = json.loads(mock_print.call_args[0][0])
+        hook_output = output["hookSpecificOutput"]
+
+        assert hook_output["permissionDecision"] == "deny", \
+            f"Subagent should be blocked from {tool_name}"
+        assert "subagent" in hook_output["permissionDecisionReason"].lower() or \
+               "orchestrator" in hook_output["permissionDecisionReason"].lower(), \
+            "Reason should explain that only orchestrator can modify workflow state"
+
+    def test_orchestrator_allowed_to_modify_workflow_state(self):
+        """Orchestrator (no agentId) should be allowed to modify workflow state."""
+        hook = load_hook_module('workflow-state-enforcement')
+
+        hook_input = {
+            "tool_name": "workflow__workflow_update",
+            "tool_input": {"workflow_id": "iterate", "updates": {"phase": "implement"}},
+        }
+
+        with patch('sys.stdin', Mock(read=lambda: json.dumps(hook_input))):
+            with patch('builtins.print') as mock_print:
+                hook.main()
+
+        output = json.loads(mock_print.call_args[0][0])
+        hook_output = output["hookSpecificOutput"]
+
+        assert hook_output["permissionDecision"] == "allow", \
+            "Orchestrator should be allowed to modify workflow state"
+
+    def test_non_workflow_tools_allowed_for_subagents(self):
+        """Subagents should still be able to use non-workflow tools."""
+        hook = load_hook_module('workflow-state-enforcement')
+
+        hook_input = {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/some/file.py"},
+            "agentId": "sub-abc12345",
+        }
+
+        with patch('sys.stdin', Mock(read=lambda: json.dumps(hook_input))):
+            with patch('builtins.print') as mock_print:
+                hook.main()
+
+        output = json.loads(mock_print.call_args[0][0])
+        hook_output = output["hookSpecificOutput"]
+
+        assert hook_output["permissionDecision"] == "allow", \
+            "Subagent should be allowed to use non-workflow tools"
+
+    @pytest.mark.parametrize("tool_name", [
+        "workflow__workflow_get_state",
+        "workflow__workflow_get_value",
+        "workflow__workflow_is_active",
+        "mcp__router__workflow__workflow_get_state",
+    ])
+    def test_workflow_read_tools_allowed_for_subagents(self, tool_name):
+        """Subagents should be able to READ workflow state (just not modify it)."""
+        hook = load_hook_module('workflow-state-enforcement')
+
+        hook_input = {
+            "tool_name": tool_name,
+            "tool_input": {"workflow_id": "iterate"},
+            "agentId": "sub-abc12345",
+        }
+
+        with patch('sys.stdin', Mock(read=lambda: json.dumps(hook_input))):
+            with patch('builtins.print') as mock_print:
+                hook.main()
+
+        output = json.loads(mock_print.call_args[0][0])
+        hook_output = output["hookSpecificOutput"]
+
+        assert hook_output["permissionDecision"] == "allow", \
+            f"Subagent should be allowed to read workflow state via {tool_name}"
+
+
+class TestAgentStateModification:
+    """Test enforcement for agent state modification."""
+
+    def test_subagent_cannot_modify_other_agent_state(self):
+        """Subagents should only be able to modify their own agent state."""
+        hook = load_hook_module('workflow-state-enforcement')
+
+        hook_input = {
+            "tool_name": "workflow__agent_set_state",
+            "tool_input": {
+                "agent_id": "other-agent-123",
+                "state": {"status": "complete"}
+            },
+            "agentId": "sub-abc12345",
+        }
+
+        with patch('sys.stdin', Mock(read=lambda: json.dumps(hook_input))):
+            with patch('builtins.print') as mock_print:
+                hook.main()
+
+        output = json.loads(mock_print.call_args[0][0])
+        hook_output = output["hookSpecificOutput"]
+
+        assert hook_output["permissionDecision"] == "deny", \
+            "Subagent should not be able to modify other agent's state"
+
+    def test_subagent_can_modify_own_state(self):
+        """Subagents should be able to modify their own agent state."""
+        hook = load_hook_module('workflow-state-enforcement')
+
+        hook_input = {
+            "tool_name": "workflow__agent_set_state",
+            "tool_input": {
+                "agent_id": "sub-abc12345",
+                "state": {"status": "complete"}
+            },
+            "agentId": "sub-abc12345",
+        }
+
+        with patch('sys.stdin', Mock(read=lambda: json.dumps(hook_input))):
+            with patch('builtins.print') as mock_print:
+                hook.main()
+
+        output = json.loads(mock_print.call_args[0][0])
+        hook_output = output["hookSpecificOutput"]
+
+        assert hook_output["permissionDecision"] == "allow", \
+            "Subagent should be allowed to modify its own state"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add `workflow-state-enforcement.py` PreToolUse hook that blocks subagents from calling workflow modification tools
- Hook checks for `agentId` in context to identify subagents
- Blocks: `workflow_start`, `workflow_stop`, `workflow_update`, `workflow_set_state`, `workflow_set_value`
- Allows: Read-only tools (`get_state`, `get_value`, `is_active`)
- Special case: `agent_set_state` allowed only for own agent ID

## Test plan
- [x] 18 parametrized tests covering all blocked tools
- [x] Tests for orchestrator (no agentId) being allowed
- [x] Tests for read-only tools being allowed for subagents

🤖 Generated with [Claude Code](https://claude.com/claude-code)