### PR TITLE
Working tree cleanup: orchestrate polling discipline + serena refresh + CLAUDE.md

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,15 +1,28 @@
+
+
 # list of languages for which language servers are started; choose from:
-#   al               bash             clojure          cpp              csharp           csharp_omnisharp
-#   dart             elixir           elm              erlang           fortran          go
-#   haskell          java             julia            kotlin           lua              markdown
-#   nix              perl             php              python           python_jedi      r
-#   rego             ruby             ruby_solargraph  rust             scala            swift
-#   terraform        typescript       typescript_vts   yaml             zig
+#   al                  ansible             bash                clojure             cpp
+#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
+#   elixir              elm                 erlang              fortran             fsharp
+#   go                  groovy              haskell             haxe                hlsl
+#   java                json                julia               kotlin              lean4
+#   lua                 luau                markdown            matlab              msl
+#   nix                 ocaml               pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         python_ty
+#   r                   rego                ruby                ruby_solargraph     rust
+#   scala               solidity            swift               systemverilog       terraform
+#   toml                typescript          typescript_vts      vue                 yaml
+#   zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
-#   - csharp: Requires the presence of a .sln file in the project folder.
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
 # When using multiple languages, the first language server that supports a given file will be used for that file.
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
@@ -20,14 +33,12 @@ languages:
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
 
-# whether to use the project's gitignore file to ignore files
-# Added on 2025-04-07
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore
-# same syntax as gitignore, so you can use * and **
-# Was previously called `ignored_dirs`, please update your config if you are using that.
-# Added (renamed) on 2025-04-07
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -35,45 +46,9 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -82,7 +57,9 @@ initial_prompt: ""
 # the name by which the project can be referenced within Serena
 project_name: "agent-swarm"
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -93,15 +70,19 @@ included_optional_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # time budget (seconds) per tool call for the retrieval of additional symbol information
@@ -125,3 +106,22 @@ read_only_memory_patterns: []
 # Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
 # This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
 line_ending:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# agent-swarm — project context
+
+## Thesis
+
+Claude Code plugin that enforces phase-gated workflows for AI-assisted development. Core idea: Claude is more effective when it cannot skip steps. The MCP router (`lib/mcp_router.py`) sits between Claude and all configured MCP servers, intercepting tool calls to enforce per-phase tool restrictions. Workflows defined in `config/workflows/*.yaml`; skills in `skills/<name>/SKILL.md`. GitHub: c-daly/agent-swarm.
+
+## Canonical state files (read these for project recovery)
+
+1. `<vault>/10-projects/agent-swarm/narrative.md` — project narrative, dated work entries
+2. `<vault>/10-projects/agent-swarm/open-recommendations.md` — outstanding follow-ups with status flags
+3. `<vault>/10-projects/agent-swarm/experiments/workflow-runs.md` — measured experiment record (append-only dated runs)
+4. `<vault>/10-projects/agent-swarm/experiments/run-context/` — per-run context snapshots
+5. `~/.claude/projects/-home-fearsidhe--claude-plugins-agent-swarm/memory/MEMORY.md` — auto-memory index
+
+## Memory topics (use these in observation captures)
+
+- `workflow-runs` — bench results, run-to-run comparisons
+- `agent-swarm-architecture` — daemon, router, hooks, workflow engine
+- `agent-swarm-bugs` — discovered defects + fixes
+- `plugin-cache` — cache vs dev path divergence findings
+- `bench-infra` — bench-start/end, benchmark.sh, related scripts
+
+## Project-specific protocols
+
+- **Plugin cache vs dev path**: skill files load from `~/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/<version>/skills/<name>/SKILL.md`, not the dev path. Edit dev, then `cp` (or sync-plugin script when it exists) before testing in a new session. In-session edits don't propagate within the session either.
+- **Bench scripts** live at `~/projects/iterate-test/assignments/`: `bench-start.sh`, `bench-end.sh`, `benchmark.sh` (full lifecycle wrapper), `nuke-and-recreate.sh` (needs `delete_repo` gh scope), `reset-assignments.sh` (lighter local reset).
+- **Bench-end has a known bug**: hardcodes `assignments/<branch>/tests/` for pytest; breaks when subagents put tests at worktree root. Tracked in open-recommendations.md.
+- **Orchestrate brief polling discipline**: orchestrator polls PR review threads once immediately after PR creation, exits before bot reviewers comment. Tracked as a recommendation; the resolveReviewThread mechanism itself is verified working when threads exist at poll time.
+- **Daemon** at port 7523. In-memory state lost on restart. Restart after code changes (no hot-reload).
+- **Subagent dispatch** via Task tool with iterate workflow; each subagent gets its own worktree at `~/projects/iterate-test-wt/<branch>/`. Worktree isolation works correctly — verified.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -165,7 +165,9 @@ Preferred → fallback:
 ### PR Lifecycle
 - Group complete → push branch: `git push origin <branch>`
 - Open PR: `gh pr create --base main --head <branch>`
-- Poll review threads: `gh api graphql -f query='{ repository(owner:"<owner>", name:"<repo>") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { body author { login } } } } } } } }'`
+- Poll review threads: `gh api graphql -f query='{ repository(owner:"<owner>", name:"<repo>") { pullRequest(number:<n>) { reviewThreads(first:100) { pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:100) { nodes { body author { login } } } } } } } }'`
+  - `comments(first:100)` captures full thread context (later replies, clarifications), not just the opening comment
+  - If `pageInfo.hasNextPage` is true (PR has >100 review threads — rare), paginate using `reviewThreads(first:100, after:"<endCursor>")` until exhausted before evaluating stop condition #3
 - Each unresolved thread → new task (same group, depends on original)
 - Task description MUST include the comment text AND the directive: "After addressing, mark the review thread resolved via `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread-id>"}) { thread { isResolved } } }'`"
 - Append to queue → dispatch when unblocked

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -165,16 +165,19 @@ Preferred → fallback:
 ### PR Lifecycle
 - Group complete → push branch: `git push origin <branch>`
 - Open PR: `gh pr create --base main --head <branch>`
-- Poll comments: `gh api repos/<owner>/<repo>/pulls/<n>/comments`
-- Each comment → new task (same group, depends on original)
+- Poll review threads: `gh api graphql -f query='{ repository(owner:"<owner>", name:"<repo>") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { body author { login } } } } } } } }'`
+- Each unresolved thread → new task (same group, depends on original)
+- Task description MUST include the comment text AND the directive: "After addressing, mark the review thread resolved via `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread-id>"}) { thread { isResolved } } }'`"
 - Append to queue → dispatch when unblocked
+- Subagent's definition-of-done for a comment-task: code change pushed AND review thread marked resolved (both required)
+- Bot/automated review comments (Copilot, etc.) get the same treatment — respond with code change OR a reply explaining why no change, then mark resolved
 
 ## Stop Condition
 
 ALL true simultaneously:
 1. queue empty (all complete)
 2. no agents in flight
-3. no unaddressed PR review comments
+3. **all PR review threads marked `isResolved: true`** (not just addressed in code — explicitly resolved on GitHub)
 4. working tree clean
 5. every group has PR
 


### PR DESCRIPTION
## Summary

Three unrelated working-tree changes that had been sitting uncommitted, separated into discrete commits.

### Commits

1. **`ae400d0` chore: refresh `.serena/project.yml` from upstream template** — Serena auto-regenerated this with a broader rewrite (new languages list, comment updates, plus three new fields: `ignored_memory_patterns`, `ls_specific_settings`, `added_modes`). No semantic change to existing settings.

2. **`0e0e84f` feat(orchestrate): graphql review threads + per-thread `resolveReviewThread`** — PR review polling now uses GraphQL `reviewThreads` and explicitly resolves each thread via `resolveReviewThread` mutation. Bot/automated reviews treated the same as human reviews. Stop Condition #3 strengthened to require all threads explicitly resolved on GitHub. **Verified working in follow-up orchestrate run: 32/32 threads resolved.**

3. **`517e069` docs: add agent-swarm CLAUDE.md project context** — project thesis, canonical state file pointers, memory topics, project-specific protocols (plugin cache vs dev path, bench scripts, daemon details). The harness was already reading this file from the working tree.

## Side cleanup

Also removed (not in this PR — just gone from working tree, never tracked): four stray AgentArena scaffolding files (`core.py`, `solution.py`, `test_solution.py`, `tournament/`) that were accidentally written into the agent-swarm directory back on 2026-03-18 and sat untouched for ~7 weeks. AgentArena (`~/projects/AgentArena/`) has its own canonical copies.

## Test plan

- [x] Orchestrate polling discipline verified in prior run (32/32 threads resolved)
- [ ] CI green on this branch