### PR TITLE
fix(bin,permissions): bin/ infra bugs + _KNOWN_WORKFLOWS gap

### DIFF
--- a/bin/start-daemon
+++ b/bin/start-daemon
@@ -9,6 +9,7 @@ import os
 import socket
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -47,21 +48,55 @@ def resolve_interpreter() -> str:
     return sys.executable
 
 
-def main() -> None:
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
+def kill_running_daemon(port: int, timeout: float = 5.0) -> bool:
+    """Kill any running daemon (identified by listening on port).
 
-    port = int(os.environ.get("DAEMON_PORT", "7523"))
-
-    # Check if already running via TCP probe (avoid importing daemon module)
+    Returns True if a daemon was killed, False if nothing was running.
+    Tries SIGTERM first; falls back to SIGKILL after `timeout` seconds.
+    """
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(1.0)
         s.connect(("127.0.0.1", port))
         s.close()
-        print("Daemon is already running")
-        return
     except (ConnectionRefusedError, OSError):
-        pass
+        return False  # nothing running
+    subprocess.run(["pkill", "-TERM", "-f", str(DAEMON_SCRIPT)], check=False)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(0.5)
+            s.connect(("127.0.0.1", port))
+            s.close()
+            time.sleep(0.2)
+        except (ConnectionRefusedError, OSError):
+            return True
+    subprocess.run(["pkill", "-KILL", "-f", str(DAEMON_SCRIPT)], check=False)
+    time.sleep(0.5)
+    return True
+
+
+def main() -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    port = int(os.environ.get("DAEMON_PORT", "7523"))
+    restart = "--restart" in sys.argv
+
+    if restart:
+        if kill_running_daemon(port):
+            print("Killed running daemon")
+    else:
+        # Check if already running via TCP probe (avoid importing daemon module)
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(1.0)
+            s.connect(("127.0.0.1", port))
+            s.close()
+            print("Daemon is already running")
+            return
+        except (ConnectionRefusedError, OSError):
+            pass
 
     # Start daemon as a detached background process
     log_out = LOG_DIR / "daemon-stdout.log"

--- a/bin/start-daemon
+++ b/bin/start-daemon
@@ -16,6 +16,37 @@ DAEMON_SCRIPT = ROOT / "lib" / "daemon.py"
 LOG_DIR = ROOT / "logs"
 
 
+def resolve_interpreter() -> str:
+    """Resolve a Python interpreter that has project deps installed.
+
+    Order:
+      1. ROOT/.venv/bin/python (poetry default venv-in-project)
+      2. `poetry env info --executable` (out-of-tree venvs)
+      3. sys.executable (final fallback)
+
+    sys.executable can be a bare system Python without PyYAML etc.,
+    which makes the daemon fail to start. Prefer the project venv.
+    """
+    venv_python = ROOT / ".venv" / "bin" / "python"
+    if venv_python.is_file():
+        return str(venv_python)
+    try:
+        result = subprocess.run(
+            ["poetry", "env", "info", "--executable"],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            path = result.stdout.strip()
+            if path and Path(path).is_file():
+                return path
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return sys.executable
+
+
 def main() -> None:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -38,7 +69,7 @@ def main() -> None:
 
     with open(log_out, "a") as out, open(log_err, "a") as err:
         subprocess.Popen(
-            [sys.executable, str(DAEMON_SCRIPT)],
+            [resolve_interpreter(), str(DAEMON_SCRIPT)],
             stdout=out,
             stderr=err,
             start_new_session=True,

--- a/bin/start-daemon
+++ b/bin/start-daemon
@@ -6,6 +6,7 @@ or manually by the user. Starts lib/daemon.py as a detached process.
 """
 
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -48,32 +49,80 @@ def resolve_interpreter() -> str:
     return sys.executable
 
 
+def _port_in_use(port: int, connect_timeout: float = 1.0) -> bool:
+    """Return True if something is listening on 127.0.0.1:port."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(connect_timeout)
+            s.connect(("127.0.0.1", port))
+        return True
+    except (ConnectionRefusedError, OSError):
+        return False
+
+
+def _wait_for_port_free(port: int, timeout: float, poll_interval: float = 0.2) -> bool:
+    """Poll until the port is free or `timeout` seconds elapse.
+
+    Returns True if the port became free, False if the timeout elapsed.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _port_in_use(port, connect_timeout=0.5):
+            return True
+        time.sleep(poll_interval)
+    return False
+
+
+def _pkill(signal: str, pattern: str) -> bool:
+    """Send `signal` to processes matching `pattern` via pkill.
+
+    Returns True if pkill ran (regardless of whether anything matched),
+    False if pkill itself is not available on this system.
+    """
+    try:
+        subprocess.run(["pkill", signal, "-f", pattern], check=False)
+        return True
+    except FileNotFoundError:
+        return False
+
+
 def kill_running_daemon(port: int, timeout: float = 5.0) -> bool:
     """Kill any running daemon (identified by listening on port).
 
     Returns True if a daemon was killed, False if nothing was running.
-    Tries SIGTERM first; falls back to SIGKILL after `timeout` seconds.
+    Tries SIGTERM first; escalates to SIGKILL after `timeout` seconds,
+    then verifies the port is released so the caller's respawn doesn't
+    race the OS tearing down the socket.
     """
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(1.0)
-        s.connect(("127.0.0.1", port))
-        s.close()
-    except (ConnectionRefusedError, OSError):
+    if not _port_in_use(port):
         return False  # nothing running
-    subprocess.run(["pkill", "-TERM", "-f", str(DAEMON_SCRIPT)], check=False)
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(0.5)
-            s.connect(("127.0.0.1", port))
-            s.close()
-            time.sleep(0.2)
-        except (ConnectionRefusedError, OSError):
-            return True
-    subprocess.run(["pkill", "-KILL", "-f", str(DAEMON_SCRIPT)], check=False)
-    time.sleep(0.5)
+
+    # pkill -f treats its pattern as an extended regex; the daemon path
+    # may contain metacharacters (+, [, etc.), so escape before passing.
+    pattern = re.escape(str(DAEMON_SCRIPT))
+
+    if not _pkill("-TERM", pattern):
+        print(
+            f"ERROR: pkill not found on PATH; cannot signal daemon on port {port}",
+            file=sys.stderr,
+        )
+        return False
+
+    if _wait_for_port_free(port, timeout):
+        return True
+
+    # SIGTERM didn't free the port within the timeout; escalate.
+    _pkill("-KILL", pattern)
+
+    # Verify the port has actually been released. Without this, the caller's
+    # immediate respawn can race kernel socket teardown and fail to bind
+    # silently (the error goes to the log file, not the user).
+    if not _wait_for_port_free(port, 2.0):
+        print(
+            f"WARNING: port {port} still in use after SIGKILL; "
+            f"replacement daemon may fail to bind.",
+            file=sys.stderr,
+        )
     return True
 
 
@@ -88,15 +137,9 @@ def main() -> None:
             print("Killed running daemon")
     else:
         # Check if already running via TCP probe (avoid importing daemon module)
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(1.0)
-            s.connect(("127.0.0.1", port))
-            s.close()
+        if _port_in_use(port):
             print("Daemon is already running")
             return
-        except (ConnectionRefusedError, OSError):
-            pass
 
     # Start daemon as a detached background process
     log_out = LOG_DIR / "daemon-stdout.log"

--- a/bin/sync-to-cache
+++ b/bin/sync-to-cache
@@ -35,6 +35,21 @@ CACHE_DIR="$HOME/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0"
 
 die() { echo "ERROR: $1" >&2; exit 1; }
 
+canonicalize_path() {
+    # Portable equivalent of GNU `realpath -m`. Tries Linux GNU first,
+    # then macOS+coreutils `grealpath`, finally a Python fallback that
+    # tolerates non-existent leaves the same way `-m` does.
+    local p="$1"
+    if realpath -m "$p" 2>/dev/null; then
+        return 0
+    fi
+    if command -v grealpath >/dev/null 2>&1; then
+        grealpath -m "$p"
+        return 0
+    fi
+    python3 -c 'import os,sys; print(os.path.realpath(os.path.abspath(sys.argv[1])))' "$p"
+}
+
 undo_symlink() {
     if [ -L "$CACHE_DIR" ]; then
         echo "Cache is a symlink — removing..."
@@ -95,9 +110,9 @@ sync_selective() {
         if [ ! -e "$file" ]; then
             die "File not found: $file"
         fi
-        # Canonicalize: -m tolerates non-existent leaves (we already checked above; -m
-        # just keeps us from failing on edge cases like trailing slashes).
-        abs="$(realpath -m "$file")"
+        # Canonicalize via the portable shim (`realpath -m` is Linux-GNU-only;
+        # the shim handles macOS BSD realpath and a Python last-resort fallback).
+        abs="$(canonicalize_path "$file")"
         if [ ! -f "$abs" ]; then
             die "Not a regular file: $file ($abs)"
         fi

--- a/lib/permission_query.py
+++ b/lib/permission_query.py
@@ -11,7 +11,7 @@ from permission_store import PermissionStore
 
 
 # Known workflow IDs to check when no specific ID given
-_KNOWN_WORKFLOWS = ["iterate", "debug", "pr_comment", "implementer", "simple"]
+_KNOWN_WORKFLOWS = ["iterate", "debug", "pr_comment", "implementer", "simple", "develop", "experiment", "orchestrate"]
 
 
 def get_active_workflow_id() -> Optional[str]:


### PR DESCRIPTION
## Summary

Four small fixes that PR #94 documented in `bin/CLAUDE.md` and `config/workflows/CLAUDE.md` but didn't actually apply:

1. **`bin/sync-to-cache`** — portable `canonicalize_path()` shim (was Linux-GNU-only with `realpath -m`)
2. **`bin/start-daemon`** — `resolve_interpreter()` that prefers the project venv over `sys.executable`
3. **`bin/start-daemon`** — actually honor `--restart` (was a silent no-op)
4. **`lib/permission_query.py`** — add `develop`, `experiment`, `orchestrate` to `_KNOWN_WORKFLOWS`

## Background

Three of the four come straight from `vault/10-projects/agent-swarm/handoffs/2026-05-09-bin-fixes.md` (plan written on 2026-05-09 but never executed before the desktop spill interrupted the session). The plan's bin-fix specifics survive verbatim in the handoff.

The fourth (`_KNOWN_WORKFLOWS`) was the security gotcha PR #94's `config/workflows/CLAUDE.md` flagged. PR #94 already documented `simple` had been added in PR #93; this catches up the remaining three workflow IDs that exist as YAML configs but aren't enrolled.

## Details

### `bin/sync-to-cache` realpath portability

`realpath -m` is GNU-only. macOS BSD `realpath` doesn't support `-m`. Helper added near the other helpers (after `die()`):

```bash
canonicalize_path() {
    # Tries Linux GNU first, then macOS coreutils `grealpath`, then Python fallback.
    ...
}
```

Call site at the start of `sync_selective()` now uses `canonicalize_path` instead of inline `realpath -m`. Surrounding comment updated to reflect the shim.

### `bin/start-daemon` interpreter resolution

`sys.executable` can be a bare system Python without PyYAML — daemon imports fail. New `resolve_interpreter()` prefers `ROOT/.venv/bin/python`, falls back to `poetry env info --executable`, then `sys.executable`.

### `bin/start-daemon` `--restart`

`bin/sync-to-cache` already calls `start-daemon --restart`. Previously the script ignored the flag and exited early on the "already running" port probe. Now: `--restart` triggers a TERM-then-KILL kill via `pkill -f lib/daemon.py`, then proceeds to spawn a fresh daemon.

**Caveat:** invoking `--restart` kills the daemon and loses any in-flight workflow state. Don't run it casually.

### `_KNOWN_WORKFLOWS`

Per gemini/greptile feedback on PR #94: the real gaps are `develop`, `experiment`, `orchestrate`. `pr_comment` was already in the list (and `pr_review` isn't a real workflow id). Single-line change.

## Test plan

- [ ] `bin/sync-to-cache config/workflows/simple.yaml` works on macOS with cwd outside SOURCE_DIR (relative-path canonicalization)
- [ ] `bin/start-daemon` from a directory whose system Python lacks PyYAML still launches the daemon
- [ ] `bin/start-daemon --restart` actually replaces the running daemon (PID changes)
- [ ] After merge, `_KNOWN_WORKFLOWS`-driven permission checks no longer fail open for develop/experiment/orchestrate
