### PR TITLE
feat: add simple workflow as auto-start default

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -204,3 +204,18 @@ workflows:
     decide:
       allowed: [native__read_file, native__glob, native__grep]
       blocked: [native__write_file, native__edit_file, native__bash]
+
+  # Simple workflow — lightweight default
+  simple:
+    plan:
+      allowed: [native__read_file, native__glob, native__grep, serena__read_file, serena__find_file, serena__search_for_pattern, serena__list_dir, serena__get_symbols_overview, serena__find_symbol, workflow__*]
+      blocked: [native__write_file, native__edit_file, native__bash, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
+    work:
+      allowed: [native__write_file, native__edit_file, native__read_file, native__glob, native__grep, native__bash, serena__*]
+      blocked: []
+    verify:
+      allowed: [native__read_file, native__glob, native__grep, native__bash(pytest*), native__bash(python*), native__bash(ruff*), native__bash(git*), serena__read_file, serena__find_file, serena__search_for_pattern]
+      blocked: [native__write_file, native__edit_file, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
+    done:
+      allowed: []
+      blocked: []

--- a/config/workflows/simple.yaml
+++ b/config/workflows/simple.yaml
@@ -2,8 +2,6 @@ name: simple
 description: "Lightweight default workflow — plan before writing, narrow verification gate"
 initial_phase: plan
 terminal_phase: done
-max_iterations: 10
-max_agents: 1
 
 phases:
   - name: plan
@@ -29,6 +27,7 @@ phases:
     blocked_tools:
       - native__write_file
       - native__edit_file
+      - native__bash
       - serena__create_text_file
       - serena__replace_content
       - serena__replace_symbol_body

--- a/config/workflows/simple.yaml
+++ b/config/workflows/simple.yaml
@@ -1,0 +1,47 @@
+name: simple
+description: "Lightweight default workflow — plan before writing, narrow verification gate"
+initial_phase: plan
+terminal_phase: done
+max_iterations: 10
+max_agents: 1
+
+phases:
+  - name: plan
+    allowed_tool_categories: [FILE_READ, FILE_SEARCH, CODE_QUERY]
+    blocked_tools:
+      - native__write_file
+      - native__edit_file
+      - native__bash
+      - serena__create_text_file
+      - serena__replace_content
+      - serena__replace_symbol_body
+    eligible_agents: [implementer]
+    checkpoint: true
+
+  - name: work
+    allowed_tool_categories: [FILE_READ, FILE_WRITE, FILE_SEARCH, CODE_QUERY, CODE_EDIT, SHELL_SAFE]
+    blocked_tools: []
+    eligible_agents: [implementer]
+    checkpoint: false
+
+  - name: verify
+    allowed_tool_categories: [FILE_READ, FILE_SEARCH, CODE_QUERY, SHELL_SAFE]
+    blocked_tools:
+      - native__write_file
+      - native__edit_file
+      - serena__create_text_file
+      - serena__replace_content
+      - serena__replace_symbol_body
+    eligible_agents: [implementer]
+    checkpoint: true
+
+  - name: done
+    allowed_tool_categories: []
+    blocked_tools: []
+    eligible_agents: []
+    checkpoint: false
+
+transitions:
+  plan: [work]
+  work: [verify]
+  verify: [done, work]

--- a/hooks/session-start.py
+++ b/hooks/session-start.py
@@ -167,12 +167,14 @@ def reset_enforcement_counters(agent_id: str | None = None):
 
 
 def auto_start_workflow():
-    """Auto-start simple workflow if none active."""
+    """Auto-start simple workflow if no workflow is currently active."""
     try:
         from daemon_client import DaemonClient
+        from permission_query import get_active_workflow_id
+        if get_active_workflow_id() is not None:
+            return
         with DaemonClient() as dc:
-            if not dc.workflow_is_active("simple"):
-                dc.workflow_start("simple", initial_state={"task": "Auto-started simple workflow"})
+            dc.workflow_start("simple", initial_state={"task": "Auto-started simple workflow"})
     except Exception as e:
         log_debug(f"Auto-start workflow failed: {e}")
 

--- a/hooks/session-start.py
+++ b/hooks/session-start.py
@@ -167,12 +167,12 @@ def reset_enforcement_counters(agent_id: str | None = None):
 
 
 def auto_start_workflow():
-    """Auto-start implementer workflow if none active."""
+    """Auto-start simple workflow if none active."""
     try:
-        from implementer_workflow import ImplementerWorkflow
-        wf = ImplementerWorkflow()
-        if not wf.is_active():
-            wf.start("Auto-started implementer workflow")
+        from daemon_client import DaemonClient
+        with DaemonClient() as dc:
+            if not dc.workflow_is_active("simple"):
+                dc.workflow_start("simple", initial_state={"task": "Auto-started simple workflow"})
     except Exception as e:
         log_debug(f"Auto-start workflow failed: {e}")
 

--- a/lib/permission_query.py
+++ b/lib/permission_query.py
@@ -11,7 +11,7 @@ from permission_store import PermissionStore
 
 
 # Known workflow IDs to check when no specific ID given
-_KNOWN_WORKFLOWS = ["iterate", "debug", "pr_comment", "implementer"]
+_KNOWN_WORKFLOWS = ["iterate", "debug", "pr_comment", "implementer", "simple"]
 
 
 def get_active_workflow_id() -> Optional[str]:

--- a/tests/test_simple_changes.py
+++ b/tests/test_simple_changes.py
@@ -1,0 +1,104 @@
+"""Non-regression tests for simple-workflow rollout (2026-05-09).
+
+Narrow scope: these tests cover only what isn't already validated by
+`lib/daemon.py:load_workflow_configs` (structural YAML) or by
+integration smoke. They guard against:
+
+1. The additive `simple:` block in permissions.yaml accidentally
+   wiping pre-existing workflow blocks.
+2. The auto-start hook still importing the legacy
+   `implementer_workflow` module after the swap.
+3. The auto-start hook calling the wrong workflow id or initial state.
+"""
+from __future__ import annotations
+
+import sys
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).parent.parent
+PERMISSIONS_YAML = PROJECT_ROOT / "config" / "permissions.yaml"
+SESSION_START_PY = PROJECT_ROOT / "hooks" / "session-start.py"
+
+
+class TestPermissionsAdditive:
+    """Ensures simple: was added without removing pre-existing workflows."""
+
+    def test_simple_block_present(self):
+        with open(PERMISSIONS_YAML) as f:
+            data = yaml.safe_load(f)
+        assert "workflows" in data
+        assert "simple" in data["workflows"], "simple: block missing"
+
+    def test_pre_existing_workflows_preserved(self):
+        with open(PERMISSIONS_YAML) as f:
+            data = yaml.safe_load(f)
+        wfs = data["workflows"]
+        for name in ("iterate", "debug", "pr_review", "develop", "experiment"):
+            assert name in wfs, f"pre-existing workflow {name!r} removed"
+
+    def test_simple_plan_blocks_writes(self):
+        with open(PERMISSIONS_YAML) as f:
+            data = yaml.safe_load(f)
+        blocked = set(data["workflows"]["simple"]["plan"]["blocked"])
+        assert {"native__write_file", "native__edit_file", "native__bash"} <= blocked
+
+
+class TestAutoStartSwap:
+    """Confirms hooks/session-start.py auto-starts simple via DaemonClient."""
+
+    def test_no_implementer_workflow_import(self):
+        src = SESSION_START_PY.read_text()
+        assert "from implementer_workflow import" not in src, (
+            "session-start.py still imports implementer_workflow"
+        )
+        assert "ImplementerWorkflow" not in src, (
+            "session-start.py still references ImplementerWorkflow"
+        )
+
+    def test_auto_start_calls_simple_workflow(self):
+        # Load session-start.py as a module so we can call auto_start_workflow().
+        # The hook prepends lib/ to sys.path at import time, which is what we want.
+        sys.path.insert(0, str(PROJECT_ROOT / "lib"))
+        spec = importlib.util.spec_from_file_location(
+            "session_start_under_test", SESSION_START_PY
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        fake_dc = MagicMock()
+        fake_dc.__enter__ = MagicMock(return_value=fake_dc)
+        fake_dc.__exit__ = MagicMock(return_value=False)
+        fake_dc.workflow_is_active = MagicMock(return_value=False)
+        fake_dc.workflow_start = MagicMock(return_value={})
+
+        with patch.dict("sys.modules", {"daemon_client": MagicMock(DaemonClient=lambda: fake_dc)}):
+            mod.auto_start_workflow()
+
+        fake_dc.workflow_is_active.assert_called_once_with("simple")
+        fake_dc.workflow_start.assert_called_once_with(
+            "simple", initial_state={"task": "Auto-started simple workflow"}
+        )
+
+    def test_auto_start_skips_when_already_active(self):
+        sys.path.insert(0, str(PROJECT_ROOT / "lib"))
+        spec = importlib.util.spec_from_file_location(
+            "session_start_under_test_2", SESSION_START_PY
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        fake_dc = MagicMock()
+        fake_dc.__enter__ = MagicMock(return_value=fake_dc)
+        fake_dc.__exit__ = MagicMock(return_value=False)
+        fake_dc.workflow_is_active = MagicMock(return_value=True)
+        fake_dc.workflow_start = MagicMock(return_value={})
+
+        with patch.dict("sys.modules", {"daemon_client": MagicMock(DaemonClient=lambda: fake_dc)}):
+            mod.auto_start_workflow()
+
+        fake_dc.workflow_is_active.assert_called_once_with("simple")
+        fake_dc.workflow_start.assert_not_called()

--- a/tests/test_simple_changes.py
+++ b/tests/test_simple_changes.py
@@ -72,13 +72,21 @@ class TestAutoStartSwap:
         fake_dc = MagicMock()
         fake_dc.__enter__ = MagicMock(return_value=fake_dc)
         fake_dc.__exit__ = MagicMock(return_value=False)
-        fake_dc.workflow_is_active = MagicMock(return_value=False)
         fake_dc.workflow_start = MagicMock(return_value={})
 
-        with patch.dict("sys.modules", {"daemon_client": MagicMock(DaemonClient=lambda: fake_dc)}):
+        fake_pq = MagicMock()
+        fake_pq.get_active_workflow_id = MagicMock(return_value=None)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "daemon_client": MagicMock(DaemonClient=lambda: fake_dc),
+                "permission_query": fake_pq,
+            },
+        ):
             mod.auto_start_workflow()
 
-        fake_dc.workflow_is_active.assert_called_once_with("simple")
+        fake_pq.get_active_workflow_id.assert_called_once_with()
         fake_dc.workflow_start.assert_called_once_with(
             "simple", initial_state={"task": "Auto-started simple workflow"}
         )
@@ -94,11 +102,20 @@ class TestAutoStartSwap:
         fake_dc = MagicMock()
         fake_dc.__enter__ = MagicMock(return_value=fake_dc)
         fake_dc.__exit__ = MagicMock(return_value=False)
-        fake_dc.workflow_is_active = MagicMock(return_value=True)
         fake_dc.workflow_start = MagicMock(return_value={})
 
-        with patch.dict("sys.modules", {"daemon_client": MagicMock(DaemonClient=lambda: fake_dc)}):
+        fake_pq = MagicMock()
+        fake_pq.get_active_workflow_id = MagicMock(return_value="iterate")
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "daemon_client": MagicMock(DaemonClient=lambda: fake_dc),
+                "permission_query": fake_pq,
+            },
+        ):
             mod.auto_start_workflow()
 
-        fake_dc.workflow_is_active.assert_called_once_with("simple")
+        fake_pq.get_active_workflow_id.assert_called_once_with()
         fake_dc.workflow_start.assert_not_called()
+        fake_dc.__enter__.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a lightweight 4-phase workflow (`plan` -> `work` -> `verify` -> `done`) intended as the auto-start default at session start. The `plan` and `verify` phases are read-only; `work` allows writes; `done` is terminal. `verify` can loop back to `work`.

Replaces the broken `implement` auto-start (which imported a workflow not registered with the daemon) without touching `lib/implementer_workflow.py`, `commands/implement.md`, or any existing `implement:` references.

## Commits

- `9ec0484` -- `config/workflows/simple.yaml`: new file. Phases + transitions; `plan` and `verify` are checkpoints.
- `25ba84f` -- `config/permissions.yaml`: additive `simple:` block under `workflows:`. `plan` blocks writes/edits/bash; `work` permits them; `verify` allows reads + targeted bash (pytest/python/ruff/git); `done` is empty. Pre-existing workflow blocks (`iterate`, `debug`, `pr_review`, `develop`, `experiment`) untouched.
- `099deec` -- `hooks/session-start.py`: `auto_start_workflow` body swapped to open a `DaemonClient` and start `simple` (with `initial_state={\"task\": \"Auto-started simple workflow\"}`) when no workflow is active. Removes the `from implementer_workflow import ImplementerWorkflow` path. Adds `tests/test_simple_changes.py` with 6 narrow non-regression tests covering: simple block additive in permissions, pre-existing workflow blocks preserved, plan phase blocks writes, hook source no longer references `ImplementerWorkflow`, hook starts simple when none active, hook skips start when already active. All 6 green.

## Smoke validation (already run locally)

- `load_workflow_configs()` parses `simple` alongside the other 5 workflows.
- Phase progression `plan -> work -> verify -> work -> verify -> done` (including the verify->work loop) verified end-to-end via `DaemonClient` against a fresh daemon restart.
- `auto_start_workflow()` from a fresh state correctly starts `simple` at phase `plan`.
- `pytest tests/test_simple_changes.py` is 6/6 green in both the dev tree and the mirrored plugin dir.

## Test plan

- [ ] Reviewer can `bin/start-daemon`, then run a fresh `claude` session and confirm `simple` is auto-started with phase `plan` (visible via `dc.workflow_get_state(\"simple\")`).
- [ ] Reviewer can advance through `plan -> work -> verify -> done` (passing checkpoints at `plan` and `verify`) without errors.
- [ ] `pytest tests/test_simple_changes.py` is 6/6 green.