### PR TITLE
feat: implementer workflow improvements and router enforcement

### DIFF
--- a/bin/mcp-call
+++ b/bin/mcp-call
@@ -3,13 +3,22 @@
 MCP tool caller for subagents - restricted to router backends only.
 
 Usage:
-  mcp-call <tool_name> [json_args]
+  mcp-call [--cwd=<path>] <tool_name> [args]
+
+Options:
+  --cwd=<path>    Set working directory for shell commands
+
+Arguments can be JSON or Python dict syntax:
+  JSON:   '{"key": "value", "flag": true}'
+  Python: "{'key': 'value', 'flag': True}"
 
 Examples:
   mcp-call serena__list_dir '{"relative_path": ".", "recursive": false}'
-  mcp-call serena__find_symbol '{"name_path_pattern": "main", "include_body": true}'
+  mcp-call serena__find_symbol "{'name_path_pattern': 'main', 'include_body': True}"
   mcp-call context7__resolve-library-id '{"libraryName": "react"}'
+  mcp-call --cwd=/path/to/repo git status
 """
+import ast
 import json
 import sys
 import os
@@ -39,6 +48,37 @@ BLOCKED_TOOLS = {
 SHELL_ALIASES = {"pytest", "ruff", "mypy", "black", "git", "gh", "python", "python3", "poetry"}
 
 
+def parse_args(arg_string: str) -> dict:
+    """Parse arguments as JSON or Python dict syntax.
+
+    Accepts:
+      - JSON: '{"key": "value", "flag": true}'
+      - Python dict: "{'key': 'value', 'flag': True}"
+
+    Returns parsed dict, raises ValueError on failure.
+    """
+    # Try JSON first (most common, backwards compatible)
+    try:
+        return json.loads(arg_string)
+    except json.JSONDecodeError:
+        pass
+
+    # Try Python literal (dict syntax)
+    try:
+        result = ast.literal_eval(arg_string)
+        if isinstance(result, dict):
+            return result
+    except (ValueError, SyntaxError):
+        pass
+
+    msg = (
+        f"Could not parse as JSON or Python dict: {arg_string}\n"
+        f"  JSON example: '{{\"key\": \"value\"}}'\n"
+        f"  Python example: \"{{\'key\': \'value\'}}\""
+    )
+    raise ValueError(msg)
+
+
 def is_tool_allowed(tool_name: str) -> bool:
     """Check if tool is allowed to be called."""
     # Check blocked list first
@@ -54,8 +94,15 @@ def is_tool_allowed(tool_name: str) -> bool:
 
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: mcp-call <tool_name> [json_args]", file=sys.stderr)
+    # Parse --cwd flag if present
+    cwd = None
+    args = sys.argv[1:]
+    if args and args[0].startswith("--cwd="):
+        cwd = args[0].split("=", 1)[1]
+        args = args[1:]
+
+    if len(args) < 1:
+        print("Usage: mcp-call [--cwd=<path>] <tool_name> [json_args]", file=sys.stderr)
         print("\nAllowed backends:", file=sys.stderr)
         for backend in sorted(ALLOWED_BACKENDS):
             print(f"  - {backend}*", file=sys.stderr)
@@ -66,14 +113,17 @@ def main():
         print("  mcp-call serena__find_symbol '{\"name_path_pattern\": \"main\"}'", file=sys.stderr)
         sys.exit(1)
 
-    tool_name = sys.argv[1]
+    tool_name = args[0]
 
     # Handle shell aliases - route to native__bash via router
     if tool_name in SHELL_ALIASES:
         # Reconstruct the command from tool_name and remaining args
-        command = " ".join([tool_name] + sys.argv[2:])
+        command = " ".join([tool_name] + args[1:])
         try:
-            result = call_tool("native__bash", {"command": command})
+            call_args = {"command": command}
+            if cwd:
+                call_args["cwd"] = cwd
+            result = call_tool("native__bash", call_args)
             if isinstance(result, (dict, list)):
                 print(json.dumps(result, indent=2))
             else:
@@ -89,19 +139,19 @@ def main():
         print(f"Allowed backends: {', '.join(sorted(ALLOWED_BACKENDS))}", file=sys.stderr)
         sys.exit(1)
 
-    # Parse arguments
-    if len(sys.argv) > 2:
+    # Parse arguments (JSON or Python dict syntax)
+    if len(args) > 1:
         try:
-            args = json.loads(sys.argv[2])
-        except json.JSONDecodeError as e:
-            print(f"Invalid JSON arguments: {e}", file=sys.stderr)
+            tool_args = parse_args(args[1])
+        except ValueError as e:
+            print(f"Invalid arguments: {e}", file=sys.stderr)
             sys.exit(1)
     else:
-        args = {}
+        tool_args = {}
 
     # Call the tool via router
     try:
-        result = call_tool(tool_name, args)
+        result = call_tool(tool_name, tool_args)
 
         # Output as JSON for easy parsing
         if isinstance(result, (dict, list)):

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,0 +1,29 @@
+---
+description: Start implementer workflow for general tasks (use when iterate is broken or unnecessary)
+argument-hint: [task description]
+---
+
+Start the implementer workflow for general implementation tasks.
+
+**Use this when:**
+- Iterate workflow is broken or unavailable
+- You need to make quick fixes without TDD ceremony
+- General implementation without specialized workflow
+
+## Initialize
+
+```bash
+python3 ~/.claude/plugins/agent-swarm/lib/implementer_workflow.py $ARGUMENTS
+```
+
+## Workflow
+
+Simple: WORK → VERIFY → DONE
+
+All tools allowed in WORK phase. This is the escape hatch when iterate has issues.
+
+## Commands
+
+- `python3 lib/implementer_workflow.py status` - Check status
+- `python3 lib/implementer_workflow.py advance` - Move to next phase
+- `python3 lib/implementer_workflow.py stop` - Stop workflow

--- a/docs/plans/2026-01-25-iterate-workflow-concerns.md
+++ b/docs/plans/2026-01-25-iterate-workflow-concerns.md
@@ -1,0 +1,152 @@
+# Iterate Workflow Concerns
+
+**Date:** 2026-01-25
+**Updated:** 2026-01-25
+**Status:** Most issues resolved or have clear path forward
+
+---
+
+## 1. Chicken-and-Egg in Orchestrate Phase
+
+**Problem:** Orchestrate phase is meant for spawning agents, but it blocks too many tools. Can't easily fix the workflow itself when problems arise.
+
+**Status:** ✅ Resolved
+
+**Resolution:** `/implement` command provides an escape hatch. When iterate workflow is broken or stuck, use `/implement` to bypass it entirely. This is documented in the command itself.
+
+---
+
+## 2. Error Message Quality
+
+**Problem:**
+- "Unknown error" masks real issues
+- "Run tests first" appears even when it doesn't apply
+- Hook errors don't always explain what to do instead
+
+**Status:** ✅ Partially Fixed
+
+**What's fixed:**
+- "Unknown error" → now shows actual stderr (mcp_native.py:661)
+- "Run tests first" → changed to "Complete current phase before using this tool" (iterate_workflow.py:329)
+
+**Still aspirational:**
+- Context-aware error messages per phase (nice-to-have, not blocking)
+
+---
+
+## 3. Multi-Repo Support Incomplete
+
+**Problem:**
+- `repo_path` exists but the plumbing is fragile
+- Race conditions with shared state when spawning parallel agents
+- `mcp-call` lacks --cwd flag
+
+**Status:** ✅ Resolved
+
+**What's fixed:**
+- `--cwd` flag added to mcp-call (bin/mcp-call)
+- Race condition fixed - repo_path passed directly to on_spawn (orchestrate.py:269-272)
+- Briefing docs updated with multi-repo git examples (hooks/subagent-briefing.md)
+
+**Verified:** 2026-01-25 - git operations with --cwd work correctly across LOGOS repos.
+
+---
+
+## 4. mcp-call Ergonomics
+
+**Problem:**
+- JSON escaping in mcp-call is error-prone for complex args
+- No tab completion or discoverability for available tools
+
+**Status:** Low priority - ergonomic annoyance, not a blocker
+
+**Notes:** Subagents *should* be limited. The mcp-call approach is functional. Shell aliases (git, gh, pytest) cover the common cases without JSON. Complex JSON args are rare in practice.
+
+**Potential improvements (if needed later):**
+- `mcp-call --list` to show available tools
+- `mcp-call --help <tool>` to show tool schema
+- Better error messages for malformed JSON
+
+---
+
+## 5. Phase Transitions Are Manual
+
+**Problem:**
+- No automatic phase advancement
+- Tests pass → still need manual `advance` command
+- Easy to get stuck in wrong phase
+
+**Status:** Open - has design proposal
+
+**Proposal:** Opt-in auto-advance triggers in workflow config:
+```python
+auto_advance = {
+    "verify": {
+        "conditions": ["tests_pass", "no_lint_errors"],
+        "target": "review"
+    }
+}
+```
+- Keep manual advancement as default
+- Let users opt into auto-advance per phase
+- Conditions are composable (all must pass)
+
+**Priority:** Medium - reduces friction but manual works fine
+
+---
+
+## 6. Debugging Is Hard
+
+**Problem:**
+- Subagent output is in temp files
+- Errors get swallowed or masked
+- No clear way to see what subagents tried
+
+**Status:** Open - has design proposal
+
+**Proposal:**
+1. **`--verbose` flag** for workflows - tails subagent output files in real-time
+2. **Failure dump** - on subagent failure, automatically include last N lines of output in main context
+3. **`/iterate debug` command** - shows recent subagent activity, output file locations, last errors
+
+**Priority:** Medium - would significantly improve debugging experience
+
+---
+
+## 7. Hook Layering Complexity
+
+**Problem:**
+- Multiple enforcement hooks with overlapping rules
+- Hard to know which hook blocked what
+- No centralized "what can I do here?" command
+
+**Status:** Migration debt - will be resolved by centralized router
+
+**Notes:** The router-based approach being developed will centralize tool access control. Once that's in place, most hooks can be removed. This concern is tracking debt to clean up, not a design flaw to fix in the current system.
+
+**Interim mitigation:** `/iterate status` shows current phase and basic info. A `--tools` flag could list allowed tools, but may not be worth implementing if hooks are going away.
+
+---
+
+## Summary
+
+| # | Concern | Status | Action |
+|---|---------|--------|--------|
+| 1 | Orchestrate chicken-and-egg | ✅ Resolved | /implement is the escape hatch |
+| 2 | Error message quality | ✅ Mostly fixed | Specific issues addressed |
+| 3 | Multi-repo support | ✅ Resolved | --cwd and race fix verified |
+| 4 | mcp-call ergonomics | Low priority | Functional, not blocking |
+| 5 | Manual phase transitions | Open | Opt-in auto-advance proposal |
+| 6 | Debugging is hard | Open | --verbose / debug command proposal |
+| 7 | Hook layering | Migration debt | Router will obsolete hooks |
+
+---
+
+## Next Steps
+
+If we want to improve iterate workflow further:
+1. Implement `/iterate debug` command (most bang for buck)
+2. Add `--verbose` to workflow init
+3. Consider auto-advance if manual transitions become painful
+
+Otherwise, the major blockers are resolved and iterate is functional.

--- a/hooks/subagent-bash-lockdown.py
+++ b/hooks/subagent-bash-lockdown.py
@@ -30,7 +30,7 @@ def main():
 
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
-    agent_id = input_data.get("agentId")
+    agent_id = input_data.get("agent_id")
 
     # Only apply to subagent Bash calls
     if not agent_id:

--- a/hooks/subagent-briefing.md
+++ b/hooks/subagent-briefing.md
@@ -29,6 +29,27 @@ These common commands work directly with mcp-call:
 - `mcp-call gh pr view` - github CLI
 - `mcp-call python script.py` - run python
 
+### Multi-Repo Git Operations
+
+When working in a specific repository (not the plugin directory), use the `--cwd` flag:
+
+```bash
+# Run git commands in a specific repo
+mcp-call --cwd=/home/fearsidhe/projects/LOGOS/logos git status
+mcp-call --cwd=/home/fearsidhe/projects/LOGOS/sophia git log -5
+
+# Run tests in a specific repo
+mcp-call --cwd=/path/to/repo pytest tests/
+
+# Lint a specific repo
+mcp-call --cwd=/path/to/repo ruff check .
+```
+
+The `--cwd` flag ensures commands run in the correct directory, which is essential for:
+- Git operations (finding the correct .git directory)
+- pytest (finding conftest.py and test discovery)
+- Poetry/venv commands (using the correct environment)
+
 ### Serena Tools
 
 For code intelligence, use `mcp-call serena__<tool>`:

--- a/hooks/workflow-enforcement.py
+++ b/hooks/workflow-enforcement.py
@@ -19,6 +19,7 @@ try:
     from workflow_client import workflow_get_state
     from debug_workflow import DebugWorkflow
     from pr_comment_workflow import PRCommentWorkflow
+    from implementer_workflow import ImplementerWorkflow
     from iterate_workflow import is_tool_allowed as iterate_is_tool_allowed, is_active as iterate_is_active
 except ImportError:
     # Fail open if modules not available
@@ -30,12 +31,14 @@ except ImportError:
         return True, ""
     DebugWorkflow = None
     PRCommentWorkflow = None
+    ImplementerWorkflow = None
 
 
 # Workflows using base classes (WorkflowEngine)
 BASE_WORKFLOWS = {
     "debug": DebugWorkflow,
     "pr_comment": PRCommentWorkflow,
+    "implementer": ImplementerWorkflow,
 }
 
 

--- a/lib/implementer_workflow.py
+++ b/lib/implementer_workflow.py
@@ -25,24 +25,30 @@ class ImplementerPhase(str, Enum):
     DONE = "done"
 
 
-# Phase definitions - permissive by default
+# Allowed router backend prefixes (normalized form - hook strips mcp__router__ prefix)
+# Full form: mcp__router__<backend>__<tool>
+# Normalized: <backend>__<tool>
+ALLOWED_ROUTER_PREFIXES = (
+    "serena__",      # Code intelligence (find_symbol, replace_content, etc.)
+    "native__",      # File ops (read_file, write_file, glob, grep, bash)
+    "context7__",    # Documentation lookup
+    "workflow__",    # Workflow state management
+    "playwright__",  # Browser automation
+)
+
+# Additional non-router tools allowed
+ALLOWED_EXTRA_TOOLS = frozenset({"Task", "TaskOutput"})
+
+# Phase definitions - minimal, actual checks in is_tool_allowed override
 IMPLEMENTER_PHASES = {
     ImplementerPhase.WORK.value: WorkflowPhase(
         name="work",
-        # All tools allowed - this is a permissive default workflow
-        allowed_tools=frozenset({
-            "Read", "Glob", "Grep", "Edit", "Write", "Bash",
-            "Task", "TaskOutput", "WebSearch", "WebFetch"
-        }),
+        allowed_tools=frozenset(),  # Handled by custom is_tool_allowed
         blocked_tools=frozenset(),
     ),
     ImplementerPhase.VERIFY.value: WorkflowPhase(
         name="verify",
-        # Verification still allows edits - agent may need to fix issues
-        allowed_tools=frozenset({
-            "Read", "Glob", "Grep", "Edit", "Write", "Bash",
-            "Task", "TaskOutput"
-        }),
+        allowed_tools=frozenset(),  # Handled by custom is_tool_allowed
         blocked_tools=frozenset(),
         requires_verification=True,
     ),
@@ -124,9 +130,41 @@ class ImplementerWorkflow:
         state["phase"] = phase
         workflow_client.workflow_set_state(self.workflow_id, state)
 
-    def is_tool_allowed(self, tool_name: str, file_path: Optional[str] = None) -> tuple[bool, str]:
-        """Check tool restriction."""
-        return self.engine.is_tool_allowed(tool_name, file_path=file_path)
+    def is_tool_allowed(
+        self, tool_name: str, file_path: Optional[str] = None  # noqa: ARG002 - kept for API compat
+    ) -> tuple[bool, str]:
+        """Check if tool is allowed - only MCP router tools and subagent management.
+
+        Implementer enforces router-only access (normalized form after hook strips prefix):
+        - serena__* (code intelligence)
+        - native__* (file ops, bash)
+        - context7__* (docs)
+        - workflow__* (workflow state)
+        - playwright__* (browser)
+        - Task, TaskOutput (subagent management)
+
+        Native Claude Code tools (Read, Edit, Bash, etc.) are NOT allowed.
+        """
+        phase = self.get_phase()
+
+        # Done phase - nothing allowed
+        if phase == "done":
+            return False, "Workflow complete - no tools allowed"
+
+        # Check router prefixes
+        for prefix in ALLOWED_ROUTER_PREFIXES:
+            if tool_name.startswith(prefix):
+                return True, f"Router tool allowed in {phase} phase"
+
+        # Check extra allowed tools (Task, TaskOutput)
+        if tool_name in ALLOWED_EXTRA_TOOLS:
+            return True, f"Tool {tool_name} allowed in {phase} phase"
+
+        # Block everything else including native Claude Code tools
+        return False, (
+            f"[BLOCKED] {tool_name} not allowed. Implementer uses router tools only. "
+            f"Use native__* or serena__* tools (via mcp__router__*)."
+        )
 
     def advance(self, **kwargs) -> TransitionResult:
         """Advance to next phase."""

--- a/lib/iterate_workflow.py
+++ b/lib/iterate_workflow.py
@@ -326,7 +326,7 @@ class IterateWorkflow(WorkflowEngine):
 
         # Check blocked list first
         if tool_name in phase_def.blocked_tools:
-            return False, f"[BLOCKED] {tool_name} not allowed in {phase} phase. Run tests first."
+            return False, f"[BLOCKED] {tool_name} not allowed in {phase} phase. Complete current phase before using this tool."
 
         # Check native__bash commands against per-phase whitelist
         if tool_name == "native__bash" and command:

--- a/lib/mcp_native.py
+++ b/lib/mcp_native.py
@@ -647,9 +647,10 @@ class MCPNativeServer:
                 "content": [{"type": "text", "text": text}]
             }
         else:
-            # Format error response
+            # Format error response - prefer stderr over generic error for better debugging
+            error_msg = result.get('stderr') or result.get('error') or 'Unknown error'
             return {
-                "content": [{"type": "text", "text": f"Error: {result.get('error', 'Unknown error')}"}],
+                "content": [{"type": "text", "text": f"Error: {error_msg}"}],
                 "isError": True
             }
 

--- a/lib/orchestrate.py
+++ b/lib/orchestrate.py
@@ -259,9 +259,11 @@ def spawn_eligible_tasks(
         worker_id = spawn_worker(task.id, task.description)
 
         # Call custom spawn callback if provided
+        # Pass repo_path explicitly to avoid race condition with global iterate_state
+        task_repo_path = getattr(task, "repo_path", "") or ""
         if on_spawn:
             try:
-                on_spawn(task.id, task.description, task.pr_id)
+                on_spawn(task.id, task.description, task.pr_id, task_repo_path)
             except Exception as e:
                 print(f"[ORCHESTRATE] Spawn callback failed: {e}", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

- Add Python dict syntax support to mcp-call (`ast.literal_eval` fallback)
- Add `--cwd` flag to mcp-call for multi-repo git operations
- Enforce router-only tools in implementer workflow
- Add implementer to workflow-enforcement.py hook
- Fix error masking in mcp_native.py (show actual stderr instead of "Unknown error")
- Fix misleading "Run tests first" error in iterate_workflow.py
- Fix race condition in orchestrate.py repo_path passing
- Add `/implement` command for escape hatch workflow
- Document multi-repo git operations in subagent briefing
- Add iterate workflow concerns tracking document

## Test plan

- [x] Verified mcp-call accepts both JSON and Python dict syntax
- [x] Verified --cwd flag works with git commands across repos
- [x] Verified implementer workflow blocks native tools (Read, Edit, Bash)
- [x] Verified implementer workflow allows router tools (native__*, serena__*)
- [x] Verified bash lockdown hook correctly detects agent_id
- [x] Verified /implement command starts workflow correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)