### PR TITLE
fix: enforce intent-not-content prompting and fix briefing tool prescription

### DIFF
--- a/docs/ANTI_PATTERNS_DETECTION.md
+++ b/docs/ANTI_PATTERNS_DETECTION.md
@@ -282,6 +282,45 @@ Edit(file_path="file3.py", ...)  # Step 3: This is NOT trivial!
 
 ---
 
+### 8. **Content Embedding in Subagent Prompts**
+
+**Pattern:** Orchestrator embeds literal file content, code blocks, or expected output in subagent prompts instead of giving intent + acceptance criteria.
+
+**Why it's wrong:**
+- Multiple agents get overlapping content, causing file stomping
+- Agent has no room for judgment (becomes a copy-paste machine)
+- Prompt bloat wastes context window
+- No verification criteria — orchestrator can't check if agent did it right
+
+**Detection Points:**
+
+| Location | Detection Method | Signal |
+|----------|-----------------|--------|
+| Prompt analysis | Length + code block check | Prompt > 2000 chars with code blocks > 10 lines |
+| Telemetry | File conflict detection | Two agents modifying same file simultaneously |
+
+**Example (WRONG):**
+```python
+# ❌ Embedding file content in prompt
+Task(prompt="Write this to briefing.md:\n# Subagent Operating Protocol\n[800 chars of content...]")
+```
+
+**Correct:**
+```python
+# ✅ Intent + acceptance criteria
+Task(prompt="""Rewrite briefing.md following constraints-first template.
+
+Acceptance criteria:
+- Contains marker 'SUBAGENT OPERATING PROTOCOL'
+- Size between 400-900 chars
+- Constraints section appears before tool reference
+- See agent_context.md for project patterns""")
+```
+
+**Related rule:** Each file may be modified by AT MOST one concurrent task. When decomposing into parallel tasks, assign non-overlapping file sets.
+
+---
+
 ## Detection Logic Integration Points
 
 ### Current Enforcement Hooks

--- a/docs/specs/explore-before-prompt.md
+++ b/docs/specs/explore-before-prompt.md
@@ -110,18 +110,27 @@ IMPLEMENTER_PROMPTS = {
 **Context from Exploration:**
 {explorer_output}
 
+**Files you may modify:** {file_list}
+Do NOT modify files outside this list.
+
 **Requirements:**
 {requirements}
 
-**Files to Modify:**
-{suggested_files}
+**Acceptance Criteria:**
+{acceptance_criteria}
 
-Follow the patterns shown above. Verify side effects before changes.""",
+Follow patterns from exploration. Verify side effects before changes.""",
 
     "without_exploration": """Implement: {task_description}
 
+**Files you may modify:** {file_list}
+Do NOT modify files outside this list.
+
 **Requirements:**
 {requirements}
+
+**Acceptance Criteria:**
+{acceptance_criteria}
 
 Explore the codebase first to understand existing patterns. Verify side effects before changes."""
 }

--- a/hooks/subagent-briefing.md
+++ b/hooks/subagent-briefing.md
@@ -2,65 +2,29 @@
 
 **You are a subagent spawned by the orchestrator.**
 
-## Tools Available
+## Available Tools
 
-You have ONE tool: **Bash**
+You access tools through the MCP router. Use the most appropriate tool for each operation:
 
-Use Bash to run `mcp-call` commands:
+| Operation | Tool | When to Use |
+|-----------|------|-------------|
+| Search code | `serena__search_for_pattern` | Find text across files |
+| Read files | `serena__read_file`, `native__read_file` | Read file contents |
+| Find symbols | `serena__find_symbol` | Find class/function definitions |
+| Get file overview | `serena__get_symbols_overview` | See structure of a file |
+| List/find files | `native__glob`, `serena__find_file` | Find files by pattern |
+| Run commands | `native__bash` | git, pytest, ruff, gh, python3 |
+| Edit code | `serena__replace_content` | Replace text in files |
+| Replace symbol | `serena__replace_symbol_body` | Replace entire function/class |
 
-| Operation | Command |
-|-----------|---------|
-| Run shell commands | `mcp-call git status`, `mcp-call pytest`, `mcp-call ruff check .` |
-| Read files | `mcp-call serena__read_file '{"relative_path": "path/to/file"}'` |
-| List directory | `mcp-call serena__list_dir '{"relative_path": "."}'` |
-| Find files | `mcp-call serena__find_file '{"file_name_pattern": "*.py"}'` |
-| Search code | `mcp-call serena__search_for_pattern '{"pattern": "def main"}'` |
-| Get symbols | `mcp-call serena__get_symbols_overview '{"relative_path": "file.py"}'` |
-| Find symbol | `mcp-call serena__find_symbol '{"name_path_pattern": "MyClass"}'` |
-| Replace content | `mcp-call serena__replace_content '{"relative_path": "file.py", ...}'` |
+Use the purpose-built tool when one exists. Fall back to `native__bash` only for shell commands (git, pytest, ruff, gh) that have no dedicated tool.
 
-### Shell Aliases
+### Multi-Repo Operations
 
-These common commands work directly with mcp-call:
-- `mcp-call pytest tests/` - run tests
-- `mcp-call ruff check .` - lint code
-- `mcp-call mypy src/` - type check
-- `mcp-call git status` - git operations
-- `mcp-call gh pr view` - github CLI
-- `mcp-call python script.py` - run python
-
-### Multi-Repo Git Operations
-
-When working in a specific repository (not the plugin directory), use the `--cwd` flag:
-
-```bash
-# Run git commands in a specific repo
-mcp-call --cwd=/home/fearsidhe/projects/LOGOS/logos git status
-mcp-call --cwd=/home/fearsidhe/projects/LOGOS/sophia git log -5
-
-# Run tests in a specific repo
-mcp-call --cwd=/path/to/repo pytest tests/
-
-# Lint a specific repo
-mcp-call --cwd=/path/to/repo ruff check .
+Use `--cwd` flag with `native__bash` for commands in a specific repository:
 ```
-
-The `--cwd` flag ensures commands run in the correct directory, which is essential for:
-- Git operations (finding the correct .git directory)
-- pytest (finding conftest.py and test discovery)
-- Poetry/venv commands (using the correct environment)
-
-### Serena Tools
-
-For code intelligence, use `mcp-call serena__<tool>`:
-- `serena__read_file` - read file contents
-- `serena__list_dir` - list directory
-- `serena__find_file` - find files by pattern
-- `serena__search_for_pattern` - grep-like search
-- `serena__get_symbols_overview` - get file symbols
-- `serena__find_symbol` - find symbol by name
-- `serena__replace_content` - replace text in file
-- `serena__replace_symbol_body` - replace entire symbol
+native__bash 'git -C /path/to/repo status'
+```
 
 ## CRITICAL: Token Efficiency Rules
 
@@ -82,87 +46,20 @@ When you need to:
 - Search 3+ patterns → Write a batch script
 - Process large results → Write a script, output summary only
 
+## Git (REVIEW Phase)
+
+When your task enters REVIEW phase (tests pass):
+
+1. Verify branch: `native__bash 'git branch --show-current'`
+2. **NEVER** create branches (`git checkout -b`) — orchestrator's job
+3. Commit: `native__bash 'git commit -m "feat: <description>"'`
+4. Push: `native__bash 'git push -u origin <branch>'`
+5. Create PR: `native__bash 'gh pr create --title "..." --body "..."'`
+
 ## Enforcement
 
 The orchestrator monitors your token usage. Inefficient subagents may be terminated early.
 
 **Stay focused. Be efficient. Complete your task.**
 
----
 
-## Git Operations
-
-Subagents handle git operations in their REVIEW phase (after tests pass).
-
-### Workflow Phases
-
-1. **IMPLEMENT Phase**: Write tests, implement code, verify tests pass
-2. **REVIEW Phase**: Commit, push, create PR for external review
-3. **Greptile Review**: External service reviews the PR
-4. **Comment Handling**: Orchestrator queues Greptile comments as new tasks
-
-## Git Responsibilities
-
-### Branch Verification (NEVER Create Branches)
-
-The orchestrator has already created the feature branch for your task group. Your prompt includes the branch name.
-
-1. Verify you're on the correct branch: `mcp-call git branch --show-current`
-2. If not on the right branch, switch: `mcp-call git checkout feature/<task-name>`
-3. **NEVER** run `git checkout -b` — branch creation is the orchestrator's job
-4. Make your changes (tests, implementation)
-5. Stage files: `mcp-call git add <files>`
-
-### In REVIEW Phase (Subagent)
-
-When your tests pass, you enter REVIEW phase and handle git operations:
-
-1. Commit: `mcp-call git commit -m "feat: <description>"`
-2. Push: `mcp-call git push -u origin feature/<task-name>`
-3. Create PR: `mcp-call gh pr create --title "..." --body "..."`
-
-### External Review (Greptile)
-
-After you create the PR:
-- Greptile (external code review service) automatically reviews it
-- If Greptile leaves comments, the orchestrator picks them up
-- Orchestrator adds comment-fix tasks to the queue
-- New subagents are spawned to address those comments
-
-**Key Point:** You commit and create the PR. Greptile reviews. Orchestrator manages resulting comments.
-
----
-
-## Memory Integration
-
-You have access to multiple memory systems. Use them strategically to avoid repeating work.
-
-### Before Starting Your Task
-
-1. **Check Serena memories** (project-specific learnings):
-   - `mcp-call serena__list_memories` to see available memories
-   - `mcp-call serena__read_memory '{"memory_name": "..."}'` if relevant
-
-### After Completing Your Task
-
-If you learned something useful, record it:
-
-1. **Patterns discovered** - What approaches worked well?
-2. **Pitfalls found** - What didn't work or caused issues?
-3. **Key decisions** - What choices did you make and why?
-
-Use `mcp-call serena__write_memory '{"memory_name": "...", "content": "..."}'` to persist significant learnings.
-
-### When to Use Memory
-
-**DO use memory for:**
-- Architectural patterns that keep recurring
-- Error solutions that took time to figure out
-- Project-specific conventions not in CLAUDE.md
-
-**DON'T use memory for:**
-- One-off implementation details
-- Information already in code comments
-- Temporary state (use handoffs instead)
-
-**Note:** Memory access adds tokens - only search if genuinely relevant to your task.

--- a/skills/iterate/SKILL.md
+++ b/skills/iterate/SKILL.md
@@ -265,6 +265,12 @@ Push happens when:
 
 **Do NOT push after each task.** Wait for the batch.
 
+### File Exclusivity
+
+When decomposing into parallel tasks, verify no two tasks modify the same file.
+If overlap detected: use `depends_on` to serialize, or merge into one task.
+Each file is owned by AT MOST one concurrent agent.
+
 ### Dynamic Queue Updates
 
 The queue can grow during execution:
@@ -309,6 +315,14 @@ When spawning implementer agents, your prompt must include:
 2. **Constraints** - What NOT to do and why (prevent logical-but-wrong fixes)
 3. **Design intent** - The "why" behind existing code/restrictions
 4. **TDD instruction** - Agents must write tests FIRST, then implement
+5. **File scope** - Explicit list of files this agent may modify (exclusive ownership)
+6. **Acceptance criteria** - Machine-checkable conditions (grep markers, size ranges, test exit codes)
+
+<constraint>
+NEVER embed literal file content in prompts. Give intent + acceptance criteria.
+The agent reads current state, understands the pattern, and writes.
+NEVER assign the same file to multiple concurrent agents.
+</constraint>
 
 **IMPORTANT:** Every implementer prompt MUST include:
 ```

--- a/skills/spawn/SKILL.md
+++ b/skills/spawn/SKILL.md
@@ -74,9 +74,30 @@ Implementer says: "Trivial task, using haiku" and spawns sub-agent with haiku.
 Every subagent prompt MUST include:
 
 1. **Task**: What exactly to do (one clear objective)
-2. **Scope**: What files/areas to touch
+2. **Scope**: What files/areas to touch (exclusive file list — no other agent touches these)
 3. **Output**: What to return (be specific about format)
 4. **Constraints**: What NOT to do
+5. **Acceptance Criteria**: Machine-checkable conditions for completion (grep markers, size ranges, test exit codes)
+
+<constraint>
+**Intent, Not Content**: NEVER embed file content, code blocks, or literal output in subagent prompts.
+Prompts specify WHAT to achieve and HOW to verify — not the bytes to write.
+
+WRONG: "Write this content to file.md: [800 chars of content]"
+RIGHT: "Rewrite file.md to follow constraints-first template. Must contain
+        marker 'PROTOCOL'. Target: 400-900 chars. See agent_context.md
+        for project patterns."
+</constraint>
+
+<constraint>
+**Exclusive File Ownership**: Each file may be modified by AT MOST one concurrent task.
+When decomposing into parallel tasks, assign non-overlapping file sets.
+
+If two tasks need the same file:
+  1. Make them sequential (depends_on)
+  2. Split into separate concerns
+  3. Merge into one task
+</constraint>
 
 ### Example Prompts
 
@@ -86,17 +107,19 @@ Find all authentication-related code.
 
 Scope: src/ directory
 Output: List of file:line references with one-line descriptions
-Constraints: Don't read file contents, just locate. Use Serena tools.
+Constraints: Don't read file contents, just locate.
+Acceptance: Output contains at least one file:line reference per auth module.
 ```
 
 **Implementer (writing code):**
 ```
 Add input validation to the login form.
 
-Scope: src/components/LoginForm.tsx only
+Scope: src/components/LoginForm.tsx only (exclusive — no other agent touches this file)
 Output: Summary of changes made
 Constraints: Don't modify other files. Don't add new dependencies.
-Follow existing patterns in the codebase.
+Acceptance: `grep -c 'validate' src/components/LoginForm.tsx` returns 1+.
+            `pytest tests/test_login.py` exits 0.
 ```
 
 **Reviewer (checking code):**
@@ -106,6 +129,7 @@ Review changes to authentication flow.
 Scope: Files modified in current branch vs main
 Output: PASS or NEEDS_CHANGES with specific issues
 Constraints: Focus on bugs and security. Skip style issues.
+Acceptance: Output contains explicit PASS or NEEDS_CHANGES verdict.
 ```
 
 ## Parallel Spawning


### PR DESCRIPTION
## Problem

Two issues discovered during the doc overhaul implementation:

1. **Orchestrator embedded content instead of intent** — literal file contents stuffed into subagent prompts, causing overlapping writes and no room for agent judgment.

2. **Briefing prescribed mechanism instead of describing tools** — told all agents 'Your only tool is Bash with mcp-call', pushing them toward native__bash instead of purpose-built MCP tools (serena__search_for_pattern, native__grep, etc.).

## Changes

### Prompting guidance (spawn + iterate skills)
- Add **Acceptance Criteria** as 5th required prompt element
- Add **Intent, Not Content** constraint — never embed file content in prompts
- Add **Exclusive File Ownership** constraint — no two concurrent tasks modify the same file
- Update example prompts to include acceptance criteria

### Briefing (hooks/subagent-briefing.md)
- Replace 'Your only tool is Bash' with MCP tool category table
- Remove Shell Aliases, Memory Integration sections (bloat)
- Trim Git Operations to minimal REVIEW phase steps (implementers still need this)

### Anti-patterns (docs/ANTI_PATTERNS_DETECTION.md)
- Add anti-pattern #8: Content Embedding in Subagent Prompts

### Prompt templates (docs/specs/explore-before-prompt.md)
- Add file_list and acceptance_criteria to both implementer prompt templates

## Files Modified
- skills/spawn/SKILL.md
- skills/iterate/SKILL.md
- hooks/subagent-briefing.md
- docs/ANTI_PATTERNS_DETECTION.md
- docs/specs/explore-before-prompt.md