### PR TITLE
fix(workflow): make WorkflowEngine call workflow_start on the daemon

### DIFF
--- a/config/workflows/pr_comment.yaml
+++ b/config/workflows/pr_comment.yaml
@@ -49,7 +49,12 @@ phases:
 
   - name: check_reviews
     allowed_tool_categories: [FILE_READ, SHELL_SAFE]
-    blocked_tools: [native__write_file, native__edit_file]
+    blocked_tools:
+      - native__write_file
+      - native__edit_file
+      - serena__create_text_file
+      - serena__replace_content
+      - serena__replace_symbol_body
     eligible_agents: [implementer]
     checkpoint: false
 

--- a/config/workflows/pr_comment.yaml
+++ b/config/workflows/pr_comment.yaml
@@ -1,0 +1,67 @@
+name: pr_comment
+description: "PR review comment workflow — understanding before fixing"
+initial_phase: understand
+terminal_phase: done
+max_iterations: 3
+max_agents: 2
+
+# Note: this YAML is a structural mirror of PR_COMMENT_DEFINITION in
+# lib/pr_comment_workflow.py. The daemon enforces phase existence and
+# transition validity from this file. The richer behavioral logic
+# (adversary_gate, required_outputs, conditional kickback) lives in the
+# Python WorkflowEngine and runs at the engine layer, not the daemon.
+
+phases:
+  - name: understand
+    allowed_tool_categories: [FILE_READ, FILE_SEARCH, CODE_QUERY]
+    blocked_tools:
+      - native__write_file
+      - native__edit_file
+      - native__bash
+      - serena__create_text_file
+      - serena__replace_content
+      - serena__replace_symbol_body
+    eligible_agents: [implementer]
+    checkpoint: true
+
+  - name: fix
+    allowed_tool_categories: [FILE_READ, FILE_WRITE, FILE_SEARCH, CODE_QUERY, CODE_EDIT, SHELL_SAFE]
+    blocked_tools: []
+    eligible_agents: [implementer]
+    checkpoint: true
+
+  - name: verify
+    allowed_tool_categories: [FILE_READ, FILE_SEARCH, CODE_QUERY, SHELL_SAFE]
+    blocked_tools:
+      - native__write_file
+      - native__edit_file
+      - serena__create_text_file
+      - serena__replace_content
+      - serena__replace_symbol_body
+    eligible_agents: [implementer]
+    checkpoint: false
+
+  - name: push
+    allowed_tool_categories: [SHELL_SAFE]
+    blocked_tools: []
+    eligible_agents: [implementer]
+    checkpoint: false
+
+  - name: check_reviews
+    allowed_tool_categories: [FILE_READ, SHELL_SAFE]
+    blocked_tools: [native__write_file, native__edit_file]
+    eligible_agents: [implementer]
+    checkpoint: false
+
+  - name: done
+    allowed_tool_categories: []
+    blocked_tools: []
+    eligible_agents: []
+    checkpoint: false
+
+transitions:
+  understand: [fix]
+  fix: [verify]
+  verify: [push, fix]
+  push: [check_reviews]
+  check_reviews: [done, understand]

--- a/lib/workflow_base.py
+++ b/lib/workflow_base.py
@@ -96,7 +96,13 @@ class WorkflowEngine:
         self._pending_objections: list = []
 
     def start(self, task: str, **initial_state) -> dict:
-        """Start the workflow."""
+        """Start the workflow.
+
+        Calls daemon's workflow_start to create the workflow_state entry
+        on the daemon side, then sets non-daemon-managed values. Subsequent
+        state updates use _save_state which routes phase changes through
+        workflow_advance_phase (which requires the workflow to already exist).
+        """
         state = {
             "workflow_type": self.definition.name,
             "workflow_id": self.workflow_id,
@@ -107,7 +113,13 @@ class WorkflowEngine:
             "max_iterations": self.definition.max_iterations,
             **initial_state,
         }
-        self._save_state(state)
+        with DaemonClient() as dc:
+            dc.workflow_start(
+                self.workflow_id,
+                initial_state={
+                    k: v for k, v in state.items() if not is_daemon_only_key(k)
+                },
+            )
         return state
 
     def get_state(self) -> Optional[dict]:

--- a/lib/workflow_base.py
+++ b/lib/workflow_base.py
@@ -114,13 +114,12 @@ class WorkflowEngine:
             **initial_state,
         }
         with DaemonClient() as dc:
-            dc.workflow_start(
+            return dc.workflow_start(
                 self.workflow_id,
                 initial_state={
                     k: v for k, v in state.items() if not is_daemon_only_key(k)
                 },
             )
-        return state
 
     def get_state(self) -> Optional[dict]:
         """Get current workflow state."""


### PR DESCRIPTION
## Summary

Fixes `pr_comment` workflow (and any future WorkflowEngine-based workflow) failing at first phase save with `Workflow not found: pr_comment`.

## Root cause (two gaps)

1. **`WorkflowEngine.start()` never called `workflow_start` on the daemon.** It built in-Python state then called `_save_state()` which immediately invokes `workflow_advance_phase`. But `workflow_advance_phase` requires the workflow to already exist in the daemon's `_workflow_state` — only populated by `workflow_start`. The TODO at `lib/daemon_client.py:26-27` already flagged this gap.

2. **No `config/workflows/pr_comment.yaml`.** The daemon validates `workflow_id` against loaded YAML configs at `_wf_start` (controller.py:763). With other configs loaded, unknown wf_id is rejected.

Both gaps had to close — fixing only one would still error on the other.

## Changes

- **`lib/workflow_base.py`**: `WorkflowEngine.start()` now calls `dc.workflow_start(self.workflow_id, initial_state=...)` passing non-daemon-managed keys. Daemon sets phase from `config.initial_phase` (correct path for protected keys). Subsequent state updates unchanged — `_save_state` still works for already-started workflows.

- **`config/workflows/pr_comment.yaml`** (new): structural mirror of `PR_COMMENT_DEFINITION`. Phases (understand, fix, verify, push, check_reviews, done) + transitions. Maps `adversary_gate: True` → `checkpoint: true`. Richer Python-only fields (`required_outputs`, conditional kickback) stay in the engine and run at runtime.

## Architectural note (not addressed here)

The pattern of "Python `WorkflowDefinition` + degraded YAML mirror" creates definition duplication. Worth filing as an open recommendation — consolidate to one source of truth long-term. Out of scope for this fix.

## Test plan

- [x] Reproduction: `python3 lib/pr_comment_workflow.py start "test" 89` succeeds, returns phase=understand
- [x] Phase advancement enforced: `advance` correctly errors "Checkpoint not passed for phase 'understand'" (YAML's `checkpoint: true` working as intended)
- [x] No regressions: `pytest tests/test_iterate_workflow.py tests/test_experiment_workflow.py tests/test_develop_workflow.py tests/test_workflow_state_service.py tests/test_workflow_validation.py` — 206 passed, 70 skipped, 0 failed
- [ ] CI green