### PR TITLE
fix: orchestration ergonomics — polling discipline, --caller-id, selective sync

### DIFF
--- a/bin/sync-to-cache
+++ b/bin/sync-to-cache
@@ -77,27 +77,44 @@ sync_all() {
 sync_selective() {
     # Copy each given file from dev to cache, preserving relative path.
     # No --delete; cache-only files (which shouldn't exist, but might) are untouched.
-    local file rel dst
+    #
+    # Path handling: each input is canonicalized with `realpath -m` (handles
+    # both absolute and cwd-relative inputs, normalizes .. segments). The
+    # canonical path is then checked against SOURCE_DIR — string-prefix
+    # match on canonical paths cannot be defeated by .. since the canonical
+    # form has no .. segments.
+    #
+    # SYNCED_RELS is set as a side effect: a newline-separated list of
+    # repo-relative paths that were copied. Used by the caller to drive
+    # needs_daemon_restart with canonical paths instead of the raw $@
+    # (which can be cwd-relative and miss path-prefix matches).
+    local file abs rel dst
+    SYNCED_RELS=""
     for file in "$@"; do
-        # Resolve to absolute path; require it to be inside SOURCE_DIR
-        if [[ "$file" = /* ]]; then
-            local abs="$file"
-        else
-            local abs="$SOURCE_DIR/$file"
+        # Existence check first — must reference a real file (relative to cwd or absolute)
+        if [ ! -e "$file" ]; then
+            die "File not found: $file"
         fi
+        # Canonicalize: -m tolerates non-existent leaves (we already checked above; -m
+        # just keeps us from failing on edge cases like trailing slashes).
+        abs="$(realpath -m "$file")"
         if [ ! -f "$abs" ]; then
-            die "File not found in dev: $abs"
+            die "Not a regular file: $file ($abs)"
         fi
-        case "$abs" in
-            "$SOURCE_DIR"/*) rel="${abs#$SOURCE_DIR/}" ;;
-            *) die "File outside dev path (refusing): $abs" ;;
-        esac
+        # Boundary check: canonical path must be inside SOURCE_DIR.
+        # Append /  to SOURCE_DIR in the comparison to prevent a path like
+        # /home/.../agent-swarm-evil from matching /home/.../agent-swarm.
+        if [[ "$abs" != "$SOURCE_DIR"/* ]]; then
+            die "File outside dev path (refusing): $file → $abs"
+        fi
+        rel="${abs#$SOURCE_DIR/}"
         dst="$CACHE_DIR/$rel"
         mkdir -p "$(dirname "$dst")"
         cp -p "$abs" "$dst"
         echo "  $rel"
+        SYNCED_RELS+="$rel"$'\n'
     done
-    echo "Synced (selective, ${#@} files): $SOURCE_DIR → $CACHE_DIR"
+    echo "Synced (selective, $# files): $SOURCE_DIR → $CACHE_DIR"
 }
 
 rewrite_paths() {
@@ -129,9 +146,12 @@ needs_daemon_restart() {
 }
 
 prompt_restart() {
+    # Caller decides when to invoke this:
+    #   - selective mode: only when needs_daemon_restart returns true
+    #   - full-sync mode: unconditionally (full sync writes every daemon-loaded file)
     echo ""
-    echo "==> Changed files include daemon-loaded paths (lib/, config/workflows/, etc.)."
-    echo "    Daemon restart is required for changes to take effect."
+    echo "==> Daemon restart is required for changes to lib/, config/workflows/,"
+    echo "    config/permissions.yaml, or hooks/hooks.json to take effect."
     if [ -t 0 ]; then
         read -p "    Restart now? [y/N] " ans
         if [[ "$ans" =~ ^[Yy]$ ]]; then
@@ -161,15 +181,19 @@ fi
 
 if [ $# -gt 0 ]; then
     # Selective-file sync mode
-    sync_selective "$@"
+    sync_selective "$@"   # sets SYNCED_RELS
     rewrite_paths
-    if needs_daemon_restart "$@"; then
+    # Pass canonical relative paths to the daemon-restart heuristic, NOT raw $@
+    # (raw $@ can be cwd-relative and miss path-prefix matches).
+    if [ -n "$SYNCED_RELS" ] && needs_daemon_restart $SYNCED_RELS; then
         prompt_restart
     fi
     echo "Done."
 else
-    # Full sync mode (default)
+    # Full sync mode (default) — by definition writes every daemon-loaded file,
+    # so the restart prompt is always warranted.
     sync_all
     rewrite_paths
-    echo "Done. Restart Claude Code if hooks.json changed."
+    prompt_restart
+    echo "Done."
 fi

--- a/bin/sync-to-cache
+++ b/bin/sync-to-cache
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 # sync-to-cache — Copy plugin source to Claude Code's cache directory.
 #
-# Usage:
-#   bin/sync-to-cache          # sync all plugin files
-#   bin/sync-to-cache --undo   # restore cache from symlink state
+# DEV/CACHE DISCIPLINE — read before changing this script.
 #
-# Call this after editing source files to push changes to the cache
-# where Claude Code actually reads hooks, skills, settings, etc.
+#   The dev path (~/.claude/plugins/agent-swarm/) is the only place edits
+#   happen. The cache path (~/.claude/plugins/cache/.../1.0.0/) is NEVER
+#   edited directly — it's a build output. Sync goes dev → cache only.
+#   It is NEVER bidirectional.
+#
+#   If you discover cache-vs-dev divergence, that means someone edited
+#   cache directly (bug). Treat as a one-time manual backport (cache → dev,
+#   commit to git), then re-establish dev as canonical. Do NOT add a
+#   --from-cache mode or any feature that legitimizes cache-side edits.
+#
+# Usage:
+#   bin/sync-to-cache                       # sync ALL plugin files (rsync --delete)
+#   bin/sync-to-cache <file> [<file> ...]   # sync only the given files (no --delete)
+#   bin/sync-to-cache --undo                # restore cache from symlink state
 #
 # After syncing, rewrites ${AGENT_SWARM_ROOT} references in cached
 # hooks.json and .mcp.json to absolute paths so they work regardless
 # of whether the env var is set.
+#
+# When changes touch lib/ or config/workflows/, the script prompts
+# whether to restart the daemon (those paths require daemon restart;
+# skills/, hooks/, agents/ etc. take effect on next session).
 
 set -euo pipefail
 
@@ -28,7 +42,7 @@ undo_symlink() {
     fi
 }
 
-sync_files() {
+sync_all() {
     mkdir -p "$CACHE_DIR"
 
     rsync -a --delete \
@@ -57,7 +71,33 @@ sync_files() {
         --exclude='.claude/settings.local.json' \
         "$SOURCE_DIR/" "$CACHE_DIR/"
 
-    echo "Synced: $SOURCE_DIR → $CACHE_DIR"
+    echo "Synced (full): $SOURCE_DIR → $CACHE_DIR"
+}
+
+sync_selective() {
+    # Copy each given file from dev to cache, preserving relative path.
+    # No --delete; cache-only files (which shouldn't exist, but might) are untouched.
+    local file rel dst
+    for file in "$@"; do
+        # Resolve to absolute path; require it to be inside SOURCE_DIR
+        if [[ "$file" = /* ]]; then
+            local abs="$file"
+        else
+            local abs="$SOURCE_DIR/$file"
+        fi
+        if [ ! -f "$abs" ]; then
+            die "File not found in dev: $abs"
+        fi
+        case "$abs" in
+            "$SOURCE_DIR"/*) rel="${abs#$SOURCE_DIR/}" ;;
+            *) die "File outside dev path (refusing): $abs" ;;
+        esac
+        dst="$CACHE_DIR/$rel"
+        mkdir -p "$(dirname "$dst")"
+        cp -p "$abs" "$dst"
+        echo "  $rel"
+    done
+    echo "Synced (selective, ${#@} files): $SOURCE_DIR → $CACHE_DIR"
 }
 
 rewrite_paths() {
@@ -72,11 +112,43 @@ rewrite_paths() {
     done
 }
 
+needs_daemon_restart() {
+    # Returns 0 (true) if any of the given paths suggest daemon restart is needed.
+    # Daemon-loaded paths: lib/, config/workflows/, config/permissions.yaml, hooks/hooks.json
+    # Hot-loaded paths: skills/, agents/, README.md, CLAUDE.md, hooks/*.md, hooks/*.py (per-call)
+    local f
+    for f in "$@"; do
+        case "$f" in
+            lib/*|*/lib/*) return 0 ;;
+            config/workflows/*|*/config/workflows/*) return 0 ;;
+            config/permissions.yaml|*/config/permissions.yaml) return 0 ;;
+            hooks/hooks.json|*/hooks/hooks.json) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+prompt_restart() {
+    echo ""
+    echo "==> Changed files include daemon-loaded paths (lib/, config/workflows/, etc.)."
+    echo "    Daemon restart is required for changes to take effect."
+    if [ -t 0 ]; then
+        read -p "    Restart now? [y/N] " ans
+        if [[ "$ans" =~ ^[Yy]$ ]]; then
+            "$SOURCE_DIR/bin/start-daemon" --restart 2>&1 || echo "    (start-daemon --restart failed; restart manually)"
+        else
+            echo "    Skipped. Restart manually with: $SOURCE_DIR/bin/start-daemon --restart"
+        fi
+    else
+        echo "    Non-interactive shell; restart manually with: $SOURCE_DIR/bin/start-daemon --restart"
+    fi
+}
+
 # --- main ---
 
 if [ "${1:-}" = "--undo" ]; then
     undo_symlink
-    sync_files
+    sync_all
     rewrite_paths
     echo "Cache restored. Restart Claude Code to pick up changes."
     exit 0
@@ -87,6 +159,17 @@ if [ -L "$CACHE_DIR" ]; then
     undo_symlink
 fi
 
-sync_files
-rewrite_paths
-echo "Done. Restart Claude Code if hooks.json changed."
+if [ $# -gt 0 ]; then
+    # Selective-file sync mode
+    sync_selective "$@"
+    rewrite_paths
+    if needs_daemon_restart "$@"; then
+        prompt_restart
+    fi
+    echo "Done."
+else
+    # Full sync mode (default)
+    sync_all
+    rewrite_paths
+    echo "Done. Restart Claude Code if hooks.json changed."
+fi

--- a/hooks/subagent-briefing.md
+++ b/hooks/subagent-briefing.md
@@ -12,37 +12,41 @@ mcp-call <tool_name> '<json_args>'
 
 | Op | Command |
 |----|---------|
-| Read files | `mcp-call native__read_file '{"file_path": "/absolute/path"}'` |
-| Write files | `mcp-call native__write_file '{"file_path": "/absolute/path", "content": "..."}'` |
-| Edit files | `mcp-call native__edit_file '{"file_path": "/absolute/path", "old_string": "...", "new_string": "..."}'` |
-| Find files | `mcp-call native__glob '{"pattern": "**/*.py", "path": "/dir"}'` |
-| Search code | `mcp-call native__grep '{"pattern": "regex", "path": "/dir"}'` |
-| Run commands | `mcp-call native__bash '{"command": "pytest tests/"}'` |
+| Read files | `mcp-call --caller-id=<your-agent-id> native__read_file '{"file_path": "/absolute/path"}'` |
+| Write files | `mcp-call --caller-id=<your-agent-id> native__write_file '{"file_path": "/absolute/path", "content": "..."}'` |
+| Edit files | `mcp-call --caller-id=<your-agent-id> native__edit_file '{"file_path": "/absolute/path", "old_string": "...", "new_string": "..."}'` |
+| Find files | `mcp-call --caller-id=<your-agent-id> native__glob '{"pattern": "**/*.py", "path": "/dir"}'` |
+| Search code | `mcp-call --caller-id=<your-agent-id> native__grep '{"pattern": "regex", "path": "/dir"}'` |
+| Run commands | `mcp-call --caller-id=<your-agent-id> native__bash '{"command": "pytest tests/"}'` |
+
+**`--caller-id` is required for all MCP tool calls.** Without it, the router cannot identify your agent for permission checks and the call fails at registration. Your agent ID was assigned at registration; use it as the value.
 
 ### Examples
 
 ```bash
 # Read a file
-mcp-call native__read_file '{"file_path": "/home/fearsidhe/projects/myproject/src/main.py"}'
+mcp-call --caller-id=01a native__read_file '{"file_path": "/home/fearsidhe/projects/myproject/src/main.py"}'
 
 # Write a file
-mcp-call native__write_file '{"file_path": "/home/fearsidhe/projects/myproject/src/new.py", "content": "class Foo:\n    pass\n"}'
+mcp-call --caller-id=01a native__write_file '{"file_path": "/home/fearsidhe/projects/myproject/src/new.py", "content": "class Foo:\n    pass\n"}'
 
 # Run tests
-mcp-call native__bash '{"command": "cd /home/fearsidhe/projects/myproject && pytest tests/ -v"}'
+mcp-call --caller-id=01a native__bash '{"command": "cd /home/fearsidhe/projects/myproject && pytest tests/ -v"}'
 
 # Git operations
-mcp-call native__bash '{"command": "cd /home/fearsidhe/projects/myproject && git add -A && git commit -m \"feat: add feature\""}'
+mcp-call --caller-id=01a native__bash '{"command": "cd /home/fearsidhe/projects/myproject && git add -A && git commit -m \"feat: add feature\""}'
 ```
+
+(Replace `01a` with your actual agent ID from registration.)
 
 **IMPORTANT:** Do NOT use bare `Bash` commands like `cat`, `echo`, `python3`. Always use `mcp-call`.
 
 ## Long-Running Commands (pytest, builds)
 MCP tool calls timeout at ~30s. For commands that take longer (e.g. full test suite):
 ```bash
-mcp-call native__bash '{"command": "nohup pytest tests/ > /tmp/output.txt 2>&1 &"}'
+mcp-call --caller-id=01a native__bash '{"command": "nohup pytest tests/ > /tmp/output.txt 2>&1 &"}'
 # then later:
-mcp-call native__bash '{"command": "cat /tmp/output.txt"}'
+mcp-call --caller-id=01a native__bash '{"command": "cat /tmp/output.txt"}'
 ```
 
 ## Efficiency

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -174,6 +174,19 @@ Preferred → fallback:
 - Subagent's definition-of-done for a comment-task: code change pushed AND review thread marked resolved (both required)
 - Bot/automated review comments (Copilot, etc.) get the same treatment — respond with code change OR a reply explaining why no change, then mark resolved
 
+#### Polling discipline (required)
+
+After PR creation, automated reviewers (Copilot, gemini-code-assist, greptile, etc.) take 1–5 minutes to post review threads. Querying once immediately after PR creation will return zero threads and falsely satisfy stop condition #3.
+
+Poll with this discipline:
+- Query the reviewThreads endpoint at **30-second intervals** starting at PR creation.
+- Track thread count between polls.
+- Continue polling until **either**:
+  - (a) thread count is **stable for 5 consecutive minutes** (no new threads appearing), OR
+  - (b) **15 minutes have elapsed** since PR creation (hard cap).
+- Only after the polling phase ends should you evaluate stop condition #3.
+- During polling, dispatch comment-resolution tasks for any unresolved threads as they appear — don't batch until the end.
+
 ## Stop Condition
 
 ALL true simultaneously:

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -165,7 +165,11 @@ Preferred → fallback:
 ### PR Lifecycle
 - Group complete → push branch: `git push origin <branch>`
 - Open PR: `gh pr create --base main --head <branch>`
-- Poll review threads: `gh api graphql -f query='{ repository(owner:"<owner>", name:"<repo>") { pullRequest(number:<n>) { reviewThreads(first:100) { pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:100) { nodes { body author { login } } } } } } } }'`
+- Poll review threads using `gh api graphql -f query='...' --jq '...'`:
+  ```
+  gh api graphql -f query='{ repository(owner:"<owner>", name:"<repo>") { pullRequest(number:<n>) { reviewThreads(first:100) { pageInfo { hasNextPage endCursor } nodes { id isResolved comments(first:100) { nodes { body author { login } } } } } } } }' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | {id, isResolved}'
+  ```
+  - **Use `gh api ... --jq` (gh's built-in --jq), not a separate `jq` pipe.** Bot review bodies frequently contain markdown with literal newline characters; `gh api graphql` emits these unescaped in JSON string values (technically invalid per JSON spec). External `jq` rejects it with "control characters must be escaped"; gh's internal parser is lenient and accepts it. Piping `gh api graphql ... | jq ...` will silently return zero results when bot reviews are present.
   - `comments(first:100)` captures full thread context (later replies, clarifications), not just the opening comment
   - If `pageInfo.hasNextPage` is true (PR has >100 review threads — rare), paginate using `reviewThreads(first:100, after:"<endCursor>")` until exhausted before evaluating stop condition #3
 - Each unresolved thread → new task (same group, depends on original)


### PR DESCRIPTION
## Summary

Three small but high-leverage fixes from the 2026-05-03 session's open-recommendations list. None touch lib/ or config/workflows/ — all are skill/briefing/tooling improvements; no daemon restart required.

### 1. Orchestrate polling discipline (`skills/orchestrate/SKILL.md`)
Adds explicit timing to PR Lifecycle: poll reviewThreads at 30s intervals from PR creation, continue until thread count is stable for 5 consecutive minutes OR 15 minutes have elapsed. Only then evaluate stop condition #3.

This unblocks the `resolveReviewThread` mechanism (already shipped) which can't fire because the orchestrator queries once and exits before bot reviewers comment. Empirical evidence from run `1777827150128_orchestrate`: 32 review threads went unaddressed because the orchestrator exited 57s before the earliest bot comment arrived.

### 2. `--caller-id` in subagent briefing (`hooks/subagent-briefing.md`)
The mcp-call examples omitted `--caller-id`, which is required for router permission checks. Without it, the first dispatch round of an orchestrate run failed at registration. Adds the flag to every example, plus an explicit note that it's required.

### 3. `bin/sync-to-cache` enhancements
- **Selective-file mode**: `sync-to-cache <file> ...` copies only the listed files (no `--delete`). Avoids full-tree rebuilds for small edits and won't clobber cache-only files. Refuses paths outside dev.
- **Daemon-restart prompting**: detects when changed files are under `lib/`, `config/workflows/`, `config/permissions.yaml`, or `hooks/hooks.json` (daemon-loaded paths) and prompts for restart. Other paths are hot-loaded and don't need it.
- **Dev/cache discipline encoded in header**: explicit comment that edits ONLY happen in dev, cache is NEVER edited, sync is dev → cache only and never bidirectional. At point of use so future contributors don't add a `--from-cache` mode.

Backward compatible: zero-args full-sync and `--undo` unchanged.

## Test plan

- [x] `bash -n bin/sync-to-cache` — syntax OK
- [x] Selective sync smoke test: `bin/sync-to-cache hooks/subagent-briefing.md skills/orchestrate/SKILL.md` → both files copied, no `--delete`, no daemon-restart prompt (correct — hot-loaded paths)
- [x] Selective sync rejects nonexistent files with clear error
- [x] All three changes verified against open-recommendations.md sources
- [ ] Next orchestrate run actually exercises the polling discipline (separate experiment run)

## Out of scope (tracked elsewhere in open-recommendations)

- Python `WorkflowDefinition` + YAML duplication (added to open-recommendations as a deferred decision)
- WorkflowEngine checkpoint/adversary-gate CLI UX (open item)
- Cache-vs-dev discipline divergence on `README.md` and `config/permissions.yaml` (separate cleanup; not addressed here)