### PR TITLE
docs(claude-md): session-start/task-completion stopgap + 3 local CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Claude Code plugin that enforces phase-gated workflows for AI-assisted developme
 2. `<vault>/10-projects/agent-swarm/open-recommendations.md` — outstanding follow-ups with status flags
 3. `<vault>/10-projects/agent-swarm/experiments/workflow-runs.md` — measured experiment record (append-only dated runs)
 4. `<vault>/10-projects/agent-swarm/experiments/run-context/` — per-run context snapshots
-5. `~/.claude/projects/-Users-cdaly-projects-agent-swarm/memory/MEMORY.md` — auto-memory index
+5. `~/.claude/projects/-Users-cdaly-projects-agent-swarm/memory/MEMORY.md` — auto-memory index *(machine-specific path; encodes this dev tree's cwd)*
 
 ## Memory topics (use these in observation captures)
 
@@ -37,7 +37,7 @@ Trigger: every session, before responding to the first user message.
 
 1. `tail -120 <vault>/10-projects/agent-swarm/narrative.md` — read the latest 1-2 dated entries.
 2. Skim `<vault>/10-projects/agent-swarm/open-recommendations.md` for `[~]` (in progress) and `[ ]` (open) items related to the cwd / area the user is asking about.
-3. Read `~/.claude/projects/-Users-cdaly-projects-agent-swarm/memory/MEMORY.md` — the auto-memory index, not bodies. Pull a body only when the index entry is relevant.
+3. Read `~/.claude/projects/-Users-cdaly-projects-agent-swarm/memory/MEMORY.md` — the auto-memory index, not bodies. Pull a body only when the index entry is relevant. *(Path encodes the cwd of this dev tree — `-Users-cdaly-projects-agent-swarm` for this machine. If you're on a different machine, derive the equivalent: `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md`.)*
 4. Briefly acknowledge what state is being picked up from in the first response (e.g., "picking up from the simple-workflow PR93 merge; bin/ infra follow-ups still open").
 
 ## Task completion protocol
@@ -49,7 +49,7 @@ Trigger: when the user signals stopping ("this is done", "good for now", "wrappi
 1. Append a dated narrative entry to `<vault>/10-projects/agent-swarm/narrative.md` summarizing what shipped — commits, PRs, decisions, validation steps.
 2. Update `<vault>/10-projects/agent-swarm/open-recommendations.md`: mark resolved items with `[x] *Done <date>*`; append new follow-ups discovered.
 3. Save feedback / project memories per the auto-memory rules already in the system prompt (don't duplicate vault entries — memories are for *cross-conversation* signals like preferences and decisions; vault entries are project narrative).
-4. **Sync the vault.** `cd <vault> && git add 10-projects/agent-swarm/{narrative,open-recommendations}.md && git commit && git push`. Don't skip — the vault is the durable record across sessions and machines.
+4. **Sync the vault.** `cd <vault> && git add 10-projects/agent-swarm/{narrative,open-recommendations}.md && git commit -m "agent-swarm: <one-line summary of what shipped>" && git push`. Always provide `-m` (Claude's shell is non-interactive — no `-m` will hang at the editor). Don't skip the sync — the vault is the durable record across sessions and machines.
 
 ## Local CLAUDE.md files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Claude Code plugin that enforces phase-gated workflows for AI-assisted developme
 2. `<vault>/10-projects/agent-swarm/open-recommendations.md` — outstanding follow-ups with status flags
 3. `<vault>/10-projects/agent-swarm/experiments/workflow-runs.md` — measured experiment record (append-only dated runs)
 4. `<vault>/10-projects/agent-swarm/experiments/run-context/` — per-run context snapshots
-5. `~/.claude/projects/-home-fearsidhe--claude-plugins-agent-swarm/memory/MEMORY.md` — auto-memory index
+5. `~/.claude/projects/-Users-cdaly-projects-agent-swarm/memory/MEMORY.md` — auto-memory index
 
 ## Memory topics (use these in observation captures)
 
@@ -28,3 +28,33 @@ Claude Code plugin that enforces phase-gated workflows for AI-assisted developme
 - **Orchestrate brief polling discipline**: orchestrator polls PR review threads once immediately after PR creation, exits before bot reviewers comment. Tracked as a recommendation; the resolveReviewThread mechanism itself is verified working when threads exist at poll time.
 - **Daemon** at port 7523. In-memory state lost on restart. Restart after code changes (no hot-reload).
 - **Subagent dispatch** via Task tool with iterate workflow; each subagent gets its own worktree at `~/projects/iterate-test-wt/<branch>/`. Worktree isolation works correctly — verified.
+
+## Session start protocol
+
+> *Stopgap until continuity's resume-brief is installed and provides this automatically — see `hooks/session-start.py:discover_resume_brief`. Remove this section when that path returns non-empty.*
+
+Trigger: every session, before responding to the first user message.
+
+1. `tail -120 <vault>/10-projects/agent-swarm/narrative.md` — read the latest 1-2 dated entries.
+2. Skim `<vault>/10-projects/agent-swarm/open-recommendations.md` for `[~]` (in progress) and `[ ]` (open) items related to the cwd / area the user is asking about.
+3. Read `~/.claude/projects/-Users-cdaly-projects-agent-swarm/memory/MEMORY.md` — the auto-memory index, not bodies. Pull a body only when the index entry is relevant.
+4. Briefly acknowledge what state is being picked up from in the first response (e.g., "picking up from the simple-workflow PR93 merge; bin/ infra follow-ups still open").
+
+## Task completion protocol
+
+> *Stopgap until continuity provides a write-on-end mechanism. Pare back when continuity covers narrative + open-rec updates automatically; keep only what continuity does not.*
+
+Trigger: when the user signals stopping ("this is done", "good for now", "wrapping up") or before a clean session end.
+
+1. Append a dated narrative entry to `<vault>/10-projects/agent-swarm/narrative.md` summarizing what shipped — commits, PRs, decisions, validation steps.
+2. Update `<vault>/10-projects/agent-swarm/open-recommendations.md`: mark resolved items with `[x] *Done <date>*`; append new follow-ups discovered.
+3. Save feedback / project memories per the auto-memory rules already in the system prompt (don't duplicate vault entries — memories are for *cross-conversation* signals like preferences and decisions; vault entries are project narrative).
+4. **Sync the vault.** `cd <vault> && git add 10-projects/agent-swarm/{narrative,open-recommendations}.md && git commit && git push`. Don't skip — the vault is the durable record across sessions and machines.
+
+## Local CLAUDE.md files
+
+These live in subdirectories and load when cwd is at or below them. Each one captures area-specific context that's non-obvious from reading the code.
+
+- `bin/CLAUDE.md` — dev/cache discipline, known infra bugs in shell scripts.
+- `config/workflows/CLAUDE.md` — what `load_workflow_configs` actually consumes vs what's aspirational; the `_KNOWN_WORKFLOWS` gotcha when adding a new workflow.
+- `lib/CLAUDE.md` — daemon/router/controller/permissions orientation; pointer to `protocol_assembly.py` as the seam for future briefing changes.

--- a/bin/CLAUDE.md
+++ b/bin/CLAUDE.md
@@ -1,0 +1,22 @@
+# `bin/` — shell scripts for daemon and cache management
+
+## Dev/cache discipline (load-bearing)
+
+- **Dev path:** `~/.claude/plugins/agent-swarm/` is what `bin/sync-to-cache` treats as the canonical source. Edits live there.
+- **Cache path:** `~/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0/` is build output. Never edit cache directly. Sync goes dev → cache only; never bidirectional.
+- **In practice on this machine:** there's also a separate dev tree at `~/projects/agent-swarm/` (this repo's working clone). When working from the dev tree, mirror changes to `~/.claude/plugins/agent-swarm/` first, then run `bin/sync-to-cache` from there. (Origin of the divergence: project was originally developed on a different machine; the dev-tree convention is the user's, not what `sync-to-cache` was written to assume.)
+- If cache and `~/.claude/plugins/agent-swarm/` diverge, that's a bug (someone edited cache directly). Treat as a one-time backport (cache → dev), commit, then re-establish dev as canonical.
+
+## Known infra bugs (tracked in `<vault>/10-projects/agent-swarm/open-recommendations.md` under "Pre-existing `bin/` infra bugs")
+
+- **`sync-to-cache` uses GNU-only `realpath -m`.** BSD realpath on macOS doesn't support `-m` and the script fails on first invocation with `realpath: illegal option -- m`. Workaround: replicate `sync_selective` logic manually (`mkdir -p` + `cp -p` per file). Fix: portable shim — try `grealpath`/`realpath -m`, fall back to a Python `realpath` call.
+- **`start-daemon --restart` is a no-op flag.** `bin/sync-to-cache` invokes `start-daemon --restart` after syncing config-touching paths, but the script just runs the port-probe early-exit and prints `Daemon is already running`. Workaround: kill the daemon manually (`kill $(lsof -tiTCP:7523 -sTCP:LISTEN)`) then run `bin/start-daemon`. Fix: implement `--restart` properly or remove the flag from `sync-to-cache`.
+- **`start-daemon` uses `sys.executable`.** When invoked outside the poetry venv (e.g. from a plain shell), `sys.executable` resolves to homebrew Python 3.14 which lacks PyYAML, and the daemon crashes at `import yaml`. Workaround: spawn from the poetry venv interpreter explicitly. Fix: resolve the poetry venv interpreter at startup (e.g. via `poetry env info -e`) instead of `sys.executable`.
+
+## Quick reference
+
+- `bin/start-daemon` — spawn the daemon if not running. Idempotent (port-probe early-exit). Background detach.
+- `bin/mcp-router` — shim Claude Code talks to. Connects to daemon over TCP. Returns "daemon not running" error if it can't connect.
+- `bin/sync-to-cache` — dev → cache copy with optional selective-files mode (`bin/sync-to-cache <file> [<file>...]`).
+- `bin/mcp-call` — CLI for subagents to call router tools. Always pass `--caller-id=<agent-id>`.
+- `bin/audit-tests`, `bin/todo` — utility scripts.

--- a/config/workflows/CLAUDE.md
+++ b/config/workflows/CLAUDE.md
@@ -25,7 +25,7 @@ When you add a new YAML here, you MUST also:
 2. Add a peer block under `workflows:` in `config/permissions.yaml` defining per-phase `allowed`/`blocked` tool lists.
 3. Restart the daemon (`bin/start-daemon` is idempotent — kill + restart). The daemon loads workflow configs once at startup; no hot-reload.
 
-PR #93 fix `75be6c2` closed the `_KNOWN_WORKFLOWS` gap for `simple`. **The same gap still applies to `develop`, `experiment`, `orchestrate`, `pr_review`** — tracked in `<vault>/10-projects/agent-swarm/open-recommendations.md`. Better long-term fix: derive `_KNOWN_WORKFLOWS` dynamically from the daemon's loaded configs.
+PR #93 fix `75be6c2` closed the `_KNOWN_WORKFLOWS` gap for `simple`. **The same gap still applies to `develop`, `experiment`, `orchestrate`** — tracked in `<vault>/10-projects/agent-swarm/open-recommendations.md`. Better long-term fix: derive `_KNOWN_WORKFLOWS` dynamically from the daemon's loaded configs.
 
 ## Existing workflows (for reference)
 

--- a/config/workflows/CLAUDE.md
+++ b/config/workflows/CLAUDE.md
@@ -1,0 +1,37 @@
+# `config/workflows/` — workflow definition YAMLs
+
+## What the daemon actually consumes
+
+`lib/daemon.py:load_workflow_configs` reads from each `<name>.yaml`:
+
+- `name` (top-level)
+- `description` (top-level — informational, not enforced)
+- `initial_phase`, `terminal_phase`
+- `phases[*].name` and `phases[*].checkpoint`
+- `transitions` (mapping `src_phase -> [target_phases]`)
+
+**Everything else in the YAML is ignored at the daemon layer.**
+
+## Aspirational fields and what (if anything) reads them
+
+- `max_iterations`, `max_agents`, `max_review_retries`, `max_agent_respawns` — only consumed by per-workflow Python *engines* (`lib/develop_workflow.py`, `lib/pr_comment_workflow.py`). For workflows without a Python engine (e.g. `simple`), these are **dead** — silently ignored. Don't add them unless you're also writing the engine, or expect them to take effect.
+- `phases[*].allowed_tool_categories`, `phases[*].blocked_tools`, `phases[*].eligible_agents` — informational at the YAML layer. Per-tool permissions are enforced via `config/permissions.yaml`, not from these fields. Best practice: keep them mirrored to the permissions block (defense-in-depth) but don't rely on the YAML alone for enforcement.
+
+## Critical gotcha: adding a new workflow
+
+When you add a new YAML here, you MUST also:
+
+1. Add the workflow ID to `lib/permission_query.py:_KNOWN_WORKFLOWS`. Without that, `get_active_workflow_id()` returns `None` for it, `get_permissions()` returns `None`, and `is_tool_allowed()` returns `(True, "")` — **fail-open**. Every restriction in `config/permissions.yaml` is bypassed.
+2. Add a peer block under `workflows:` in `config/permissions.yaml` defining per-phase `allowed`/`blocked` tool lists.
+3. Restart the daemon (`bin/start-daemon` is idempotent — kill + restart). The daemon loads workflow configs once at startup; no hot-reload.
+
+PR #93 fix `75be6c2` closed the `_KNOWN_WORKFLOWS` gap for `simple`. **The same gap still applies to `develop`, `experiment`, `orchestrate`, `pr_review`** — tracked in `<vault>/10-projects/agent-swarm/open-recommendations.md`. Better long-term fix: derive `_KNOWN_WORKFLOWS` dynamically from the daemon's loaded configs.
+
+## Existing workflows (for reference)
+
+- `simple.yaml` — 4-phase lightweight default (auto-start at session start). `plan` → `work` → `verify` → `done`. Plan and verify are checkpoints; verify can loop back to work.
+- `iterate.yaml` — TDD-style. `test_writing` → `implement` → `test` → `review`.
+- `develop.yaml` — full PR-based SE team simulation. `intake` → `research` → `design` → `branch` → `test_writing` → `implement` → `test` → `review` → `merge` → `acceptance` → `complete`.
+- `pr_comment.yaml` — PR review comment workflow. `understand` → `fix` → `verify` → `push` → `check_reviews` → `done`.
+- `orchestrate.yaml` — orchestrator workflow.
+- `experiment.yaml` — experiment workflow with eval gates.

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -1,0 +1,27 @@
+# `lib/` — Python library modules
+
+## Architecture orientation
+
+The daemon is a long-lived process (port 7523) that owns all of agent-swarm's state. Layers, top-down:
+
+- **`lib/daemon.py`** — entry point. Singleton (flock at `.daemon.lock`). Loads workflow configs from `config/workflows/*.yaml` once at startup; **no hot-reload** — restart after config changes. In-memory state is lost on restart.
+- **`lib/router.py`** — TCP server. Accepts both MCP-protocol and internal JSON-RPC connections; translates and delegates to controller.
+- **`lib/controller.py`** — RPC handler. Owns permissions + workflow + agent state. Notable entry points:
+  - `_prepare_dispatch` (line ~582) — generates a `sub-XXXXXXXX` agent ID, registers in permissions, assembles a role-specific briefing, records agent state. Called by the agent-dispatch hook before subagent `Task()` proceeds.
+  - `_get_agent_briefing` — main-agent briefing (subagents get theirs via dispatch hook `additionalContext`).
+  - `handle_call(tool_name, args)` — routes named tools (e.g. `prepare_dispatch`, `agent/register`).
+- **`lib/permissions.py`** + **`lib/permission_query.py`** — yaml-driven layered allow/block (`global` → `roles` → `agents` → `workflow/phase`). `permission_query._KNOWN_WORKFLOWS` is a hardcoded list — see `config/workflows/CLAUDE.md` for the security gotcha when adding a new workflow.
+- **Per-workflow engines** — `lib/implementer_workflow.py`, `lib/develop_workflow.py`, `lib/pr_comment_workflow.py`, etc. These are the only places where YAML fields like `max_iterations` and `max_agents` are read; workflows without a corresponding engine module silently ignore those fields.
+
+## Briefing assembly
+
+`lib/protocol_assembly.py` assembles role/workflow briefings used by `_prepare_dispatch`. If we ever auto-inject project state (vault narrative head, open-recs slice) into subagent briefings, this is the seam — likely a new helper that reads canonical state files and concatenates the result into `assemble_subagent_briefing`'s output.
+
+## DaemonClient (the in-process router)
+
+`lib/daemon_client.py` is the Python client used by hooks, tests, and the orchestrator main agent. Key methods:
+
+- `register(agent_id, agent_type, session_id, workflow_id)` — registers a connection's identity. One register per connection (raises if called twice).
+- `call_tool(name, arguments)` — generic `tools/call`. Most agent work goes through here. Requires registration (the `_call` whitelist allows `agent/*` and `workflow/*` without registration).
+- `workflow_start`, `workflow_stop`, `workflow_get_state`, `workflow_set_value`, `workflow_is_active`, `workflow_advance_phase`, `workflow_pass_checkpoint` — workflow-state RPCs (no registration required).
+- `_call("agent/get_state", {agent_id})` — raw RPC; used by the registration-enforcement hook to verify a fabricated ID was actually issued.


### PR DESCRIPTION
## Summary

Short-term continuity-style discipline via prose in CLAUDE.md files, while the continuity plugin is still being developed.

Continuity is supposed to handle (a) reading project state at session start, (b) writing project state on session end, (c) cross-agent handoff, (d) "pointers, not data". On this machine continuity isn't installed, so `hooks/session-start.py:discover_resume_brief()` returns `""` and zero project state is injected. This PR fills that gap with prose discipline that's explicitly **stopgap** — both new sections in the top-level CLAUDE.md are headed with notes saying when to remove or pare back.

Trigger for the read-on-start protocol: every session, always. Cross-agent handoff is **deferred** — main agents only.

## Changes

**Top-level `CLAUDE.md`**
- Fix stale `home/fearsidhe` path in canonical state file #5 (memory index).
- Add `## Session start protocol` (read narrative tail / open-recs / MEMORY.md). Stopgap-headered with pointer at `hooks/session-start.py:discover_resume_brief`.
- Add `## Task completion protocol` (append narrative entry, update open-recs, save memories, sync vault). Stopgap-headered.
- Add `## Local CLAUDE.md files` index.

**New local CLAUDE.md files** (load when cwd is at or below them — Claude Code hierarchical context)
- `bin/CLAUDE.md` — dev/cache discipline + 3 known infra bugs (sync-to-cache `realpath -m`, start-daemon `--restart` no-op, start-daemon `sys.executable` -> Python without yaml).
- `config/workflows/CLAUDE.md` — what `load_workflow_configs` actually consumes vs aspirational fields; the `_KNOWN_WORKFLOWS` security gotcha (PR #93 closed it for `simple`; still open for `develop` / `experiment` / `orchestrate` / `pr_review`).
- `lib/CLAUDE.md` — daemon/router/controller/permissions orientation; `protocol_assembly.py` as the seam if/when we want to auto-inject project state into subagent briefings.

## Out of scope (per plan)

- Subagent handoff (deferred — main agents only).
- Touching `lib/controller.py:_prepare_dispatch`.
- Installing or modifying continuity.
- Local CLAUDE.md files in `hooks/`, `tests/`, `skills/` (not yet motivated by hit-us cases).

## Reconciliation when continuity ships

The plan file (`~/.claude/plans/i-want-to-talk-frolicking-peach.md`) has a "Reconciliation when continuity ships" section. Short version: re-read both stopgap sections and remove what continuity now provides automatically; keep the local CLAUDE.md files (they're area-specific context, not session lifecycle).

## Test plan

- [ ] In a fresh `claude` session from `~/projects/agent-swarm/`, ask "what's the state?" — confirm Claude reads `narrative.md` tail and acknowledges the most recent entry.
- [ ] Make a trivial change, say "let's wrap up" — confirm Claude appends a narrative entry, updates relevant open-recs, syncs the vault.
- [ ] `cd ~/projects/agent-swarm/bin/`, ask "why doesn't sync-to-cache work cleanly?" — confirm `bin/CLAUDE.md` is loaded.
- [ ] Same drill for `config/workflows/` and `lib/`.
