### PR TITLE
fix: unblock workflow bootstrap at session start

### DIFF
--- a/hooks/session-start.py
+++ b/hooks/session-start.py
@@ -15,6 +15,7 @@ import json
 import socket
 import sys
 import time
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 import os
@@ -174,12 +175,14 @@ _DAEMON_CONNECT_ATTEMPTS = 5
 _DAEMON_CONNECT_DELAY = 0.2
 
 
+@contextmanager
 def _open_daemon_client_with_retry(label: str):
-    """Open a DaemonClient, retrying briefly on cold-daemon ConnectionRefused.
+    """Yield a connected DaemonClient, or None when retries are exhausted.
 
-    Returns the opened client (already in `__enter__`'d state, caller is
-    responsible for closing) on success, or None when retries are exhausted.
-    Logs at WARNING (not DEBUG) on exhaustion so the failure is visible.
+    Retries `connect()` briefly on cold-daemon `ConnectionRefusedError` /
+    `OSError`. Always logs at WARNING (not DEBUG) on exhaustion so the
+    failure is visible. Closes the client on exit, including when the body
+    raised — surfaces close errors at WARNING (don't mask the original).
 
     Imports `DaemonClient` lazily so tests can inject mocks via
     `sys.modules["daemon_client"]`.
@@ -187,23 +190,33 @@ def _open_daemon_client_with_retry(label: str):
     try:
         from daemon_client import DaemonClient as _DC
     except ImportError:
-        return None
+        yield None
+        return
 
     last_exc: Exception | None = None
     for attempt in range(_DAEMON_CONNECT_ATTEMPTS):
         try:
             dc = _DC()
-            dc.__enter__()
-            return dc
+            dc.connect()
         except (ConnectionRefusedError, ConnectionError, OSError) as e:
             last_exc = e
             if attempt < _DAEMON_CONNECT_ATTEMPTS - 1:
                 time.sleep(_DAEMON_CONNECT_DELAY)
+            continue
+        try:
+            yield dc
+        finally:
+            try:
+                dc.close()
+            except Exception as close_exc:
+                log_warning(f"{label}: error closing daemon client: {close_exc}")
+        return
+
     log_warning(
         f"{label}: daemon unreachable after "
         f"{_DAEMON_CONNECT_ATTEMPTS} attempts: {last_exc}"
     )
-    return None
+    yield None
 
 
 def auto_start_workflow():
@@ -213,17 +226,14 @@ def auto_start_workflow():
         try:
             if get_active_workflow_id() is not None:
                 return
-        except Exception:
+        except Exception as e:
             # Likely a cold-daemon race on the query path; the retry below
             # will surface a clear warning if the daemon is genuinely down.
-            pass
-        dc = _open_daemon_client_with_retry("auto_start_workflow")
-        if dc is None:
-            return
-        try:
+            log_debug(f"auto_start_workflow: get_active_workflow_id check failed: {e}")
+        with _open_daemon_client_with_retry("auto_start_workflow") as dc:
+            if dc is None:
+                return
             dc.workflow_start("simple", initial_state={"task": "Auto-started simple workflow"})
-        finally:
-            dc.__exit__(None, None, None)
     except Exception as e:
         log_warning(f"auto_start_workflow failed: {e}")
 
@@ -246,11 +256,10 @@ def register_main_agent():
         log_debug("register_main_agent: DaemonClient unavailable; skipping")
         return
 
-    dc = _open_daemon_client_with_retry("register_main_agent")
-    if dc is None:
-        return
+    with _open_daemon_client_with_retry("register_main_agent") as dc:
+        if dc is None:
+            return
 
-    try:
         try:
             dc.call_tool("router__register_agent", {
                 "agent_id": "",
@@ -281,11 +290,6 @@ def register_main_agent():
                 f"register_main_agent: agent registered but phase binding failed "
                 f"(agent will fall back to global-only until next session): {e}"
             )
-    finally:
-        try:
-            dc.__exit__(None, None, None)
-        except Exception:
-            pass
 
 
 def cleanup_stale_outputs() -> str | None:

--- a/hooks/session-start.py
+++ b/hooks/session-start.py
@@ -166,17 +166,66 @@ def reset_enforcement_counters(agent_id: str | None = None):
         log_warning(f"Failed to reset enforcement counters: {e}")
 
 
+# Brief retry to absorb the cold-daemon race at session start: the daemon
+# is launched alongside the hook, and the socket may not be ready on the
+# first attempt. Five 200 ms tries (~1 s) is enough in practice without
+# slowing happy-path session starts (first attempt succeeds).
+_DAEMON_CONNECT_ATTEMPTS = 5
+_DAEMON_CONNECT_DELAY = 0.2
+
+
+def _open_daemon_client_with_retry(label: str):
+    """Open a DaemonClient, retrying briefly on cold-daemon ConnectionRefused.
+
+    Returns the opened client (already in `__enter__`'d state, caller is
+    responsible for closing) on success, or None when retries are exhausted.
+    Logs at WARNING (not DEBUG) on exhaustion so the failure is visible.
+
+    Imports `DaemonClient` lazily so tests can inject mocks via
+    `sys.modules["daemon_client"]`.
+    """
+    try:
+        from daemon_client import DaemonClient as _DC
+    except ImportError:
+        return None
+
+    last_exc: Exception | None = None
+    for attempt in range(_DAEMON_CONNECT_ATTEMPTS):
+        try:
+            dc = _DC()
+            dc.__enter__()
+            return dc
+        except (ConnectionRefusedError, ConnectionError, OSError) as e:
+            last_exc = e
+            if attempt < _DAEMON_CONNECT_ATTEMPTS - 1:
+                time.sleep(_DAEMON_CONNECT_DELAY)
+    log_warning(
+        f"{label}: daemon unreachable after "
+        f"{_DAEMON_CONNECT_ATTEMPTS} attempts: {last_exc}"
+    )
+    return None
+
+
 def auto_start_workflow():
     """Auto-start simple workflow if no workflow is currently active."""
     try:
-        from daemon_client import DaemonClient
         from permission_query import get_active_workflow_id
-        if get_active_workflow_id() is not None:
+        try:
+            if get_active_workflow_id() is not None:
+                return
+        except Exception:
+            # Likely a cold-daemon race on the query path; the retry below
+            # will surface a clear warning if the daemon is genuinely down.
+            pass
+        dc = _open_daemon_client_with_retry("auto_start_workflow")
+        if dc is None:
             return
-        with DaemonClient() as dc:
+        try:
             dc.workflow_start("simple", initial_state={"task": "Auto-started simple workflow"})
+        finally:
+            dc.__exit__(None, None, None)
     except Exception as e:
-        log_debug(f"Auto-start workflow failed: {e}")
+        log_warning(f"auto_start_workflow failed: {e}")
 
 
 def register_main_agent():
@@ -197,40 +246,46 @@ def register_main_agent():
         log_debug("register_main_agent: DaemonClient unavailable; skipping")
         return
 
-    try:
-        with DaemonClient() as dc:
-            try:
-                dc.call_tool("router__register_agent", {
-                    "agent_id": "",
-                    "agent_type": "implementer",
-                    "roles": ["editor", "shell_full"],
-                })
-            except Exception as e:
-                log_warning(f"register_main_agent: register step failed: {e}")
-                return
+    dc = _open_daemon_client_with_retry("register_main_agent")
+    if dc is None:
+        return
 
-            try:
-                active_wf = get_active_workflow_id()
-                if not active_wf:
-                    log_debug("register_main_agent: no active workflow; agent registered but not phase-bound")
-                    return
-                state = dc.workflow_get_state(active_wf)
-                phase = state.get("phase") if isinstance(state, dict) else None
-                if not phase:
-                    log_debug(f"register_main_agent: workflow {active_wf} has no phase; registered without phase binding")
-                    return
-                dc.call_tool("router__update_agent_phase", {
-                    "agent_id": "",
-                    "workflow": active_wf,
-                    "phase": phase,
-                })
-            except Exception as e:
-                log_warning(
-                    f"register_main_agent: agent registered but phase binding failed "
-                    f"(agent will fall back to global-only until next session): {e}"
-                )
-    except Exception as e:
-        log_warning(f"register_main_agent: daemon connection failed: {e}")
+    try:
+        try:
+            dc.call_tool("router__register_agent", {
+                "agent_id": "",
+                "agent_type": "implementer",
+                "roles": ["editor", "shell_full"],
+            })
+        except Exception as e:
+            log_warning(f"register_main_agent: register step failed: {e}")
+            return
+
+        try:
+            active_wf = get_active_workflow_id()
+            if not active_wf:
+                log_debug("register_main_agent: no active workflow; agent registered but not phase-bound")
+                return
+            state = dc.workflow_get_state(active_wf)
+            phase = state.get("phase") if isinstance(state, dict) else None
+            if not phase:
+                log_debug(f"register_main_agent: workflow {active_wf} has no phase; registered without phase binding")
+                return
+            dc.call_tool("router__update_agent_phase", {
+                "agent_id": "",
+                "workflow": active_wf,
+                "phase": phase,
+            })
+        except Exception as e:
+            log_warning(
+                f"register_main_agent: agent registered but phase binding failed "
+                f"(agent will fall back to global-only until next session): {e}"
+            )
+    finally:
+        try:
+            dc.__exit__(None, None, None)
+        except Exception:
+            pass
 
 
 def cleanup_stale_outputs() -> str | None:

--- a/lib/daemon_client.py
+++ b/lib/daemon_client.py
@@ -214,17 +214,31 @@ class DaemonClient:
     # Internal
     # ─────────────────────────────────────────────────────────────────
 
+    # Tools callable via `tools/call` before `register()` has run.
+    # These are the agent-bootstrap tools the session-start hook uses to
+    # register the main agent with its workflow. Keep this set narrow.
+    _NO_REGISTER_TOOLS = frozenset({
+        "router__register_agent",
+        "router__update_agent_phase",
+    })
+
     def _call(self, method: str, params: dict) -> Any:
         """Send JSON-RPC request, block for response, return result."""
         if self._sock is None:
             raise ConnectionError("Not connected")
         # Registration required for agent tool calls, not for workflow/agent
-        # state operations (infrastructure ops used by internal tooling).
+        # state operations (infrastructure ops used by internal tooling) or
+        # the narrow set of bootstrap tools the session-start hook needs.
         _NO_REGISTER = ("agent/register", "tools/list",
                         "initialize", "notifications/initialized")
+        is_bootstrap_tool = (
+            method == "tools/call"
+            and params.get("name") in self._NO_REGISTER_TOOLS
+        )
         if (not self._registered
                 and method not in _NO_REGISTER
-                and not method.startswith(("workflow/", "agent/"))):
+                and not method.startswith(("workflow/", "agent/"))
+                and not is_bootstrap_tool):
             raise RuntimeError("Must call register() before tool calls")
 
         self._request_id += 1

--- a/tests/test_session_start_bootstrap.py
+++ b/tests/test_session_start_bootstrap.py
@@ -187,6 +187,25 @@ class TestAutoStartRetriesOnColdDaemon:
 class TestRegisterMainAgentRetriesOnColdDaemon:
     """register_main_agent must survive the same startup race."""
 
+    def test_warns_when_retries_exhausted(self):
+        mod = _load_session_start("session_start_register_warn")
+
+        dc_factory = MagicMock(side_effect=_connection_refused())
+
+        warnings: list[str] = []
+
+        with patch.dict(
+            "sys.modules",
+            {"daemon_client": MagicMock(DaemonClient=dc_factory)},
+        ), patch.object(mod, "get_active_workflow_id", lambda: "simple"), \
+                patch.object(mod.time, "sleep", lambda _s: None), \
+                patch.object(mod, "log_warning", lambda msg, **kw: warnings.append(msg)):
+            mod.register_main_agent()
+
+        assert any("register_main_agent" in w for w in warnings), (
+            f"register_main_agent swallowed exhaustion silently; warnings={warnings!r}"
+        )
+
     def test_retries_then_succeeds(self):
         mod = _load_session_start("session_start_register_retry")
 

--- a/tests/test_session_start_bootstrap.py
+++ b/tests/test_session_start_bootstrap.py
@@ -1,0 +1,216 @@
+"""Tests covering the session-start bootstrap path.
+
+Two bugs surfaced 2026-05-14 (workflow not active at session start):
+
+Bug A. `register_main_agent` calls `dc.call_tool("router__register_agent", ...)`
+which sends JSON-RPC method `tools/call`. The DaemonClient guard in
+`_call` requires `register()` first for any method that isn't in the
+narrow exempt set, so the bootstrap registration always raises
+`RuntimeError("Must call register() before tool calls")`. The hook
+swallows it and the main agent never gets phase-bound.
+
+Bug B. `auto_start_workflow` and `register_main_agent` both race the
+daemon socket on cold session-start. When the daemon is still binding,
+the connect attempt gets ECONNREFUSED. `auto_start_workflow` swallows
+the failure at DEBUG level (invisible at default WARNING) and no
+workflow is started for the session.
+
+These tests guard the fixes:
+- DaemonClient must allow `tools/call` for the bootstrap tool names
+  (`router__register_agent`, `router__update_agent_phase`) even before
+  `register()` has been called. Any other tool name must still hit the
+  guard.
+- Both hook functions must retry briefly on `ConnectionRefusedError`
+  rather than giving up on the first miss, and must log at WARNING (not
+  DEBUG) when retries are exhausted.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SESSION_START_PY = PROJECT_ROOT / "hooks" / "session-start.py"
+DAEMON_CLIENT_PY = PROJECT_ROOT / "lib" / "daemon_client.py"
+
+sys.path.insert(0, str(PROJECT_ROOT / "lib"))
+sys.path.insert(0, str(PROJECT_ROOT / "hooks"))
+
+
+def _load_session_start(name: str):
+    """Fresh module load of hooks/session-start.py for isolation between tests."""
+    spec = importlib.util.spec_from_file_location(name, SESSION_START_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_real_daemon_client(name: str):
+    """Fresh module load of lib/daemon_client.py to bypass conftest's autouse mock.
+
+    The conftest at tests/conftest.py installs a `MockDaemonClient` over the
+    `DaemonClient` attribute of any already-imported `daemon_client` module.
+    These tests need the real class to exercise the `_call` guard, so we load
+    daemon_client.py under a unique module name that conftest does not patch.
+    """
+    spec = importlib.util.spec_from_file_location(name, DAEMON_CLIENT_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Bug A — DaemonClient guard must let bootstrap tools through `tools/call`.
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonClientBootstrapToolExemption:
+    """Allow `router__register_agent` / `router__update_agent_phase` pre-register."""
+
+    def _client_with_fake_sock(self):
+        # Load DaemonClient fresh so the conftest autouse mock doesn't apply.
+        dc_mod = _load_real_daemon_client(
+            f"daemon_client_under_test_{id(self)}_{id(object())}"
+        )
+        dc = dc_mod.DaemonClient()
+        dc._sock = MagicMock()
+        dc._registered = False
+        dc._read_response = MagicMock(
+            return_value=b'{"jsonrpc":"2.0","id":1,"result":{}}'
+        )
+        return dc
+
+    def test_router_register_agent_bypasses_guard(self):
+        dc = self._client_with_fake_sock()
+        try:
+            dc.call_tool("router__register_agent", {
+                "agent_id": "",
+                "agent_type": "implementer",
+                "roles": ["editor", "shell_full"],
+            })
+        except RuntimeError as e:
+            assert "Must call register" not in str(e), (
+                "Guard still blocks router__register_agent before register()"
+            )
+
+    def test_router_update_agent_phase_bypasses_guard(self):
+        dc = self._client_with_fake_sock()
+        try:
+            dc.call_tool("router__update_agent_phase", {
+                "agent_id": "",
+                "workflow": "simple",
+                "phase": "plan",
+            })
+        except RuntimeError as e:
+            assert "Must call register" not in str(e), (
+                "Guard still blocks router__update_agent_phase before register()"
+            )
+
+    def test_non_bootstrap_tool_still_guarded(self):
+        """Guard must remain in place for any tool that isn't part of bootstrap."""
+        dc = self._client_with_fake_sock()
+        with pytest.raises(RuntimeError, match="Must call register"):
+            dc.call_tool("router__ping", {})
+
+
+# ---------------------------------------------------------------------------
+# Bug B — both hook functions must retry briefly on cold-daemon connect.
+# ---------------------------------------------------------------------------
+
+
+def _connection_refused():
+    return ConnectionRefusedError(111, "Connection refused")
+
+
+class TestAutoStartRetriesOnColdDaemon:
+    """auto_start_workflow must survive a brief startup race with the daemon."""
+
+    def test_retries_then_succeeds(self):
+        mod = _load_session_start("session_start_autostart_retry")
+
+        good_dc = MagicMock()
+        good_dc.__enter__ = MagicMock(return_value=good_dc)
+        good_dc.__exit__ = MagicMock(return_value=False)
+        good_dc.workflow_start = MagicMock(return_value={})
+
+        dc_factory = MagicMock(side_effect=[_connection_refused(), good_dc])
+
+        fake_pq = MagicMock()
+        fake_pq.get_active_workflow_id = MagicMock(return_value=None)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "daemon_client": MagicMock(DaemonClient=dc_factory),
+                "permission_query": fake_pq,
+            },
+        ), patch.object(mod.time, "sleep", lambda _s: None):
+            mod.auto_start_workflow()
+
+        assert dc_factory.call_count >= 2, (
+            "auto_start_workflow did not retry after ConnectionRefusedError"
+        )
+        good_dc.workflow_start.assert_called_once_with(
+            "simple", initial_state={"task": "Auto-started simple workflow"}
+        )
+
+    def test_warns_when_retries_exhausted(self):
+        mod = _load_session_start("session_start_autostart_warn")
+
+        dc_factory = MagicMock(side_effect=_connection_refused())
+
+        fake_pq = MagicMock()
+        fake_pq.get_active_workflow_id = MagicMock(return_value=None)
+
+        warnings: list[str] = []
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "daemon_client": MagicMock(DaemonClient=dc_factory),
+                "permission_query": fake_pq,
+            },
+        ), patch.object(mod.time, "sleep", lambda _s: None), \
+                patch.object(mod, "log_warning", lambda msg, **kw: warnings.append(msg)):
+            mod.auto_start_workflow()
+
+        assert any("auto-start" in w.lower() or "auto_start" in w.lower()
+                   for w in warnings), (
+            f"auto_start_workflow swallowed exhaustion silently; warnings={warnings!r}"
+        )
+
+
+class TestRegisterMainAgentRetriesOnColdDaemon:
+    """register_main_agent must survive the same startup race."""
+
+    def test_retries_then_succeeds(self):
+        mod = _load_session_start("session_start_register_retry")
+
+        good_dc = MagicMock()
+        # __enter__ returns self; the helper calls __enter__ directly (not via
+        # `with`), so that's the entry point for subsequent attribute access.
+        good_dc.__enter__ = MagicMock(return_value=good_dc)
+        good_dc.__exit__ = MagicMock(return_value=False)
+        good_dc.call_tool = MagicMock(return_value={})
+        good_dc.workflow_get_state = MagicMock(return_value={"phase": "plan"})
+
+        dc_factory = MagicMock(side_effect=[_connection_refused(), good_dc])
+
+        with patch.dict(
+            "sys.modules",
+            {"daemon_client": MagicMock(DaemonClient=dc_factory)},
+        ), patch.object(mod, "get_active_workflow_id", lambda: "simple"), \
+                patch.object(mod.time, "sleep", lambda _s: None):
+            mod.register_main_agent()
+
+        assert dc_factory.call_count >= 2, (
+            "register_main_agent did not retry after ConnectionRefusedError"
+        )
+        called_tools = [c.args[0] for c in good_dc.call_tool.call_args_list]
+        assert "router__register_agent" in called_tools, (
+            f"register_main_agent never registered after retry; calls={called_tools!r}"
+        )


### PR DESCRIPTION
## Summary

Two distinct bugs converged to leave the auto-started `simple` workflow inactive at session start — the workflow yaml was loaded by the daemon and `auto_start_workflow` pointed at the right id, but the main agent ended the bootstrap with no workflow active and no phase binding. This PR fixes both.

### Bug A — DaemonClient's register-guard blocks the bootstrap path

`DaemonClient._call` requires `register()` before any tool call (`lib/daemon_client.py:225-228`), but the main-agent registration in `hooks/session-start.py:register_main_agent` *is* a tool call: `dc.call_tool("router__register_agent", …)` → sends JSON-RPC `tools/call`, not in the exempt set, guard raises `RuntimeError("Must call register() before tool calls")`. The hook swallows it as `register step failed: …` — that exact message has been in `hooks.log` on every session-start since the main-agent registration code landed.

Fix: narrow set of bootstrap tool names (`router__register_agent`, `router__update_agent_phase`) bypasses the guard when called via `tools/call`. Any other tool name still hits it.

### Bug B — `auto_start_workflow` races the daemon socket and swallows the failure silently

Daemon process is launched alongside the SessionStart hook; on a cold start the socket isn't accepting yet when the hook fires. `auto_start_workflow` caught the resulting `ConnectionRefusedError` at DEBUG level (invisible at default WARNING), so no workflow got started and no trace appeared in logs. Same race affected `register_main_agent` (which logged at WARNING, hence the visible `daemon connection failed: [Errno 111] Connection refused` entry that surfaced this).

Fix: shared `_open_daemon_client_with_retry` helper does 5×200 ms retries (~1 s total) on `ConnectionRefusedError` / `OSError`, used by both hook functions. Exhaustion logs at WARNING so future cold-daemon failures are visible.

## Test plan

- [x] `tests/test_session_start_bootstrap.py` — 6 new tests, all pass:
  - Guard exempts `router__register_agent` and `router__update_agent_phase` pre-register.
  - Guard still blocks any other tool pre-register (negative case).
  - `auto_start_workflow` retries on `ConnectionRefusedError` then succeeds.
  - `auto_start_workflow` logs WARNING when retries exhausted.
  - `register_main_agent` retries on `ConnectionRefusedError` then succeeds.
- [x] Existing `tests/test_simple_changes.py` (6 tests) still passes.
- [x] Full suite: 1358 pass, 275 skip, 1 pre-existing failure (`test_paths.py::TestHooksJsonPortable::test_uses_shell_env_placeholder`) — confirmed identical with `git stash`, unrelated to this change.
- [ ] After merge: sync `hooks/session-start.py` and `lib/daemon_client.py` into the plugin cache and verify `register_main_agent: register step failed` no longer appears in `hooks.log` on next session start, and that `mcp__router__workflow__workflow_is_active` returns `true` immediately at session start.

## Note on the diff

This branch builds on `fix/main-agent-permission-routing` (`ba007cc` → `a3babf3`), which introduced the `register_main_agent` codepath that Bug A applies to. Those 4 parent commits appear in this PR's diff because they aren't yet on master.