### PR TITLE
Merge parallel-orchestration plugin into agent-swarm

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -8,7 +8,11 @@
   "skills": [
     "orchestrate",
     "spawn",
-    "iterate"
+    "iterate",
+    "parallel-orchestrate",
+    "agent-teams-workflow",
+    "pipeline",
+    "plan-to-manifest"
   ],
   "hooks": {
     "preToolUse": {

--- a/config/manifests/demo_data_structures.yaml
+++ b/config/manifests/demo_data_structures.yaml
@@ -1,0 +1,60 @@
+# Demo manifest: Data Structures
+# Three independent data structures, each with TDD (10+ tests)
+
+project: data-structures
+base_branch: main
+max_retries: 2
+
+tasks:
+  - name: stack
+    description: |
+      Implement a Stack class with the following operations:
+      - push(item): Add item to top of stack
+      - pop() -> item: Remove and return top item (raise IndexError if empty)
+      - peek() -> item: Return top item without removing (raise IndexError if empty)
+      - is_empty() -> bool: Check if stack is empty
+      - size() -> int: Return number of items
+      - clear(): Remove all items
+      - __contains__(item) -> bool: Support 'in' operator
+      - __iter__(): Support iteration (top to bottom)
+      - __repr__(): String representation
+      - from_iterable(cls, iterable) -> Stack: Class method constructor
+    target_dir: src/stack
+    test_dir: tests/test_stack
+    min_tests: 10
+
+  - name: queue
+    description: |
+      Implement a Queue class with the following operations:
+      - enqueue(item): Add item to back of queue
+      - dequeue() -> item: Remove and return front item (raise IndexError if empty)
+      - peek() -> item: Return front item without removing (raise IndexError if empty)
+      - is_empty() -> bool: Check if queue is empty
+      - size() -> int: Return number of items
+      - clear(): Remove all items
+      - __contains__(item) -> bool: Support 'in' operator
+      - __iter__(): Support iteration (front to back)
+      - __repr__(): String representation
+      - from_iterable(cls, iterable) -> Queue: Class method constructor
+    target_dir: src/queue
+    test_dir: tests/test_queue
+    min_tests: 10
+
+  - name: linked_list
+    description: |
+      Implement a LinkedList class (singly linked) with the following operations:
+      - append(item): Add item to end
+      - prepend(item): Add item to beginning
+      - insert(index, item): Insert at index (raise IndexError if out of range)
+      - remove(item): Remove first occurrence (raise ValueError if not found)
+      - pop(index=-1) -> item: Remove and return item at index
+      - __getitem__(index) -> item: Index access
+      - __len__() -> int: Length
+      - __contains__(item) -> bool: Support 'in' operator
+      - __iter__(): Support iteration
+      - __repr__(): String representation
+      - reverse(): Reverse the list in place
+      - to_list() -> list: Convert to Python list
+    target_dir: src/linked_list
+    test_dir: tests/test_linked_list
+    min_tests: 10

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -1,0 +1,98 @@
+# Parallel Orchestration Workflow Definition
+# Declarative phase definitions, transitions, and gateway conditions
+
+phases:
+  init:
+    description: "Load manifest and validate configuration"
+    transitions:
+      - target: spawning
+        gateway: manifest_loaded
+    tools:
+      - file_read
+      - manifest_parse
+
+  spawning:
+    description: "Create branches and spawn TDD subagents"
+    transitions:
+      - target: monitoring
+        gateway: all_spawned
+    tools:
+      - git_branch
+      - task_spawn
+
+  monitoring:
+    description: "Monitor subagent progress, handle completions"
+    transitions:
+      - target: spawning
+        gateway: has_retries
+        description: "Re-enter spawning if tasks need retry"
+      - target: merging
+        gateway: all_done
+    tools:
+      - task_status
+      - task_complete
+
+  merging:
+    description: "Merge completed task branches into base"
+    transitions:
+      - target: verifying
+        gateway: all_branches_merged
+    tools:
+      - git_merge
+      - git_checkout
+
+  verifying:
+    description: "Run full test suite to confirm integration"
+    transitions:
+      - target: done
+        gateway: full_suite_passes
+      - target: failed
+        gateway: suite_failed
+    tools:
+      - test_run
+
+  done:
+    description: "All tasks completed and verified"
+    terminal: true
+
+  failed:
+    description: "Orchestration failed — manual intervention needed"
+    terminal: true
+
+  stopped:
+    description: "Orchestration stopped by user"
+    terminal: true
+
+gateway_conditions:
+  manifest_loaded:
+    description: "Manifest file parsed and validated"
+    type: internal
+
+  all_spawned:
+    description: "All pending tasks have been spawned"
+    type: internal
+
+  has_retries:
+    description: "One or more tasks are pending retry"
+    type: internal
+
+  all_done:
+    description: "All tasks are completed or failed (no pending/spawned)"
+    type: internal
+    validator: check_all_done
+
+  all_branches_merged:
+    description: "All completed task branches merged into base"
+    type: subprocess
+    validator: all_branches_merged
+
+  full_suite_passes:
+    description: "Full pytest suite passes after merge"
+    type: subprocess
+    validator: full_suite_passes
+
+  suite_failed:
+    description: "Full pytest suite has failures"
+    type: subprocess
+    validator: full_suite_passes
+    invert: true

--- a/lib/gateway_conditions.py
+++ b/lib/gateway_conditions.py
@@ -1,0 +1,138 @@
+"""Phase gate validators. Never raise — always return (bool, str)."""
+
+import subprocess
+from typing import Any
+
+
+def _last_line(output: str, fallback: str = "unknown") -> str:
+    """Extract the last line from output, or return fallback."""
+    stripped = output.strip()
+    if stripped:
+        return stripped.splitlines()[-1]
+    return fallback
+
+
+def branch_exists(*, branch: str, cwd: str, **kwargs: Any) -> tuple[bool, str]:
+    """Check if a git branch exists."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", branch],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True, f"Branch '{branch}' exists"
+        return False, f"Branch '{branch}' does not exist"
+    except Exception as e:
+        return False, f"Error checking branch: {e}"
+
+
+def tests_written(
+    *, test_dir: str, min_tests: int, cwd: str, **kwargs: Any
+) -> tuple[bool, str]:
+    """Check if enough test functions have been written."""
+    try:
+        result = subprocess.run(
+            ["grep", "-r", "-c", "def test_", test_dir],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        # Count lines of output (each line is file:count)
+        lines = [line for line in result.stdout.strip().split("\n") if line]
+        total = 0
+        for line in lines:
+            # grep -c output: filename:count or just count
+            parts = line.rsplit(":", 1)
+            try:
+                total += int(parts[-1])
+            except ValueError:
+                # Line itself is a test function name (non -c mode fallback)
+                total += 1
+
+        if total >= min_tests:
+            return True, f"Found {total} tests (minimum: {min_tests})"
+        return False, f"Found {total} tests, need at least {min_tests}"
+    except Exception as e:
+        return False, f"Error counting tests: {e}"
+
+
+def all_tests_pass(*, test_dir: str, cwd: str, **kwargs: Any) -> tuple[bool, str]:
+    """Run pytest on a test directory and check all pass."""
+    try:
+        result = subprocess.run(
+            ["python3", "-m", "pytest", test_dir, "-v", "--tb=short"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        last = _last_line(result.stdout, "ok")
+        if result.returncode == 0:
+            return True, f"All tests passed: {last}"
+        return False, f"Tests failed: {last}"
+    except Exception as e:
+        return False, f"Error running tests: {e}"
+
+
+def all_branches_merged(
+    *, branches: list[str], cwd: str, **kwargs: Any
+) -> tuple[bool, str]:
+    """Check if all specified branches have been merged into current branch."""
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--merged"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        merged = {b.strip().lstrip("* ") for b in result.stdout.strip().split("\n")}
+        unmerged = [b for b in branches if b not in merged]
+        if not unmerged:
+            return True, "All branches merged"
+        return False, f"Unmerged branches: {', '.join(unmerged)}"
+    except Exception as e:
+        return False, f"Error checking merged branches: {e}"
+
+
+def full_suite_passes(*, cwd: str, **kwargs: Any) -> tuple[bool, str]:
+    """Run the full test suite and check all pass."""
+    try:
+        result = subprocess.run(
+            ["python3", "-m", "pytest", "-v", "--tb=short"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        last = _last_line(result.stdout, "ok")
+        if result.returncode == 0:
+            return True, f"Full suite passed: {last}"
+        return False, f"Full suite failed: {last}"
+    except Exception as e:
+        return False, f"Error running full suite: {e}"
+
+
+def commit_exists(*, branch: str, cwd: str, **kwargs: Any) -> tuple[bool, str]:
+    """Check if a branch has commits beyond the base."""
+    try:
+        result = subprocess.run(
+            ["git", "log", branch, "-1", "--format=%h"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return True, f"Commit found on '{branch}': {result.stdout.strip()}"
+        return False, f"No commits found on '{branch}'"
+    except Exception as e:
+        return False, f"Error checking commits: {e}"
+
+
+GATEWAY_CONDITIONS: dict[str, callable] = {
+    "branch_exists": branch_exists,
+    "tests_written": tests_written,
+    "all_tests_pass": all_tests_pass,
+    "all_branches_merged": all_branches_merged,
+    "full_suite_passes": full_suite_passes,
+    "commit_exists": commit_exists,
+}

--- a/lib/manifest.py
+++ b/lib/manifest.py
@@ -1,0 +1,160 @@
+"""YAML manifest parser and dataclasses for parallel orchestration tasks."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class ManifestTask:
+    """A single task to be executed by a subagent."""
+
+    name: str
+    description: str
+    target_dir: str
+    test_dir: str
+    min_tests: int = 5
+    branch_name: str = ""
+    depends_on: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not self.branch_name:
+            self.branch_name = f"task/{self.name}"
+
+
+@dataclass
+class Manifest:
+    """Parsed manifest containing project config and tasks."""
+
+    project: str
+    tasks: list[ManifestTask]
+    base_branch: str = "main"
+    max_retries: int = 2
+
+
+def parse_manifest(path: str) -> Manifest:
+    """Parse a YAML manifest file into a Manifest object.
+
+    Raises FileNotFoundError if path doesn't exist.
+    Raises ValueError for missing or invalid fields.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Manifest not found: {path}")
+
+    data = yaml.safe_load(p.read_text())
+    if not isinstance(data, dict):
+        raise ValueError("Manifest must be a YAML mapping")
+
+    if "project" not in data:
+        raise ValueError("Manifest missing required field: project")
+
+    if "tasks" not in data:
+        raise ValueError("Manifest missing required field: tasks")
+
+    raw_tasks = data["tasks"]
+    if not raw_tasks:
+        raise ValueError("Manifest must contain at least one task")
+
+    tasks = []
+    for i, raw in enumerate(raw_tasks):
+        _validate_task_fields(raw, i)
+        tasks.append(
+            ManifestTask(
+                name=raw["name"],
+                description=raw["description"],
+                target_dir=raw["target_dir"],
+                test_dir=raw["test_dir"],
+                min_tests=raw.get("min_tests", 5),
+                branch_name=raw.get("branch_name", ""),
+                depends_on=raw.get("depends_on", []),
+            )
+        )
+
+    return Manifest(
+        project=data["project"],
+        tasks=tasks,
+        base_branch=data.get("base_branch", "main"),
+        max_retries=data.get("max_retries", 2),
+    )
+
+
+_REQUIRED_TASK_FIELDS = ["name", "description", "target_dir", "test_dir"]
+
+
+def _validate_task_fields(raw: dict[str, Any], index: int) -> None:
+    """Validate that a raw task dict has all required fields."""
+    for field_name in _REQUIRED_TASK_FIELDS:
+        if field_name not in raw:
+            raise ValueError(f"Task {index} missing required field: {field_name}")
+
+
+def _detect_cycles(manifest: Manifest) -> None:
+    """Raise ValueError if dependency graph has cycles."""
+    dep_map = {t.name: t.depends_on for t in manifest.tasks}
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {name: WHITE for name in dep_map}
+    path: list[str] = []
+
+    def dfs(node: str) -> None:
+        color[node] = GRAY
+        path.append(node)
+        for dep in dep_map.get(node, []):
+            if color[dep] == GRAY:
+                cycle_start = path.index(dep)
+                cycle = path[cycle_start:] + [dep]
+                raise ValueError(
+                    f"Circular dependency detected: {' -> '.join(cycle)}"
+                )
+            if color[dep] == WHITE:
+                dfs(dep)
+        path.pop()
+        color[node] = BLACK
+
+    for name in dep_map:
+        if color[name] == WHITE:
+            dfs(name)
+
+
+def validate_manifest(manifest: Manifest) -> list[str]:
+    """Return a list of warning strings (non-fatal issues)."""
+    warnings = []
+
+    # Check duplicate task names
+    names = [t.name for t in manifest.tasks]
+    if len(names) != len(set(names)):
+        seen = set()
+        for name in names:
+            if name in seen:
+                warnings.append(f"Duplicate task name: {name}")
+            seen.add(name)
+
+    # Check duplicate branch names
+    branches = [t.branch_name for t in manifest.tasks]
+    if len(branches) != len(set(branches)):
+        seen = set()
+        for branch in branches:
+            if branch in seen:
+                warnings.append(f"Duplicate branch name: {branch}")
+            seen.add(branch)
+
+    # Check low min_tests
+    for task in manifest.tasks:
+        if task.min_tests < 3:
+            warnings.append(f"Task '{task.name}' has low min_tests ({task.min_tests})")
+
+    # Validate depends_on references
+    task_names = {t.name for t in manifest.tasks}
+    for task in manifest.tasks:
+        for dep in task.depends_on:
+            if dep not in task_names:
+                raise ValueError(
+                    f"Task '{task.name}' depends on unknown task: {dep}"
+                )
+
+    # Detect circular dependencies via DFS
+    _detect_cycles(manifest)
+
+    return warnings

--- a/lib/orchestration_state.py
+++ b/lib/orchestration_state.py
@@ -1,0 +1,95 @@
+"""JSON file-based state persistence with atomic writes."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def _get_state_dir() -> Path:
+    """Return the state directory, preferring env var override."""
+    env_dir = os.environ.get("ORCHESTRATION_STATE_DIR")
+    if env_dir:
+        return Path(env_dir)
+    # Default: <plugin_root>/.state/
+    plugin_root = Path(__file__).parent.parent
+    return plugin_root / ".state"
+
+
+class OrchestrationState:
+    """Manages orchestration state as a JSON file on disk.
+
+    State is stored as a flat JSON object. Supports dotted key paths
+    for nested access (e.g., "tasks.stack.status").
+    """
+
+    def __init__(self, project_name: str):
+        self._project_name = project_name
+        state_dir = _get_state_dir()
+        state_dir.mkdir(parents=True, exist_ok=True)
+        self._state_path = state_dir / f"{project_name}.json"
+        self._data: dict[str, Any] = {}
+
+    def exists(self) -> bool:
+        return self._state_path.exists()
+
+    def load(self) -> None:
+        """Load state from disk. No-op if file doesn't exist."""
+        if self._state_path.exists():
+            self._data = json.loads(self._state_path.read_text())
+
+    def save(self) -> None:
+        """Atomically write state to disk via tempfile + rename."""
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self._state_path.parent),
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(self._data, f, indent=2)
+            os.rename(tmp_path, str(self._state_path))
+        except BaseException:
+            # Clean up temp file on failure
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get a value by dotted key path. Returns default if missing."""
+        parts = key.split(".")
+        current = self._data
+        for part in parts:
+            if not isinstance(current, dict) or part not in current:
+                return default
+            current = current[part]
+        return current
+
+    def set(self, key: str, value: Any) -> None:
+        """Set a value by dotted key path, creating intermediate dicts."""
+        parts = key.split(".")
+        current = self._data
+        for part in parts[:-1]:
+            if part not in current or not isinstance(current[part], dict):
+                current[part] = {}
+            current = current[part]
+        current[parts[-1]] = value
+
+    def update_task(self, task_name: str, **kwargs: Any) -> None:
+        """Update a task's state, creating the tasks dict if needed."""
+        if "tasks" not in self._data:
+            self._data["tasks"] = {}
+        if task_name not in self._data["tasks"]:
+            self._data["tasks"][task_name] = {}
+        self._data["tasks"][task_name].update(kwargs)
+
+    def clear(self) -> None:
+        """Remove the state file and reset in-memory data."""
+        self._data = {}
+        try:
+            self._state_path.unlink()
+        except FileNotFoundError:
+            pass

--- a/lib/orchestrator.py
+++ b/lib/orchestrator.py
@@ -1,0 +1,463 @@
+"""Core orchestrator for parallel TDD subagents."""
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+# Ensure plugin root is on sys.path for CLI invocation
+_plugin_root = str(Path(__file__).parent.parent)
+if _plugin_root not in sys.path:
+    sys.path.insert(0, _plugin_root)
+
+from lib.gateway_conditions import GATEWAY_CONDITIONS  # noqa: E402
+from lib.manifest import Manifest, parse_manifest, validate_manifest  # noqa: E402
+from lib.prompt_builder import build_retry_prompt, build_subagent_prompt  # noqa: E402
+from lib.orchestration_state import OrchestrationState  # noqa: E402
+
+
+@dataclass
+class SpawnRequest:
+    """Request to spawn a subagent for a task."""
+
+    task_name: str
+    branch_name: str
+    prompt: str
+
+
+@dataclass
+class MergeResult:
+    """Result of merging a single branch."""
+
+    branch: str
+    success: bool
+    message: str
+
+
+class ParallelOrchestrator:
+    """Orchestrates N independent TDD subagents from a manifest."""
+
+    def __init__(self):
+        self._manifest: Manifest | None = None
+        self._state: OrchestrationState | None = None
+
+    def load_manifest(self, path: str) -> None:
+        """Parse and validate a YAML manifest."""
+        self._manifest = parse_manifest(path)
+        warnings = validate_manifest(self._manifest)
+        for w in warnings:
+            print(f"[WARN] {w}", file=sys.stderr)
+        self._state = OrchestrationState(self._manifest.project)
+        if self._state.exists():
+            self._state.load()
+
+    def start(self) -> None:
+        """Initialize orchestration state for all tasks."""
+        self._require_manifest()
+        if self.is_active():
+            raise RuntimeError("Orchestration already active — stop first")
+
+        self._state.set("active", True)
+        self._state.set("phase", "spawning")
+        self._state.set("tasks", {})
+        for task in self._manifest.tasks:
+            self._state.update_task(task.name, status="pending", retries=0)
+        self._state.save()
+
+    def stop(self) -> None:
+        """Deactivate orchestration."""
+        self._require_state()
+        self._state.set("active", False)
+        self._state.set("phase", "stopped")
+        self._state.save()
+
+    def is_active(self) -> bool:
+        self._require_state()
+        return bool(self._state.get("active", False))
+
+    # --- Spawn ---
+
+    def _dependencies_met(self, task) -> bool:
+        """Check if all depends_on tasks are completed."""
+        tasks_state = self._state.get("tasks", {})
+        for dep_name in task.depends_on:
+            dep_state = tasks_state.get(dep_name, {})
+            if dep_state.get("status") != "completed":
+                return False
+        return True
+
+    def get_pending_tasks(self) -> list[SpawnRequest]:
+        """Return spawn requests for tasks still pending."""
+        self._require_manifest()
+        self._require_state()
+        tasks_state = self._state.get("tasks", {})
+        pending = []
+        for task in self._manifest.tasks:
+            ts = tasks_state.get(task.name, {})
+            if ts.get("status") == "pending" and self._dependencies_met(task):
+                retries = ts.get("retries", 0)
+                last_error = ts.get("last_error", "")
+                if retries > 0 and last_error:
+                    prompt = build_retry_prompt(
+                        task,
+                        base_branch=self._manifest.base_branch,
+                        error=last_error,
+                        attempt=retries + 1,
+                        max_retries=self._manifest.max_retries,
+                    )
+                else:
+                    prompt = build_subagent_prompt(task, self._manifest.base_branch)
+                pending.append(SpawnRequest(
+                    task_name=task.name,
+                    branch_name=task.branch_name,
+                    prompt=prompt,
+                ))
+        return pending
+
+    def record_spawn(self, task_name: str, worker_id: str) -> None:
+        """Record that a task has been spawned."""
+        self._require_state()
+        self._state.update_task(task_name, status="spawned", worker_id=worker_id)
+        self._update_phase()
+        self._state.save()
+
+    # --- Monitor ---
+
+    def record_completion(
+        self, task_name: str, success: bool, error: str = ""
+    ) -> Literal["completed", "retrying", "failed"]:
+        """Record task completion. Returns outcome."""
+        self._require_manifest()
+        self._require_state()
+        tasks = self._state.get("tasks", {})
+        task_state = tasks.get(task_name, {})
+        retries = task_state.get("retries", 0)
+
+        if success:
+            self._state.update_task(task_name, status="completed", error="")
+            self._update_phase()
+            self._state.save()
+            return "completed"
+
+        if retries >= self._manifest.max_retries:
+            self._state.update_task(
+                task_name, status="failed", last_error=error
+            )
+            self._propagate_failure(task_name)
+            self._update_phase()
+            self._state.save()
+            return "failed"
+
+        self._state.update_task(
+            task_name, status="pending", retries=retries + 1, last_error=error
+        )
+        self._update_phase()
+        self._state.save()
+        return "retrying"
+
+    def check_all_done(self) -> bool:
+        """Check if all tasks are completed or failed."""
+        self._require_state()
+        tasks = self._state.get("tasks", {})
+        return all(
+            t.get("status") in ("completed", "failed") for t in tasks.values()
+        )
+
+    # --- Merge ---
+
+    def _topological_order(self) -> list[str]:
+        """Return task names in topological order (dependencies first)."""
+        dep_map = {t.name: list(t.depends_on) for t in self._manifest.tasks}
+        order: list[str] = []
+        visited: set[str] = set()
+
+        def visit(name: str) -> None:
+            if name in visited:
+                return
+            visited.add(name)
+            for dep in dep_map.get(name, []):
+                visit(dep)
+            order.append(name)
+
+        for task in self._manifest.tasks:
+            visit(task.name)
+        return order
+
+    def merge_all(self, cwd: str) -> list[MergeResult]:
+        """Merge all completed task branches into base branch."""
+        self._require_manifest()
+        self._require_state()
+        results = []
+        tasks = self._state.get("tasks", {})
+
+        # Checkout base branch first
+        subprocess.run(
+            ["git", "checkout", self._manifest.base_branch],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+
+        merge_order = self._topological_order()
+        task_by_name = {t.name: t for t in self._manifest.tasks}
+        for task_name in merge_order:
+            task = task_by_name[task_name]
+            ts = tasks.get(task.name, {})
+            if ts.get("status") != "completed":
+                continue
+
+            result = subprocess.run(
+                ["git", "merge", task.branch_name, "--no-ff",
+                 "-m", f"Merge {task.branch_name}"],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode == 0:
+                results.append(MergeResult(
+                    branch=task.branch_name,
+                    success=True,
+                    message=f"Merged {task.branch_name}",
+                ))
+            else:
+                # Abort the failed merge
+                subprocess.run(
+                    ["git", "merge", "--abort"],
+                    cwd=cwd,
+                    capture_output=True,
+                    text=True,
+                )
+                results.append(MergeResult(
+                    branch=task.branch_name,
+                    success=False,
+                    message=f"Merge conflict: {result.stderr.strip()}",
+                ))
+
+        return results
+
+    # --- Verify ---
+
+    def verify(self, cwd: str) -> tuple[bool, str]:
+        """Run full test suite after merges."""
+        result = subprocess.run(
+            ["python3", "-m", "pytest", "-v", "--tb=short"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            last_line = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else "ok"
+            return True, f"Full suite passed: {last_line}"
+        last_line = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else "unknown"
+        return False, f"Full suite failed: {last_line}"
+
+    # --- Gateway ---
+
+    def check_gateway(
+        self, name: str, context: dict[str, Any]
+    ) -> tuple[bool, str]:
+        """Check a named gateway condition."""
+        fn = GATEWAY_CONDITIONS.get(name)
+        if fn is None:
+            return False, f"Unknown gateway condition: {name}"
+        return fn(**context)
+
+    # --- Status ---
+
+    def get_phase(self) -> str:
+        self._require_state()
+        return self._state.get("phase", "unknown")
+
+    def get_status(self) -> dict[str, Any]:
+        self._require_state()
+        return {
+            "project": self._manifest.project if self._manifest else "unknown",
+            "active": self._state.get("active", False),
+            "phase": self._state.get("phase", "unknown"),
+            "tasks": self._state.get("tasks", {}),
+        }
+
+    def generate_summary(self) -> str:
+        """Generate a markdown summary table."""
+        self._require_state()
+        self._require_manifest()
+        tasks = self._state.get("tasks", {})
+        lines = [
+            f"# Orchestration: {self._manifest.project}",
+            f"Phase: {self.get_phase()}",
+            "",
+            "| Task | Status | Retries | Worker | Blocked by |",
+            "|------|--------|---------|--------|------------|",
+        ]
+        for task in self._manifest.tasks:
+            ts = tasks.get(task.name, {})
+            # Show unmet dependencies
+            unmet = []
+            for dep in task.depends_on:
+                dep_state = tasks.get(dep, {})
+                if dep_state.get("status") != "completed":
+                    unmet.append(dep)
+            blocked = ", ".join(unmet) if unmet else "-"
+            lines.append(
+                f"| {task.name} | {ts.get('status', 'unknown')} | "
+                f"{ts.get('retries', 0)} | {ts.get('worker_id', '-')} | {blocked} |"
+            )
+        return "\n".join(lines)
+
+    # --- Internal ---
+
+    def _propagate_failure(self, failed_task_name: str) -> None:
+        """Mark all tasks that transitively depend on failed_task_name as failed."""
+        # Build reverse dependency map: task -> list of tasks that depend on it
+        dependents: dict[str, list[str]] = {}
+        for task in self._manifest.tasks:
+            for dep in task.depends_on:
+                dependents.setdefault(dep, []).append(task.name)
+
+        # BFS from failed task
+        queue = [failed_task_name]
+        visited = {failed_task_name}
+        while queue:
+            current = queue.pop(0)
+            for dependent in dependents.get(current, []):
+                if dependent not in visited:
+                    visited.add(dependent)
+                    self._state.update_task(
+                        dependent,
+                        status="failed",
+                        last_error=f"Dependency '{failed_task_name}' failed",
+                    )
+                    queue.append(dependent)
+
+    def _update_phase(self) -> None:
+        """Auto-advance phase based on task states."""
+        tasks = self._state.get("tasks", {})
+        statuses = [t.get("status") for t in tasks.values()]
+
+        if all(s in ("completed", "failed") for s in statuses):
+            self._state.set("phase", "merging")
+        elif any(s == "spawned" for s in statuses):
+            self._state.set("phase", "monitoring")
+        elif any(s == "pending" for s in statuses):
+            self._state.set("phase", "spawning")
+
+    def _require_manifest(self) -> None:
+        if self._manifest is None:
+            raise RuntimeError("No manifest loaded — call load_manifest() first")
+
+    def _require_state(self) -> None:
+        if self._state is None:
+            raise RuntimeError("No state initialized — call load_manifest() first")
+
+
+# --- CLI ---
+
+def main():
+    """CLI entry point for orchestrator commands."""
+    if len(sys.argv) < 2:
+        print("Usage: orchestrator.py <command> [args]")
+        cmds = "load, start, pending, spawned, complete, status, merge, verify, summary, stop"
+        print(f"Commands: {cmds}")
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    orch = ParallelOrchestrator()
+
+    if cmd == "load":
+        if len(sys.argv) < 3:
+            print("Usage: orchestrator.py load <manifest.yaml>")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        print(json.dumps({
+            "project": orch._manifest.project,
+            "tasks": len(orch._manifest.tasks),
+            "base_branch": orch._manifest.base_branch,
+        }, indent=2))
+
+    elif cmd == "start":
+        if len(sys.argv) < 3:
+            print("Usage: orchestrator.py start <manifest.yaml>")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        orch.start()
+        print(json.dumps(orch.get_status(), indent=2))
+
+    elif cmd == "pending":
+        if len(sys.argv) < 3:
+            print("Usage: orchestrator.py pending <manifest.yaml>")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        pending = orch.get_pending_tasks()
+        for req in pending:
+            print(f"\n=== {req.task_name} ({req.branch_name}) ===")
+            print(req.prompt)
+
+    elif cmd == "spawned":
+        if len(sys.argv) < 5:
+            print("Usage: orchestrator.py spawned <manifest.yaml> <task_name> <worker_id>")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        orch.record_spawn(sys.argv[3], sys.argv[4])
+        print(json.dumps(orch.get_status(), indent=2))
+
+    elif cmd == "complete":
+        if len(sys.argv) < 4:
+            print("Usage: orchestrator.py complete <manifest.yaml> <task_name> [error]")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        task_name = sys.argv[3]
+        error = sys.argv[4] if len(sys.argv) > 4 else ""
+        success = not error
+        result = orch.record_completion(task_name, success=success, error=error)
+        print(f"Result: {result}")
+        print(json.dumps(orch.get_status(), indent=2))
+
+    elif cmd == "status":
+        if len(sys.argv) < 3:
+            print("Usage: orchestrator.py status <manifest.yaml>")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        print(json.dumps(orch.get_status(), indent=2))
+
+    elif cmd == "merge":
+        if len(sys.argv) < 4:
+            print("Usage: orchestrator.py merge <manifest.yaml> <cwd>")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        results = orch.merge_all(cwd=sys.argv[3])
+        for r in results:
+            status = "OK" if r.success else "FAIL"
+            print(f"[{status}] {r.branch}: {r.message}")
+
+    elif cmd == "verify":
+        if len(sys.argv) < 3:
+            print("Usage: orchestrator.py verify <cwd>")
+            sys.exit(1)
+        ok, msg = orch.verify(cwd=sys.argv[2])
+        print(f"{'PASS' if ok else 'FAIL'}: {msg}")
+
+    elif cmd == "summary":
+        if len(sys.argv) < 3:
+            print("Usage: orchestrator.py summary <manifest.yaml>")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        print(orch.generate_summary())
+
+    elif cmd == "stop":
+        if len(sys.argv) < 3:
+            print("Usage: orchestrator.py stop <manifest.yaml>")
+            sys.exit(1)
+        orch.load_manifest(sys.argv[2])
+        orch.stop()
+        print("Orchestration stopped.")
+
+    else:
+        print(f"Unknown command: {cmd}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/prompt_builder.py
+++ b/lib/prompt_builder.py
@@ -1,0 +1,65 @@
+"""Builds prompts for TDD subagents."""
+
+from lib.manifest import ManifestTask
+
+
+def build_subagent_prompt(task: ManifestTask, base_branch: str) -> str:
+    """Build the initial TDD prompt for a subagent."""
+    return f"""You are a TDD subagent working on task: {task.name}
+
+## Task Description
+{task.description}
+
+## Setup
+1. Create and checkout branch `{task.branch_name}` from `{base_branch}`
+2. Work in target directory: `{task.target_dir}`
+3. Tests go in: `{task.test_dir}`
+
+## TDD Workflow (strict order)
+1. **Write tests first** — at least {task.min_tests} test functions in `{task.test_dir}`
+2. **Run tests** — confirm they all fail (red phase)
+3. **Implement** the code in `{task.target_dir}` to make tests pass
+4. **Run tests again** — all {task.min_tests}+ tests must pass (green phase)
+5. **Commit** all changes on branch `{task.branch_name}`
+
+## Rules
+- Do NOT modify files outside `{task.target_dir}` and `{task.test_dir}`
+- Write at least {task.min_tests} test functions
+- All tests must pass before committing
+- Commit with a descriptive message summarizing what was implemented
+"""
+
+
+def build_retry_prompt(
+    task: ManifestTask,
+    base_branch: str,
+    error: str,
+    attempt: int,
+    max_retries: int,
+) -> str:
+    """Build a retry prompt with error context."""
+    return f"""You are a TDD subagent retrying task: {task.name}
+
+## Retry Attempt {attempt} of {max_retries}
+
+## Previous Error
+```
+{error}
+```
+
+## Task Description
+{task.description}
+
+## Context
+- Branch: `{task.branch_name}` (already exists, checkout and continue)
+- Target directory: `{task.target_dir}`
+- Test directory: `{task.test_dir}`
+- Minimum tests: {task.min_tests}
+
+## Instructions
+1. Review the error above and understand what went wrong
+2. Check existing tests in `{task.test_dir}` — fix or add as needed
+3. Fix the implementation in `{task.target_dir}`
+4. Run tests — all must pass
+5. Commit the fix on branch `{task.branch_name}`
+"""

--- a/skills/agent-teams-workflow/.claude/settings.json
+++ b/skills/agent-teams-workflow/.claude/settings.json
@@ -1,0 +1,4 @@
+{
+  "name": "agent-teams-workflow",
+  "description": "Coordinate agent teams for multi-domain collaborative implementation"
+}

--- a/skills/agent-teams-workflow/SKILL.md
+++ b/skills/agent-teams-workflow/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: agent-teams-workflow
+description: "Coordinate agent teams for multi-domain collaborative implementation from a design doc or plan"
+---
+
+# Agent Teams Workflow
+
+Coordinate a team of domain-specialist Claude Code teammates for collaborative implementation work. Each teammate owns a domain (repo, module, layer, or concern), works in its own git worktree, and communicates directly with other teammates at domain boundaries.
+
+**Usage:** `/agent-teams-workflow <path-to-document>`
+
+**Requires:** Agent teams enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json)
+
+---
+
+## Flow
+
+```
+FORM → PLAN → IMPLEMENT → REVIEW → INTEGRATE → DONE
+```
+
+You (the lead) coordinate the team. You never implement — use delegate mode throughout.
+
+---
+
+## FORM: Build the Team
+
+### 1. Read the input document
+
+Read the file passed as the argument. It should be a design doc or implementation plan. If the file doesn't exist, report the error and stop.
+
+### 2. Identify domains
+
+Scan the document for natural boundaries. A domain is whatever makes sense for the work — a repo, a directory, a layer (frontend/backend), or a concern (auth/data/API). Each domain becomes one teammate.
+
+### 3. Propose team composition
+
+Present a table to the user:
+
+```
+| Teammate | Domain       | Branch                      | Context Summary              |
+|----------|--------------|-----------------------------|------------------------------|
+| sophia   | sophia repo  | teams/<effort-name>/sophia  | "You own the sophia repo..." |
+| hermes   | hermes repo  | teams/<effort-name>/hermes  | "You own the hermes repo..." |
+```
+
+**Wait for user approval.** The user can adjust domains, add/remove teammates, or approve. Do not spawn teammates until the user approves.
+
+### 4. Create worktrees
+
+Use `superpowers:using-git-worktrees` to create a worktree per teammate. Branch naming convention: `teams/<effort-name>/<domain>`.
+
+### 5. Spawn teammates
+
+Spawn each teammate with a prompt that includes:
+
+- Their domain and boundaries: "You own `<domain>`. Do not modify files outside this domain."
+- The relevant sections of the input document for their domain
+- Instruction to start in plan mode: "You must plan before implementing. Submit your plan for approval before writing any code."
+
+### 6. Enable delegate mode
+
+Press Shift+Tab to enter delegate mode. From this point forward, you coordinate only — no implementation.
+
+---
+
+## PLAN: Align Before Building
+
+All teammates start in plan mode. This phase has two rounds.
+
+### Round 1: Independent planning
+
+Each teammate explores their domain and writes a plan covering:
+- Tasks they'll tackle
+- Files they'll create or modify
+- Interfaces they expose to or consume from other domains
+
+**Wait for all plans.** Do not approve any plan until every teammate has submitted one.
+
+### Round 2: Cross-review (interacting domains only)
+
+Identify which domains share interfaces — teammates that expose or consume something from each other. For each interacting pair, ask each teammate to review the other's plan.
+
+Reviewers check for:
+- Mismatched assumptions about shared interfaces
+- Contract conflicts (types, formats, error handling)
+- Missing dependencies between domains
+
+Collect feedback. Share conflicts with the responsible teammates and let them revise. Once all conflicts are resolved, approve all plans. Teammates exit plan mode and begin implementation.
+
+**If no domains interact** (fully independent work), skip Round 2 and approve all plans directly.
+
+---
+
+## IMPLEMENT: Teammates Work, You Coordinate
+
+Stay in delegate mode. Do not implement.
+
+### Teammate responsibilities
+
+- **Claim tasks** from the shared task list and mark them in-progress/completed
+- **Message other teammates directly** when reaching a point that affects another domain (shared interface, config format, contract change)
+- **Commit regularly** on their feature branch
+
+### Your responsibilities
+
+- **Monitor progress.** Watch for:
+  - Teammates going idle (may need new tasks or be stuck)
+  - Task status lagging (nudge teammates to update the task list)
+  - Scope creep (teammate modifying files outside their domain)
+- **Resolve escalations.** If two teammates can't agree on a shared interface, make the call or ask the user.
+- **Do not implement.** If you notice work that needs doing, assign it to a teammate.
+
+### Handling blocked work
+
+If teammate B needs something teammate A hasn't finished, B messages A directly. If they can't resolve it:
+1. B works on a different task while waiting
+2. If no other tasks are available, escalate to the lead (you)
+3. You decide: reorder work, reassign, or ask the user
+
+### Phase exit
+
+The phase ends when all tasks in the shared task list are completed and no teammates are actively working.
+
+---
+
+## REVIEW: Verify Integration Boundaries
+
+Boundary review only — teammates review each other's work where their domains interact. Independent domains skip teammate review and rely on automated code review during INTEGRATE.
+
+### Steps
+
+1. **Assign boundary reviews.** Using the boundary map from PLAN (plus any new boundaries discovered during IMPLEMENT), pair teammates whose domains share interfaces. Each reviewer examines the other's branch at the interaction points.
+
+2. **Review criteria:**
+   - Do shared interfaces match what was agreed in PLAN?
+   - Are contracts honored (types, error handling, formats)?
+   - Will the domains integrate cleanly?
+
+3. **Fix cycle.** Route issues to the responsible teammate. Both sides of a boundary confirm the resolution. Re-request review only on changed boundaries, not the full domain.
+
+4. **Phase exit.** All boundary reviews are clean.
+
+**If no domains interact**, skip this phase entirely and move to INTEGRATE.
+
+---
+
+## INTEGRATE: PRs, CI, and Cleanup
+
+### 1. Open PRs
+
+Create one PR per teammate branch. Each PR body includes:
+- Summary of work done in that domain
+- Boundary review findings (if applicable)
+- Links to related PRs from other teammates
+
+### 2. Wait for CI and automated code review
+
+Monitor all PRs for:
+- CI pipeline results
+- Automated code review feedback
+
+### 3. Teammates fix issues
+
+If CI fails or automated review flags problems on a PR:
+- Route the feedback to the relevant teammate
+- The teammate fixes on their branch and pushes
+- The team stays alive until all PRs are green and review-clean
+
+### 4. Report and clean up
+
+Once all PRs pass, report a summary:
+
+```
+| Domain  | PR     | Status | Branch                     |
+|---------|--------|--------|----------------------------|
+| sophia  | #142   | green  | teams/effort-name/sophia   |
+| hermes  | #143   | green  | teams/effort-name/hermes   |
+```
+
+Then:
+- Shut down all teammates (ask each to shut down gracefully)
+- Clean up the team
+- Worktrees and branches remain — the user merges PRs through their normal process
+
+---
+
+## Rules
+
+1. **Always use delegate mode** — the lead never implements, only coordinates.
+2. **One teammate per domain** — no shared ownership of files or directories.
+3. **Plan before implementing** — all teammates must have approved plans before writing code.
+4. **Communicate at boundaries** — teammates message each other directly about shared interfaces.
+5. **Boundary review, not full review** — teammate reviews focus on integration points. Automated review handles single-domain quality.
+6. **Team stays alive through INTEGRATE** — teammates fix CI and review issues with full context.
+7. **User approves team composition** — never spawn teammates without explicit user approval.
+
+## Required Sub-Skills
+
+- `superpowers:using-git-worktrees` (FORM phase — worktree creation)

--- a/skills/parallel-orchestrate/SKILL.md
+++ b/skills/parallel-orchestrate/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: parallel-orchestrate
+description: "Orchestrate N independent TDD subagents from a YAML task manifest with branch isolation"
+---
+
+# Parallel Orchestrate
+
+Orchestrate N independent TDD subagents from a YAML task manifest. Each subagent works on its own git branch, writes tests first, implements until green, then commits. You monitor progress, retry failures, merge branches, and verify the full suite.
+
+## Initialize
+
+```bash
+python3 lib/orchestrator.py load <manifest.yaml>
+python3 lib/orchestrator.py start <manifest.yaml>
+```
+
+## Flow
+
+```
+LOAD → START → SPAWN → MONITOR → MERGE → VERIFY → COMPLETE → DONE
+                 ↑         |                |
+                 └─ RETRY ─┘          (fail: fix/rollback/continue)
+         (blocked tasks wait for dependencies)
+```
+
+### Phase 1: SPAWN
+Get pending tasks and spawn subagents:
+
+```bash
+python3 lib/orchestrator.py pending <manifest.yaml>
+```
+
+For each SpawnRequest, use the Task tool to launch a subagent:
+- Use `subagent_type: "general-purpose"`
+- Pass the `prompt` from the SpawnRequest verbatim
+- Record the spawn:
+
+```bash
+python3 lib/orchestrator.py spawned <manifest.yaml> <task_name> <worker_id>
+```
+
+### Phase 2: MONITOR
+When a subagent completes, record the result:
+
+```bash
+# Success
+python3 lib/orchestrator.py complete <manifest.yaml> <task_name>
+
+# Failure (include error message)
+python3 lib/orchestrator.py complete <manifest.yaml> <task_name> "error message"
+```
+
+Check status:
+```bash
+python3 lib/orchestrator.py status <manifest.yaml>
+```
+
+If result is "retrying", go back to SPAWN phase for that task.
+
+### Phase 3: MERGE
+Once all tasks are completed/failed, merge branches:
+
+```bash
+python3 lib/orchestrator.py merge <manifest.yaml> <project_cwd>
+```
+
+### Phase 4: VERIFY
+Run full suite verification:
+
+```bash
+python3 lib/orchestrator.py verify <project_cwd>
+```
+
+**If verification fails**, present these options to the user:
+
+1. **Fix and retry** — Investigate failures, apply fixes on the current branch, and re-run verification
+2. **Rollback** — Undo the merge and report which tasks caused conflicts
+3. **Continue anyway** — Accept the failures and proceed to completion
+
+### Phase 5: COMPLETION
+After verification passes (or user chose "continue anyway"):
+
+1. Generate the final summary:
+
+```bash
+python3 lib/orchestrator.py summary <manifest.yaml>
+```
+
+2. Hand off to `superpowers:finishing-a-development-branch` to decide how to integrate the work (merge, PR, or cleanup). This is a **REQUIRED SUB-SKILL** — do not skip.
+
+3. Stop orchestration:
+
+```bash
+python3 lib/orchestrator.py stop <manifest.yaml>
+```
+
+### Summary
+Generate a markdown summary at any point:
+
+```bash
+python3 lib/orchestrator.py summary <manifest.yaml>
+```
+
+### Stop
+Stop orchestration:
+
+```bash
+python3 lib/orchestrator.py stop <manifest.yaml>
+```
+
+## CLI Reference
+
+| Command | Args | Description |
+|---------|------|-------------|
+| `load` | `<manifest.yaml>` | Parse manifest, show task count |
+| `start` | `<manifest.yaml>` | Initialize state, set all tasks pending |
+| `pending` | `<manifest.yaml>` | Show pending SpawnRequests with prompts |
+| `spawned` | `<manifest.yaml> <task> <worker>` | Record task spawn |
+| `complete` | `<manifest.yaml> <task> [error]` | Record completion (error = failure) |
+| `status` | `<manifest.yaml>` | Show JSON state |
+| `merge` | `<manifest.yaml> <cwd>` | Merge completed branches |
+| `verify` | `<cwd>` | Run full test suite |
+| `summary` | `<manifest.yaml>` | Markdown summary table |
+| `stop` | `<manifest.yaml>` | Deactivate orchestration |
+
+## Manifest Format
+
+```yaml
+project: my-project          # Project name (used for state file)
+base_branch: main             # Branch to create task branches from
+max_retries: 2                # Max retry attempts per task
+
+tasks:
+  - name: feature-name        # Unique task identifier
+    description: |             # What to implement
+      Detailed description...
+    target_dir: src/feature    # Implementation directory
+    test_dir: tests/feature    # Test directory
+    min_tests: 10              # Minimum test functions required
+    branch_name: custom/name   # Optional (defaults to task/<name>)
+    depends_on:                # Optional: tasks that must complete first
+      - other-task-name
+```
+
+## Rules
+
+1. **Never skip TDD** — subagents must write tests FIRST
+2. **One branch per task** — no cross-task file modifications
+3. **Retry before failing** — exhaust max_retries before marking failed
+4. **Merge order matters** — merge in manifest order to minimize conflicts
+5. **Verify after merge** — always run full suite after merging all branches
+6. **Don't modify subagent branches** — only subagents write to their branches
+
+## Dependencies
+
+Tasks can declare dependencies with `depends_on`. A task won't be spawned until all its dependencies are `completed`.
+
+- If a dependency fails (exhausts retries), all tasks that depend on it are automatically marked `failed`
+- Branches are merged in topological order (dependencies first)
+- Circular dependencies are rejected at parse time
+
+Example: `setup -> feature-a -> integration`
+
+```yaml
+tasks:
+  - name: setup
+    description: Initialize project
+    target_dir: src
+    test_dir: tests
+  - name: feature-a
+    description: Build feature A
+    target_dir: src/a
+    test_dir: tests/a
+    depends_on: [setup]
+  - name: integration
+    description: Integration tests
+    target_dir: src/int
+    test_dir: tests/int
+    depends_on: [feature-a]
+```

--- a/skills/pipeline/.claude/settings.json
+++ b/skills/pipeline/.claude/settings.json
@@ -1,0 +1,4 @@
+{
+  "name": "pipeline",
+  "description": "Full pipeline: plan → manifest → parallel orchestration → branch completion"
+}

--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: pipeline
+description: "Full pipeline from design doc through plan, manifest, parallel orchestration, to branch completion"
+---
+
+# Pipeline
+
+Run the full implementation pipeline: design doc → plan → manifest → parallel orchestration → branch completion. Detects which stage to start from based on the input artifact, with checkpoints between each stage.
+
+**Usage:** `/pipeline <path-to-artifact>`
+
+---
+
+## Stage Detection
+
+Determine the starting stage from the input file:
+
+| Pattern | Starting Stage |
+|---------|---------------|
+| `*-design.md` | Stage 1 (Planning) |
+| `*-manifest.yaml` | Stage 3 (Orchestration) |
+| `*.md` (other) | Stage 2 (Manifest Generation) |
+
+If the file doesn't match any pattern, ask the user which stage to start from.
+
+---
+
+## Artifact Tracking
+
+Maintain a tracking table throughout the pipeline. Print it at every checkpoint:
+
+```
+| Artifact     | Path                          | Status    |
+|--------------|-------------------------------|-----------|
+| Design doc   | docs/my-feature-design.md     | provided  |
+| Plan         | docs/my-feature-plan.md       | pending   |
+| Manifest     | docs/my-feature-manifest.yaml | pending   |
+| Branches     | (per-task)                    | pending   |
+```
+
+Update status values as stages complete: `provided` → `generated` → `pending`.
+
+---
+
+## Stage 1: Planning
+
+**Precondition:** Input is a design doc.
+
+Invoke `superpowers:writing-plans` with the design doc path, adding these supplemental instructions to the prompt:
+
+> When writing the plan, follow these conventions for parallel orchestration compatibility:
+>
+> 1. **Dependency markers**: For any task that must run after another, add a `**Depends on:** Task N` line immediately after the task description paragraph. Tasks without this marker are treated as independent and will run in parallel.
+> 2. **Explicit file paths**: Every Do and Verify bullet must reference concrete file paths (e.g., `Create src/store.ts`, `Verify tests/store.test.ts passes`). The manifest generator infers directories from these paths.
+> 3. **Independence by default**: Design tasks to be independent whenever possible. Only add dependencies when a task genuinely requires artifacts from another task.
+
+**Output artifact:** `<design-basename>-plan.md` (produced by writing-plans)
+
+### Checkpoint 1
+
+Print the artifact tracking table with the plan marked as `generated`. Show a summary:
+
+```
+Plan generated: <path>
+Tasks found: <count>
+Dependencies: <count> task(s) have explicit dependencies
+```
+
+Ask the user: **Proceed to manifest generation / Edit the plan first / Stop**
+
+---
+
+## Stage 2: Manifest Generation
+
+**Precondition:** Input is an implementation plan (`.md`).
+
+Invoke `agent-swarm:plan-to-manifest` with the plan path.
+
+**Output artifact:** `<plan-basename>-manifest.yaml` (produced by plan-to-manifest)
+
+### Checkpoint 2
+
+Print the artifact tracking table with the manifest marked as `generated`. Show a summary:
+
+```
+Manifest generated: <path>
+Tasks: <count>
+Dependencies: <dependency graph summary>
+```
+
+Ask the user: **Proceed to orchestration / Edit the manifest first / Stop**
+
+---
+
+## Stage 3: Orchestration
+
+**Precondition:** Input is a manifest YAML (`.yaml`).
+
+Invoke `agent-swarm:parallel-orchestrate` with the manifest path.
+
+The orchestrator handles everything from here: spawning subagents, monitoring, merging, verification, and branch completion.
+
+---
+
+## Rules
+
+1. **Always show checkpoints** between stages — never skip the user prompt.
+2. **Never modify artifacts** produced by sub-skills — if edits are needed, tell the user and wait.
+3. **Preserve the full artifact chain** — every artifact path must be tracked from start to finish.
+4. **Resume from any stage** — if given a manifest directly, skip Stages 1 and 2.
+
+## Required Sub-Skills
+
+- `superpowers:writing-plans` (Stage 1)
+- `agent-swarm:plan-to-manifest` (Stage 2)
+- `agent-swarm:parallel-orchestrate` (Stage 3)

--- a/skills/plan-to-manifest/.claude/settings.json
+++ b/skills/plan-to-manifest/.claude/settings.json
@@ -1,0 +1,4 @@
+{
+  "name": "plan-to-manifest",
+  "description": "Translate a superpowers implementation plan into a parallel orchestration manifest YAML"
+}

--- a/skills/plan-to-manifest/SKILL.md
+++ b/skills/plan-to-manifest/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: plan-to-manifest
+description: "Translate a superpowers implementation plan into a parallel orchestration YAML manifest"
+---
+
+# Plan to Manifest
+
+Translate a superpowers-style implementation plan (Markdown) into a parallel orchestration manifest (YAML).
+
+**Usage:** `/plan-to-manifest <path-to-plan.md>`
+
+---
+
+## Process
+
+Follow these steps exactly:
+
+### 1. Read the plan file
+
+Read the file passed as the argument. If the file doesn't exist or isn't readable, report the error and stop.
+
+### 2. Extract project name
+
+Find the top-level heading matching `# <Name> - Implementation Plan`.
+
+Slugify the name portion:
+- Lowercase
+- Replace spaces with hyphens
+- Strip non-alphanumeric characters (except hyphens)
+- Collapse multiple hyphens into one
+
+Example: `"Svelte Todo List"` becomes `"svelte-todo-list"`
+
+### 3. Parse each task
+
+Locate every `### Task N: <Title>` section. For each task, extract:
+
+- **name**: Slugify the task number and title together. Example: `"Task 3: Todo Store"` becomes `"3-todo-store"`
+- **description**: Combine the description paragraph, `**Do:**` bullets, and `**Verify:**` bullets into a single multiline string. Preserve the original wording faithfully.
+- **depends_on**: If the task has a `**Depends on:** Task N, Task M` line, parse the referenced task numbers, look up their slugified names, and list them as dependencies.
+- **target_dir**: Infer from file paths in Do/Verify bullets (see directory inference rules below).
+- **test_dir**: Infer from file paths in Do/Verify bullets (see directory inference rules below).
+
+#### Implicit dependency detection
+
+After parsing all tasks, if **no tasks** have explicit `**Depends on:**` markers, warn the user:
+
+> No dependency markers found. Tasks will all run in parallel. Should I analyze file references to detect implicit dependencies?
+
+If the user agrees (or if some but not all tasks have markers), perform implicit analysis:
+
+1. For each task, collect all file paths from its Do/Verify bullets.
+2. For each pair of tasks (A, B), check if Task B references (imports, reads, or extends) a file that Task A creates or modifies.
+3. If a cross-reference is found, suggest the dependency to the user:
+   > Task B ("<name>") references `<file>` which Task A ("<name>") creates. Add dependency B → A?
+4. The user can accept, reject, or choose **"skip all"** to stop further suggestions.
+5. Add accepted dependencies to the manifest.
+
+### 4. Directory inference rules
+
+Scan all Do and Verify bullets for file paths (patterns like `src/foo/bar.py`, `tests/something.ts`, `Create src/lib/store.ts`):
+
+- Paths containing `/test` or `/tests` or starting with `test` are candidates for **test_dir**. Extract the directory portion (strip the filename).
+- Other paths with file extensions (`.py`, `.ts`, `.js`, `.rs`, `.go`, `.jsx`, `.tsx`, `.svelte`, `.vue`, `.rb`, `.java`, `.kt`, `.swift`, `.c`, `.cpp`, `.h`, etc.) are candidates for **target_dir**. Extract the directory portion.
+- If multiple candidates exist for either directory, pick the most specific common directory (longest common prefix that is a complete directory path).
+- **If inference fails** for a task (no file paths found, or paths are ambiguous), ask the user: `"I couldn't determine target_dir/test_dir for task '<name>'. What directories should it use?"`
+
+### 5. Generate YAML
+
+Produce the manifest with this structure:
+
+```yaml
+project: <slugified-project-name>
+base_branch: main
+max_retries: 2
+
+tasks:
+  - name: <slugified-name>
+    description: |
+      <combined description>
+    target_dir: <inferred-target-dir>
+    test_dir: <inferred-test-dir>
+    depends_on:  # only include if the task has dependencies
+      - <dep-slug>
+```
+
+Do not set `min_tests` explicitly unless the plan specifies a test count. The default is 5.
+
+### 6. Write the output file
+
+Write the YAML to `<plan-basename>-manifest.yaml` in the same directory as the input plan.
+
+Example: `docs/plans/my-plan.md` produces `docs/plans/my-plan-manifest.yaml`
+
+### 7. Report
+
+Tell the user the output path and summarize how many tasks were extracted.
+
+### 8. Confirm execution
+
+Show a manifest summary table:
+
+```
+| Task | Dependencies | target_dir | test_dir |
+|------|-------------|------------|----------|
+| ...  | ...         | ...        | ...      |
+```
+
+Ask the user: **Proceed to orchestration / Edit the manifest first / Stop**
+
+### 9. Hand off to orchestrator
+
+If the user chose to proceed, invoke `agent-swarm:parallel-orchestrate` with the generated manifest path. This is a **REQUIRED SUB-SKILL** — do not skip the handoff.
+
+---
+
+## Example
+
+**Input** (`docs/plans/api-plan.md`):
+
+```markdown
+# Simple API - Implementation Plan
+
+## Tasks
+
+### Task 1: Project Setup
+
+Initialize the Node.js project.
+
+**Do:**
+- Create `src/server.js` with Express app
+- Create `tests/server.test.js`
+
+**Verify:**
+- Server starts on port 3000
+
+---
+
+### Task 2: Todo Model
+
+Create the data model.
+
+**Depends on:** Task 1
+
+**Do:**
+- Create `src/models/todo.js`
+- Create `tests/models/todo.test.js`
+
+**Verify:**
+- CRUD functions work
+```
+
+**Output** (`docs/plans/api-plan-manifest.yaml`):
+
+```yaml
+project: simple-api
+base_branch: main
+max_retries: 2
+
+tasks:
+  - name: 1-project-setup
+    description: |
+      Initialize the Node.js project.
+
+      Do:
+      - Create `src/server.js` with Express app
+      - Create `tests/server.test.js`
+
+      Verify:
+      - Server starts on port 3000
+    target_dir: src
+    test_dir: tests
+
+  - name: 2-todo-model
+    description: |
+      Create the data model.
+
+      Do:
+      - Create `src/models/todo.js`
+      - Create `tests/models/todo.test.js`
+
+      Verify:
+      - CRUD functions work
+    target_dir: src/models
+    test_dir: tests/models
+    depends_on:
+      - 1-project-setup
+```
+
+---
+
+## Rules
+
+- Never add tasks that aren't in the plan.
+- Never remove tasks from the plan.
+- Preserve the original task descriptions faithfully.
+- Ask the user when directories can't be inferred.
+- Default `min_tests` to 5 (don't set it explicitly unless the plan specifies a count).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,3 +143,53 @@ def mock_workflow_client(monkeypatch):
     monkeypatch.setattr(workflow_client, "list_agents", _mock_state.list_agents)
 
     yield _mock_state
+
+
+# ============================================================================
+# Parallel Orchestration Fixtures
+# ============================================================================
+# These fixtures support tests for the parallel-orchestrate subsystem
+# (manifest-driven CLI orchestration, separate from MCP router workflows).
+
+@pytest.fixture
+def tmp_state_dir(tmp_path):
+    """Provide an isolated state directory for parallel orchestration tests."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    old = os.environ.get("ORCHESTRATION_STATE_DIR")
+    os.environ["ORCHESTRATION_STATE_DIR"] = str(state_dir)
+    yield state_dir
+    if old is None:
+        os.environ.pop("ORCHESTRATION_STATE_DIR", None)
+    else:
+        os.environ["ORCHESTRATION_STATE_DIR"] = old
+
+
+@pytest.fixture
+def tmp_manifest_file(tmp_path):
+    """Create a temporary YAML manifest file."""
+    def _create(content: str) -> str:
+        path = tmp_path / "manifest.yaml"
+        path.write_text(content)
+        return str(path)
+    return _create
+
+
+@pytest.fixture
+def sample_manifest_yaml():
+    """Return a valid manifest YAML string."""
+    return """\
+project: test-project
+base_branch: main
+tasks:
+  - name: stack
+    description: "Implement a stack data structure"
+    target_dir: src/stack
+    test_dir: tests/test_stack
+    min_tests: 10
+  - name: queue
+    description: "Implement a queue data structure"
+    target_dir: src/queue
+    test_dir: tests/test_queue
+    min_tests: 10
+"""

--- a/tests/test_gateway_conditions.py
+++ b/tests/test_gateway_conditions.py
@@ -1,0 +1,176 @@
+"""Tests for gateway condition validators."""
+
+from unittest.mock import MagicMock, patch
+
+from lib.gateway_conditions import (
+    GATEWAY_CONDITIONS,
+    all_branches_merged,
+    all_tests_pass,
+    branch_exists,
+    commit_exists,
+    full_suite_passes,
+)
+from lib.gateway_conditions import (
+    tests_written as check_tests_written,
+)
+
+
+def _mock_run(returncode=0, stdout="", stderr=""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+class TestBranchExists:
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_branch_exists_true(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=0)
+        ok, msg = branch_exists(branch="task/stack", cwd="/repo")
+        assert ok is True
+        assert "exists" in msg.lower()
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_branch_exists_false(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=1)
+        ok, msg = branch_exists(branch="task/stack", cwd="/repo")
+        assert ok is False
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_branch_exists_exception(self, mock_run):
+        mock_run.side_effect = OSError("git not found")
+        ok, msg = branch_exists(branch="task/stack", cwd="/repo")
+        assert ok is False
+        assert "error" in msg.lower()
+
+
+class TestTestsWritten:
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_enough_tests(self, mock_run):
+        # Simulate 12 test functions found
+        mock_run.return_value = _mock_run(stdout="test_a\ntest_b\n" * 6)
+        ok, msg = check_tests_written(test_dir="tests/", min_tests=10, cwd="/repo")
+        assert ok is True
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_not_enough_tests(self, mock_run):
+        mock_run.return_value = _mock_run(stdout="test_a\n")
+        ok, msg = check_tests_written(test_dir="tests/", min_tests=10, cwd="/repo")
+        assert ok is False
+        assert "10" in msg
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_no_output(self, mock_run):
+        mock_run.return_value = _mock_run(stdout="")
+        ok, msg = check_tests_written(test_dir="tests/", min_tests=5, cwd="/repo")
+        assert ok is False
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_exception(self, mock_run):
+        mock_run.side_effect = OSError("grep not found")
+        ok, msg = check_tests_written(test_dir="tests/", min_tests=5, cwd="/repo")
+        assert ok is False
+
+
+class TestAllTestsPass:
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_tests_pass(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=0, stdout="10 passed")
+        ok, msg = all_tests_pass(test_dir="tests/", cwd="/repo")
+        assert ok is True
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_tests_fail(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=1, stdout="3 failed")
+        ok, msg = all_tests_pass(test_dir="tests/", cwd="/repo")
+        assert ok is False
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_exception(self, mock_run):
+        mock_run.side_effect = OSError("pytest not found")
+        ok, msg = all_tests_pass(test_dir="tests/", cwd="/repo")
+        assert ok is False
+
+
+class TestAllBranchesMerged:
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_all_merged(self, mock_run):
+        # git branch --merged lists all branches including the ones we want
+        mock_run.return_value = _mock_run(stdout="  main\n  task/stack\n  task/queue\n")
+        ok, msg = all_branches_merged(
+            branches=["task/stack", "task/queue"], cwd="/repo"
+        )
+        assert ok is True
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_not_all_merged(self, mock_run):
+        mock_run.return_value = _mock_run(stdout="  main\n  task/stack\n")
+        ok, msg = all_branches_merged(
+            branches=["task/stack", "task/queue"], cwd="/repo"
+        )
+        assert ok is False
+        assert "task/queue" in msg
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_exception(self, mock_run):
+        mock_run.side_effect = OSError("git error")
+        ok, msg = all_branches_merged(branches=["task/stack"], cwd="/repo")
+        assert ok is False
+
+
+class TestFullSuitePasses:
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_suite_passes(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=0, stdout="50 passed")
+        ok, msg = full_suite_passes(cwd="/repo")
+        assert ok is True
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_suite_fails(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=1, stdout="2 failed")
+        ok, msg = full_suite_passes(cwd="/repo")
+        assert ok is False
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_exception(self, mock_run):
+        mock_run.side_effect = OSError("pytest not found")
+        ok, msg = full_suite_passes(cwd="/repo")
+        assert ok is False
+
+
+class TestCommitExists:
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_commit_exists(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=0, stdout="abc1234")
+        ok, msg = commit_exists(branch="task/stack", cwd="/repo")
+        assert ok is True
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_no_commits(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=1, stdout="")
+        ok, msg = commit_exists(branch="task/stack", cwd="/repo")
+        assert ok is False
+
+    @patch("lib.gateway_conditions.subprocess.run")
+    def test_exception(self, mock_run):
+        mock_run.side_effect = OSError("git error")
+        ok, msg = commit_exists(branch="task/stack", cwd="/repo")
+        assert ok is False
+
+
+class TestRegistry:
+    def test_registry_has_all_conditions(self):
+        expected = {
+            "branch_exists",
+            "tests_written",
+            "all_tests_pass",
+            "all_branches_merged",
+            "full_suite_passes",
+            "commit_exists",
+        }
+        assert set(GATEWAY_CONDITIONS.keys()) == expected
+
+    def test_registry_values_are_callable(self):
+        for name, fn in GATEWAY_CONDITIONS.items():
+            assert callable(fn), f"{name} is not callable"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,374 @@
+"""Tests for manifest parsing and validation."""
+
+import pytest
+
+from lib.manifest import Manifest, ManifestTask, parse_manifest, validate_manifest
+
+
+class TestManifestTask:
+    def test_task_has_required_fields(self):
+        task = ManifestTask(
+            name="stack",
+            description="Implement a stack",
+            target_dir="src/stack",
+            test_dir="tests/test_stack",
+            min_tests=10,
+        )
+        assert task.name == "stack"
+        assert task.min_tests == 10
+
+    def test_task_default_min_tests(self):
+        task = ManifestTask(
+            name="stack",
+            description="Implement a stack",
+            target_dir="src/stack",
+            test_dir="tests/test_stack",
+        )
+        assert task.min_tests == 5
+
+    def test_task_branch_name(self):
+        task = ManifestTask(
+            name="stack",
+            description="Implement a stack",
+            target_dir="src/stack",
+            test_dir="tests/test_stack",
+        )
+        assert task.branch_name == "task/stack"
+
+    def test_task_custom_branch(self):
+        task = ManifestTask(
+            name="stack",
+            description="Implement a stack",
+            target_dir="src/stack",
+            test_dir="tests/test_stack",
+            branch_name="feature/custom-stack",
+        )
+        assert task.branch_name == "feature/custom-stack"
+
+    def test_task_default_depends_on(self):
+        task = ManifestTask(
+            name="stack",
+            description="Implement a stack",
+            target_dir="src/stack",
+            test_dir="tests/test_stack",
+        )
+        assert task.depends_on == []
+
+    def test_task_custom_depends_on(self):
+        task = ManifestTask(
+            name="queue",
+            description="Implement a queue",
+            target_dir="src/queue",
+            test_dir="tests/test_queue",
+            depends_on=["stack"],
+        )
+        assert task.depends_on == ["stack"]
+
+
+class TestManifest:
+    def test_manifest_has_project_and_tasks(self):
+        task = ManifestTask(
+            name="stack",
+            description="Implement a stack",
+            target_dir="src/stack",
+            test_dir="tests/test_stack",
+        )
+        manifest = Manifest(project="my-project", base_branch="main", tasks=[task])
+        assert manifest.project == "my-project"
+        assert len(manifest.tasks) == 1
+
+    def test_manifest_default_base_branch(self):
+        manifest = Manifest(project="my-project", tasks=[])
+        assert manifest.base_branch == "main"
+
+    def test_manifest_default_max_retries(self):
+        manifest = Manifest(project="my-project", tasks=[])
+        assert manifest.max_retries == 2
+
+
+class TestParseManifest:
+    def test_parse_valid_manifest(self, tmp_manifest_file, sample_manifest_yaml):
+        path = tmp_manifest_file(sample_manifest_yaml)
+        manifest = parse_manifest(path)
+        assert manifest.project == "test-project"
+        assert manifest.base_branch == "main"
+        assert len(manifest.tasks) == 2
+        assert manifest.tasks[0].name == "stack"
+        assert manifest.tasks[1].name == "queue"
+
+    def test_parse_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            parse_manifest("/nonexistent/manifest.yaml")
+
+    def test_parse_missing_project(self, tmp_manifest_file):
+        yaml_str = (
+            "tasks:\n  - name: foo\n    description: bar\n"
+            "    target_dir: x\n    test_dir: y\n"
+        )
+        path = tmp_manifest_file(yaml_str)
+        with pytest.raises(ValueError, match="project"):
+            parse_manifest(path)
+
+    def test_parse_missing_tasks(self, tmp_manifest_file):
+        path = tmp_manifest_file("project: foo\n")
+        with pytest.raises(ValueError, match="tasks"):
+            parse_manifest(path)
+
+    def test_parse_empty_tasks(self, tmp_manifest_file):
+        path = tmp_manifest_file("project: foo\ntasks: []\n")
+        with pytest.raises(ValueError, match="at least one task"):
+            parse_manifest(path)
+
+    def test_parse_task_missing_name(self, tmp_manifest_file):
+        yaml_str = (
+            "project: foo\ntasks:\n  - description: bar\n"
+            "    target_dir: x\n    test_dir: y\n"
+        )
+        path = tmp_manifest_file(yaml_str)
+        with pytest.raises(ValueError, match="name"):
+            parse_manifest(path)
+
+    def test_parse_task_missing_description(self, tmp_manifest_file):
+        yaml_str = "project: foo\ntasks:\n  - name: bar\n    target_dir: x\n    test_dir: y\n"
+        path = tmp_manifest_file(yaml_str)
+        with pytest.raises(ValueError, match="description"):
+            parse_manifest(path)
+
+    def test_parse_task_missing_target_dir(self, tmp_manifest_file):
+        yaml_str = "project: foo\ntasks:\n  - name: bar\n    description: desc\n    test_dir: y\n"
+        path = tmp_manifest_file(yaml_str)
+        with pytest.raises(ValueError, match="target_dir"):
+            parse_manifest(path)
+
+    def test_parse_task_missing_test_dir(self, tmp_manifest_file):
+        yaml_str = "project: foo\ntasks:\n  - name: bar\n    description: desc\n    target_dir: x\n"
+        path = tmp_manifest_file(yaml_str)
+        with pytest.raises(ValueError, match="test_dir"):
+            parse_manifest(path)
+
+    def test_parse_defaults_applied(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: bar
+    description: desc
+    target_dir: x
+    test_dir: y
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        assert manifest.base_branch == "main"
+        assert manifest.max_retries == 2
+        assert manifest.tasks[0].min_tests == 5
+        assert manifest.tasks[0].branch_name == "task/bar"
+
+    def test_parse_custom_values(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+base_branch: develop
+max_retries: 5
+tasks:
+  - name: bar
+    description: desc
+    target_dir: x
+    test_dir: y
+    min_tests: 20
+    branch_name: feature/custom
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        assert manifest.base_branch == "develop"
+        assert manifest.max_retries == 5
+        assert manifest.tasks[0].min_tests == 20
+        assert manifest.tasks[0].branch_name == "feature/custom"
+
+
+    def test_parse_depends_on(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: setup
+    description: Setup project
+    target_dir: src
+    test_dir: tests
+  - name: feature
+    description: Build feature
+    target_dir: src/feature
+    test_dir: tests/feature
+    depends_on:
+      - setup
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        assert manifest.tasks[0].depends_on == []
+        assert manifest.tasks[1].depends_on == ["setup"]
+
+
+class TestValidateManifest:
+    def test_validate_no_warnings(self, tmp_manifest_file, sample_manifest_yaml):
+        path = tmp_manifest_file(sample_manifest_yaml)
+        manifest = parse_manifest(path)
+        warnings = validate_manifest(manifest)
+        assert warnings == []
+
+    def test_validate_duplicate_task_names(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: bar
+    description: desc1
+    target_dir: x1
+    test_dir: y1
+  - name: bar
+    description: desc2
+    target_dir: x2
+    test_dir: y2
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        warnings = validate_manifest(manifest)
+        assert any("duplicate" in w.lower() for w in warnings)
+
+    def test_validate_low_min_tests(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: bar
+    description: desc
+    target_dir: x
+    test_dir: y
+    min_tests: 1
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        warnings = validate_manifest(manifest)
+        assert any("min_tests" in w.lower() for w in warnings)
+
+    def test_validate_duplicate_branches(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: a
+    description: desc
+    target_dir: x1
+    test_dir: y1
+    branch_name: same-branch
+  - name: b
+    description: desc
+    target_dir: x2
+    test_dir: y2
+    branch_name: same-branch
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        warnings = validate_manifest(manifest)
+        assert any("branch" in w.lower() for w in warnings)
+
+    def test_validate_depends_on_unknown_task(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: a
+    description: desc
+    target_dir: x
+    test_dir: y
+    depends_on:
+      - nonexistent
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        with pytest.raises(ValueError, match="nonexistent"):
+            validate_manifest(manifest)
+
+    def test_validate_self_dependency(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: a
+    description: desc
+    target_dir: x
+    test_dir: y
+    depends_on:
+      - a
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        with pytest.raises(ValueError, match="[Cc]ircular"):
+            validate_manifest(manifest)
+
+    def test_validate_circular_dependency(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: a
+    description: desc
+    target_dir: x
+    test_dir: y
+    depends_on:
+      - b
+  - name: b
+    description: desc
+    target_dir: x2
+    test_dir: y2
+    depends_on:
+      - a
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        with pytest.raises(ValueError, match="[Cc]ircular"):
+            validate_manifest(manifest)
+
+    def test_validate_deep_circular_dependency(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: a
+    description: desc
+    target_dir: x
+    test_dir: y
+    depends_on:
+      - c
+  - name: b
+    description: desc
+    target_dir: x2
+    test_dir: y2
+    depends_on:
+      - a
+  - name: c
+    description: desc
+    target_dir: x3
+    test_dir: y3
+    depends_on:
+      - b
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        with pytest.raises(ValueError, match="[Cc]ircular"):
+            validate_manifest(manifest)
+
+    def test_validate_valid_dependencies(self, tmp_manifest_file):
+        yaml_str = """\
+project: foo
+tasks:
+  - name: a
+    description: desc
+    target_dir: x
+    test_dir: y
+  - name: b
+    description: desc
+    target_dir: x2
+    test_dir: y2
+    depends_on:
+      - a
+  - name: c
+    description: desc
+    target_dir: x3
+    test_dir: y3
+    depends_on:
+      - a
+      - b
+"""
+        path = tmp_manifest_file(yaml_str)
+        manifest = parse_manifest(path)
+        warnings = validate_manifest(manifest)
+        assert not any("depend" in w.lower() or "circular" in w.lower() for w in warnings)

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -1,0 +1,120 @@
+"""Tests for OrchestrationState."""
+
+import json
+import os
+
+from lib.orchestration_state import OrchestrationState
+
+
+class TestOrchestrationStateBasics:
+    def test_new_state_does_not_exist(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        assert not state.exists()
+
+    def test_save_creates_file(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.set("phase", "init")
+        state.save()
+        assert state.exists()
+
+    def test_round_trip(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.set("phase", "spawning")
+        state.set("tasks", {"stack": {"status": "pending"}})
+        state.save()
+
+        loaded = OrchestrationState("test-project")
+        loaded.load()
+        assert loaded.get("phase") == "spawning"
+        assert loaded.get("tasks") == {"stack": {"status": "pending"}}
+
+    def test_get_missing_key_returns_default(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        assert state.get("missing") is None
+        assert state.get("missing", "fallback") == "fallback"
+
+    def test_clear_removes_file(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.set("phase", "init")
+        state.save()
+        assert state.exists()
+
+        state.clear()
+        assert not state.exists()
+
+    def test_clear_nonexistent_is_noop(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.clear()  # Should not raise
+
+
+class TestOrchestrationStateNested:
+    def test_set_nested_key(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.set("tasks", {})
+        state.set("tasks.stack", {"status": "pending"})
+        assert state.get("tasks") == {"stack": {"status": "pending"}}
+
+    def test_get_nested_key(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.set("tasks", {"stack": {"status": "running", "retries": 2}})
+        assert state.get("tasks.stack.status") == "running"
+        assert state.get("tasks.stack.retries") == 2
+
+    def test_get_nested_missing_returns_default(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.set("tasks", {})
+        assert state.get("tasks.stack.status", "unknown") == "unknown"
+
+
+class TestUpdateTask:
+    def test_update_task_creates_entry(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.update_task("stack", status="spawned", worker_id="w1")
+        tasks = state.get("tasks")
+        assert tasks["stack"]["status"] == "spawned"
+        assert tasks["stack"]["worker_id"] == "w1"
+
+    def test_update_task_merges(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.update_task("stack", status="spawned")
+        state.update_task("stack", retries=1)
+        task = state.get("tasks")["stack"]
+        assert task["status"] == "spawned"
+        assert task["retries"] == 1
+
+    def test_update_task_overwrites_field(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.update_task("stack", status="spawned")
+        state.update_task("stack", status="completed")
+        assert state.get("tasks")["stack"]["status"] == "completed"
+
+
+class TestAtomicWrite:
+    def test_atomic_write_produces_valid_json(self, tmp_state_dir):
+        state = OrchestrationState("test-project")
+        state.set("data", list(range(100)))
+        state.save()
+
+        path = tmp_state_dir / "test-project.json"
+        data = json.loads(path.read_text())
+        assert data["data"] == list(range(100))
+
+    def test_state_file_path_uses_env_var(self, tmp_state_dir):
+        state = OrchestrationState("myproj")
+        state.set("x", 1)
+        state.save()
+
+        expected = tmp_state_dir / "myproj.json"
+        assert expected.exists()
+
+
+class TestEnvOverride:
+    def test_default_state_dir_without_env(self, tmp_path):
+        old = os.environ.pop("ORCHESTRATION_STATE_DIR", None)
+        try:
+            state = OrchestrationState("test-project")
+            # Should use plugin_root/.state/
+            assert ".state" in str(state._state_path)
+        finally:
+            if old:
+                os.environ["ORCHESTRATION_STATE_DIR"] = old

--- a/tests/test_parallel_orchestrator.py
+++ b/tests/test_parallel_orchestrator.py
@@ -1,0 +1,433 @@
+"""Tests for the ParallelOrchestrator."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lib.orchestrator import ParallelOrchestrator, SpawnRequest
+
+
+@pytest.fixture
+def manifest_path(tmp_path):
+    """Create a manifest file and return its path."""
+    content = """\
+project: test-project
+base_branch: main
+max_retries: 2
+tasks:
+  - name: stack
+    description: "Implement a stack"
+    target_dir: src/stack
+    test_dir: tests/test_stack
+    min_tests: 10
+  - name: queue
+    description: "Implement a queue"
+    target_dir: src/queue
+    test_dir: tests/test_queue
+    min_tests: 10
+  - name: linked_list
+    description: "Implement a linked list"
+    target_dir: src/linked_list
+    test_dir: tests/test_linked_list
+    min_tests: 10
+"""
+    path = tmp_path / "manifest.yaml"
+    path.write_text(content)
+    return str(path)
+
+
+@pytest.fixture
+def orchestrator(tmp_state_dir, manifest_path):
+    """Create and load an orchestrator."""
+    orch = ParallelOrchestrator()
+    orch.load_manifest(manifest_path)
+    return orch
+
+
+class TestLifecycle:
+    def test_load_manifest(self, orchestrator):
+        assert orchestrator._manifest is not None
+        assert orchestrator._manifest.project == "test-project"
+        assert len(orchestrator._manifest.tasks) == 3
+
+    def test_start_initializes_state(self, orchestrator):
+        orchestrator.start()
+        assert orchestrator.is_active()
+        assert orchestrator.get_phase() == "spawning"
+
+    def test_start_sets_all_tasks_pending(self, orchestrator):
+        orchestrator.start()
+        status = orchestrator.get_status()
+        for task in orchestrator._manifest.tasks:
+            assert status["tasks"][task.name]["status"] == "pending"
+
+    def test_stop_deactivates(self, orchestrator):
+        orchestrator.start()
+        orchestrator.stop()
+        assert not orchestrator.is_active()
+
+    def test_double_start_raises(self, orchestrator):
+        orchestrator.start()
+        with pytest.raises(RuntimeError, match="already active"):
+            orchestrator.start()
+
+
+class TestSpawn:
+    def test_get_pending_tasks(self, orchestrator):
+        orchestrator.start()
+        pending = orchestrator.get_pending_tasks()
+        assert len(pending) == 3
+        assert all(isinstance(p, SpawnRequest) for p in pending)
+
+    def test_pending_tasks_have_prompts(self, orchestrator):
+        orchestrator.start()
+        pending = orchestrator.get_pending_tasks()
+        for req in pending:
+            assert len(req.prompt) > 0
+            assert req.task_name in req.prompt
+
+    def test_record_spawn(self, orchestrator):
+        orchestrator.start()
+        orchestrator.record_spawn("stack", "worker-1")
+        status = orchestrator.get_status()
+        assert status["tasks"]["stack"]["status"] == "spawned"
+        assert status["tasks"]["stack"]["worker_id"] == "worker-1"
+
+    def test_pending_excludes_spawned(self, orchestrator):
+        orchestrator.start()
+        orchestrator.record_spawn("stack", "worker-1")
+        pending = orchestrator.get_pending_tasks()
+        assert len(pending) == 2
+        assert all(p.task_name != "stack" for p in pending)
+
+
+class TestMonitor:
+    def test_record_completion_success(self, orchestrator):
+        orchestrator.start()
+        orchestrator.record_spawn("stack", "w1")
+        result = orchestrator.record_completion("stack", success=True)
+        assert result == "completed"
+        status = orchestrator.get_status()
+        assert status["tasks"]["stack"]["status"] == "completed"
+
+    def test_record_completion_failure_retries(self, orchestrator):
+        orchestrator.start()
+        orchestrator.record_spawn("stack", "w1")
+        result = orchestrator.record_completion("stack", success=False, error="test failed")
+        assert result == "retrying"
+        status = orchestrator.get_status()
+        assert status["tasks"]["stack"]["status"] == "pending"
+        assert status["tasks"]["stack"]["retries"] == 1
+
+    def test_record_completion_exhausted_retries(self, orchestrator):
+        orchestrator.start()
+        # Exhaust retries (max_retries=2)
+        orchestrator.record_spawn("stack", "w1")
+        orchestrator.record_completion("stack", success=False, error="fail 1")
+        orchestrator.record_spawn("stack", "w2")
+        orchestrator.record_completion("stack", success=False, error="fail 2")
+        orchestrator.record_spawn("stack", "w3")
+        result = orchestrator.record_completion("stack", success=False, error="fail 3")
+        assert result == "failed"
+        status = orchestrator.get_status()
+        assert status["tasks"]["stack"]["status"] == "failed"
+
+    def test_check_all_done_false(self, orchestrator):
+        orchestrator.start()
+        assert not orchestrator.check_all_done()
+
+    def test_check_all_done_true(self, orchestrator):
+        orchestrator.start()
+        for task in orchestrator._manifest.tasks:
+            orchestrator.record_spawn(task.name, f"w-{task.name}")
+            orchestrator.record_completion(task.name, success=True)
+        assert orchestrator.check_all_done()
+
+    def test_check_all_done_with_failures(self, orchestrator):
+        orchestrator.start()
+        # Complete 2, fail 1 (exhausted retries)
+        orchestrator.record_spawn("stack", "w1")
+        orchestrator.record_completion("stack", success=True)
+        orchestrator.record_spawn("queue", "w2")
+        orchestrator.record_completion("queue", success=True)
+        # Exhaust linked_list retries
+        for i in range(3):
+            orchestrator.record_spawn("linked_list", f"w{i}")
+            orchestrator.record_completion("linked_list", success=False, error=f"fail {i}")
+        assert orchestrator.check_all_done()
+
+
+class TestPhaseTransitions:
+    def test_phase_advances_to_monitoring(self, orchestrator):
+        orchestrator.start()
+        # Spawn all
+        for task in orchestrator._manifest.tasks:
+            orchestrator.record_spawn(task.name, f"w-{task.name}")
+        assert orchestrator.get_phase() == "monitoring"
+
+    def test_phase_advances_to_merging(self, orchestrator):
+        orchestrator.start()
+        for task in orchestrator._manifest.tasks:
+            orchestrator.record_spawn(task.name, f"w-{task.name}")
+            orchestrator.record_completion(task.name, success=True)
+        assert orchestrator.get_phase() == "merging"
+
+
+class TestMerge:
+    @patch("lib.orchestrator.subprocess.run")
+    def test_merge_all_success(self, mock_run, orchestrator):
+        orchestrator.start()
+        for task in orchestrator._manifest.tasks:
+            orchestrator.record_spawn(task.name, f"w-{task.name}")
+            orchestrator.record_completion(task.name, success=True)
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        results = orchestrator.merge_all(cwd="/repo")
+        assert len(results) == 3
+        assert all(r.success for r in results)
+
+    @patch("lib.orchestrator.subprocess.run")
+    def test_merge_conflict(self, mock_run, orchestrator):
+        orchestrator.start()
+        for task in orchestrator._manifest.tasks:
+            orchestrator.record_spawn(task.name, f"w-{task.name}")
+            orchestrator.record_completion(task.name, success=True)
+
+        # First merge succeeds, second has conflict
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),  # checkout main
+            MagicMock(returncode=0, stdout="", stderr=""),  # merge stack
+            MagicMock(returncode=1, stdout="", stderr="CONFLICT"),  # merge queue
+            MagicMock(returncode=0, stdout="", stderr=""),  # abort merge
+            MagicMock(returncode=0, stdout="", stderr=""),  # merge linked_list
+        ]
+        results = orchestrator.merge_all(cwd="/repo")
+        failed = [r for r in results if not r.success]
+        assert len(failed) == 1
+        assert failed[0].branch == "task/queue"
+
+    @patch("lib.orchestrator.subprocess.run")
+    def test_merge_skips_failed_tasks(self, mock_run, orchestrator):
+        orchestrator.start()
+        # stack: completed, queue: failed
+        orchestrator.record_spawn("stack", "w1")
+        orchestrator.record_completion("stack", success=True)
+        for i in range(3):
+            orchestrator.record_spawn("queue", f"w{i}")
+            orchestrator.record_completion("queue", success=False, error="fail")
+        orchestrator.record_spawn("linked_list", "w3")
+        orchestrator.record_completion("linked_list", success=True)
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        results = orchestrator.merge_all(cwd="/repo")
+        # Should only merge stack and linked_list
+        merged_branches = [r.branch for r in results]
+        assert "task/queue" not in merged_branches
+        assert "task/stack" in merged_branches
+        assert "task/linked_list" in merged_branches
+
+
+class TestVerify:
+    @patch("lib.orchestrator.subprocess.run")
+    def test_verify_pass(self, mock_run, orchestrator):
+        mock_run.return_value = MagicMock(returncode=0, stdout="50 passed")
+        ok, msg = orchestrator.verify(cwd="/repo")
+        assert ok is True
+
+    @patch("lib.orchestrator.subprocess.run")
+    def test_verify_fail(self, mock_run, orchestrator):
+        mock_run.return_value = MagicMock(returncode=1, stdout="3 failed")
+        ok, msg = orchestrator.verify(cwd="/repo")
+        assert ok is False
+
+
+class TestGateway:
+    @patch("lib.orchestrator.subprocess.run")
+    def test_check_gateway(self, mock_run, orchestrator):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        ok, msg = orchestrator.check_gateway(
+            "branch_exists", {"branch": "task/stack", "cwd": "/repo"}
+        )
+        assert ok is True
+
+    def test_check_unknown_gateway(self, orchestrator):
+        ok, msg = orchestrator.check_gateway("nonexistent", {})
+        assert ok is False
+        assert "unknown" in msg.lower()
+
+
+@pytest.fixture
+def manifest_with_deps_path(tmp_path):
+    """Create a manifest with dependencies."""
+    content = """\
+project: test-deps
+base_branch: main
+max_retries: 2
+tasks:
+  - name: setup
+    description: "Project setup"
+    target_dir: src
+    test_dir: tests
+  - name: feature-a
+    description: "Feature A"
+    target_dir: src/a
+    test_dir: tests/a
+    depends_on:
+      - setup
+  - name: feature-b
+    description: "Feature B"
+    target_dir: src/b
+    test_dir: tests/b
+    depends_on:
+      - setup
+  - name: integration
+    description: "Integration"
+    target_dir: src/int
+    test_dir: tests/int
+    depends_on:
+      - feature-a
+      - feature-b
+"""
+    path = tmp_path / "manifest-deps.yaml"
+    path.write_text(content)
+    return str(path)
+
+
+@pytest.fixture
+def orch_with_deps(tmp_state_dir, manifest_with_deps_path):
+    """Create orchestrator with dependency manifest."""
+    orch = ParallelOrchestrator()
+    orch.load_manifest(manifest_with_deps_path)
+    return orch
+
+
+class TestDependencies:
+    def test_only_root_tasks_initially_pending(self, orch_with_deps):
+        orch_with_deps.start()
+        pending = orch_with_deps.get_pending_tasks()
+        names = [p.task_name for p in pending]
+        assert names == ["setup"]
+
+    def test_dependents_unlocked_after_dependency_completes(self, orch_with_deps):
+        orch_with_deps.start()
+        orch_with_deps.record_spawn("setup", "w1")
+        orch_with_deps.record_completion("setup", success=True)
+        pending = orch_with_deps.get_pending_tasks()
+        names = sorted(p.task_name for p in pending)
+        assert names == ["feature-a", "feature-b"]
+
+    def test_multi_dependency_waits_for_all(self, orch_with_deps):
+        orch_with_deps.start()
+        orch_with_deps.record_spawn("setup", "w1")
+        orch_with_deps.record_completion("setup", success=True)
+        orch_with_deps.record_spawn("feature-a", "w2")
+        orch_with_deps.record_completion("feature-a", success=True)
+        pending = orch_with_deps.get_pending_tasks()
+        names = [p.task_name for p in pending]
+        assert "feature-b" in names
+        assert "integration" not in names
+
+    def test_multi_dependency_unlocks_when_all_complete(self, orch_with_deps):
+        orch_with_deps.start()
+        orch_with_deps.record_spawn("setup", "w1")
+        orch_with_deps.record_completion("setup", success=True)
+        orch_with_deps.record_spawn("feature-a", "w2")
+        orch_with_deps.record_completion("feature-a", success=True)
+        orch_with_deps.record_spawn("feature-b", "w3")
+        orch_with_deps.record_completion("feature-b", success=True)
+        pending = orch_with_deps.get_pending_tasks()
+        names = [p.task_name for p in pending]
+        assert names == ["integration"]
+
+    def test_no_deps_still_works(self, orchestrator):
+        """Tasks without depends_on behave as before."""
+        orchestrator.start()
+        pending = orchestrator.get_pending_tasks()
+        assert len(pending) == 3
+
+    def test_failure_propagates_to_direct_dependents(self, orch_with_deps):
+        orch_with_deps.start()
+        # Exhaust setup retries (max_retries=2, so 3 attempts total)
+        for i in range(3):
+            orch_with_deps.record_spawn("setup", f"w{i}")
+            orch_with_deps.record_completion("setup", success=False, error="fail")
+        status = orch_with_deps.get_status()
+        assert status["tasks"]["setup"]["status"] == "failed"
+        assert status["tasks"]["feature-a"]["status"] == "failed"
+        assert status["tasks"]["feature-b"]["status"] == "failed"
+        assert status["tasks"]["integration"]["status"] == "failed"
+
+    def test_failure_propagation_message(self, orch_with_deps):
+        orch_with_deps.start()
+        for i in range(3):
+            orch_with_deps.record_spawn("setup", f"w{i}")
+            orch_with_deps.record_completion("setup", success=False, error="fail")
+        status = orch_with_deps.get_status()
+        assert "setup" in status["tasks"]["feature-a"].get("last_error", "")
+
+    def test_partial_failure_only_affects_dependents(self, orch_with_deps):
+        orch_with_deps.start()
+        orch_with_deps.record_spawn("setup", "w1")
+        orch_with_deps.record_completion("setup", success=True)
+        # Fail feature-a (exhaust retries)
+        for i in range(3):
+            orch_with_deps.record_spawn("feature-a", f"w{i}")
+            orch_with_deps.record_completion("feature-a", success=False, error="fail")
+        status = orch_with_deps.get_status()
+        assert status["tasks"]["setup"]["status"] == "completed"
+        assert status["tasks"]["feature-a"]["status"] == "failed"
+        assert status["tasks"]["feature-b"]["status"] == "pending"  # unaffected
+        assert status["tasks"]["integration"]["status"] == "failed"  # depends on feature-a
+
+    def test_check_all_done_after_propagation(self, orch_with_deps):
+        orch_with_deps.start()
+        for i in range(3):
+            orch_with_deps.record_spawn("setup", f"w{i}")
+            orch_with_deps.record_completion("setup", success=False, error="fail")
+        assert orch_with_deps.check_all_done()
+
+
+class TestMergeOrder:
+    @patch("lib.orchestrator.subprocess.run")
+    def test_merge_respects_dependency_order(self, mock_run, orch_with_deps):
+        orch_with_deps.start()
+        # Complete all tasks
+        for name in ["setup", "feature-a", "feature-b", "integration"]:
+            orch_with_deps.record_spawn(name, f"w-{name}")
+            orch_with_deps.record_completion(name, success=True)
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        results = orch_with_deps.merge_all(cwd="/repo")
+        merged = [r.branch for r in results]
+        # setup must come before feature-a and feature-b
+        # feature-a and feature-b must come before integration
+        setup_idx = merged.index("task/setup")
+        fa_idx = merged.index("task/feature-a")
+        fb_idx = merged.index("task/feature-b")
+        int_idx = merged.index("task/integration")
+        assert setup_idx < fa_idx
+        assert setup_idx < fb_idx
+        assert fa_idx < int_idx
+        assert fb_idx < int_idx
+
+
+class TestSummary:
+    def test_generate_summary(self, orchestrator):
+        orchestrator.start()
+        orchestrator.record_spawn("stack", "w1")
+        orchestrator.record_completion("stack", success=True)
+        summary = orchestrator.generate_summary()
+        assert "stack" in summary
+        assert "pending" in summary.lower() or "completed" in summary.lower()
+
+    def test_summary_includes_all_tasks(self, orchestrator):
+        orchestrator.start()
+        summary = orchestrator.generate_summary()
+        for task in orchestrator._manifest.tasks:
+            assert task.name in summary
+
+    def test_summary_shows_blocked_by(self, orch_with_deps):
+        orch_with_deps.start()
+        summary = orch_with_deps.generate_summary()
+        # integration depends on feature-a and feature-b
+        assert "Blocked" in summary or "blocked" in summary

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,62 @@
+"""Tests for prompt builder."""
+
+from lib.manifest import ManifestTask
+from lib.prompt_builder import build_retry_prompt, build_subagent_prompt
+
+
+def _make_task(**overrides) -> ManifestTask:
+    defaults = dict(
+        name="stack",
+        description="Implement a stack data structure with push, pop, peek, is_empty",
+        target_dir="src/stack",
+        test_dir="tests/test_stack",
+        min_tests=10,
+    )
+    defaults.update(overrides)
+    return ManifestTask(**defaults)
+
+
+class TestBuildSubagentPrompt:
+    def test_contains_branch_name(self):
+        task = _make_task()
+        prompt = build_subagent_prompt(task, base_branch="main")
+        assert "task/stack" in prompt
+
+    def test_contains_tdd_order(self):
+        task = _make_task()
+        prompt = build_subagent_prompt(task, base_branch="main")
+        # TDD workflow steps: write tests is step 1, implement is step 3
+        assert "Write tests first" in prompt
+        # "Implement" step should come after the test-writing step
+        write_tests_pos = prompt.find("Write tests first")
+        implement_pos = prompt.find("Implement", write_tests_pos)
+        assert implement_pos > write_tests_pos, "Tests should be mentioned before implementation"
+
+    def test_contains_task_description(self):
+        task = _make_task(description="Build a red-black tree")
+        prompt = build_subagent_prompt(task, base_branch="main")
+        assert "red-black tree" in prompt
+
+    def test_contains_min_tests(self):
+        task = _make_task(min_tests=15)
+        prompt = build_subagent_prompt(task, base_branch="main")
+        assert "15" in prompt
+
+
+class TestBuildRetryPrompt:
+    def test_contains_error_context(self):
+        task = _make_task()
+        prompt = build_retry_prompt(
+            task, base_branch="main", error="AssertionError: expected 5 got 3",
+            attempt=2, max_retries=3,
+        )
+        assert "AssertionError" in prompt
+
+    def test_contains_attempt_info(self):
+        task = _make_task()
+        prompt = build_retry_prompt(
+            task, base_branch="main", error="test failed",
+            attempt=2, max_retries=3,
+        )
+        assert "2" in prompt
+        assert "3" in prompt


### PR DESCRIPTION
## Summary

- Consolidates the standalone parallel-orchestration plugin into agent-swarm as a single unified plugin
- Adds 4 new skills: `parallel-orchestrate`, `agent-teams-workflow`, `pipeline`, `plan-to-manifest`
- Adds 5 lib modules: `orchestrator.py`, `orchestration_state.py`, `manifest.py`, `gateway_conditions.py`, `prompt_builder.py`
- Adds 5 test files with 109 new tests (all passing, no regressions in existing suite)
- Updates all cross-references from `parallel-orchestration:*` to `agent-swarm:*`
- Renames `state.py` to `orchestration_state.py` to avoid collision with existing state module

## Test plan

- [x] All 109 new tests pass (`test_manifest`, `test_orchestration_state`, `test_parallel_orchestrator`, `test_gateway_conditions`, `test_prompt_builder`)
- [x] Existing 959 tests still pass (22 pre-existing env-dependent failures unchanged)
- [ ] Verify skills register correctly via `/parallel-orchestrate`, `/pipeline`, `/plan-to-manifest`
- [ ] Run a manifest-driven orchestration end-to-end
- [ ] Remove parallel-orchestration plugin directory and marketplace entry after merge