### PR TITLE
Workflow permission audit: review-git, subagent binding, compound-bash policing, orchestrate workflow

### DIFF
--- a/bin/mcp-call
+++ b/bin/mcp-call
@@ -32,18 +32,16 @@ from daemon_client import DaemonClient
 
 
 def call_tool(name, arguments, caller_id=None):
-    """Call a tool via the router daemon."""
+    """Call a tool via the router daemon.
+
+    The agent is registered once at dispatch by the agent-dispatch hook
+    (prepare_dispatch), and the daemon holds that registration in its shared
+    in-memory registry. The caller id travels in arguments["_caller"], so the
+    daemon resolves the existing registration on every call. We deliberately do
+    NOT re-register here: re-registering would overwrite the agent's real
+    role/phase with AGENT_TYPE/WORKFLOW_ID env defaults (implementer/iterate).
+    """
     with DaemonClient() as dc:
-        if caller_id:
-            agent_type = os.environ.get("AGENT_TYPE", "implementer")
-            workflow_id = os.environ.get("WORKFLOW_ID", "iterate")
-            session_id = os.environ.get("AGENT_SESSION_ID", f"mcp-call-{caller_id}")
-            dc.register(
-                agent_id=caller_id,
-                agent_type=agent_type,
-                session_id=session_id,
-                workflow_id=workflow_id,
-            )
         return dc.call_tool(name, arguments)
 
 

--- a/bin/mcp-call
+++ b/bin/mcp-call
@@ -34,14 +34,25 @@ from daemon_client import DaemonClient
 def call_tool(name, arguments, caller_id=None):
     """Call a tool via the router daemon.
 
-    The agent is registered once at dispatch by the agent-dispatch hook
-    (prepare_dispatch), and the daemon holds that registration in its shared
-    in-memory registry. The caller id travels in arguments["_caller"], so the
-    daemon resolves the existing registration on every call. We deliberately do
-    NOT re-register here: re-registering would overwrite the agent's real
-    role/phase with AGENT_TYPE/WORKFLOW_ID env defaults (implementer/iterate).
+    The agent's real role + live phase were registered at dispatch by the
+    agent-dispatch hook (prepare_dispatch). We still complete the DaemonClient
+    registration handshake here because it flips the client-side _registered
+    flag that call_tool requires. The daemon's register_agent handler is
+    idempotent, so this does NOT clobber the agent's role/phase — it attaches
+    this connection to the existing identity. The caller id also travels in
+    arguments["_caller"] for per-call permission resolution.
     """
     with DaemonClient() as dc:
+        if caller_id:
+            agent_type = os.environ.get("AGENT_TYPE", "implementer")
+            workflow_id = os.environ.get("WORKFLOW_ID", "iterate")
+            session_id = os.environ.get("AGENT_SESSION_ID", f"mcp-call-{caller_id}")
+            dc.register(
+                agent_id=caller_id,
+                agent_type=agent_type,
+                session_id=session_id,
+                workflow_id=workflow_id,
+            )
         return dc.call_tool(name, arguments)
 
 

--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -97,7 +97,22 @@ agents:
     blocked: [native__write_file, native__edit_file, native__bash]
 
 workflows:
-  # Iterate workflow (TDD-style)
+  # Orchestrate workflow — coordinator. The orchestrator spawns iterate workers
+  # and never edits code itself. intake/design are context kickbacks; orchestrate
+  # is the home phase it never leaves. (Was conflated into `iterate`; now its own
+  # permission-gated workflow, matching config/workflows/orchestrate.yaml.)
+  orchestrate:
+    intake:
+      allowed: [native__read_file, native__glob, native__grep, serena__*, context7__*, native__web_fetch, native__web_search, workflow__*]
+      blocked: [native__write_file, native__edit_file, native__bash]
+    design:
+      allowed: [native__read_file, native__glob, native__grep, serena__*, context7__*, native__web_fetch, native__web_search, workflow__*]
+      blocked: [native__write_file, native__edit_file, native__bash]
+    orchestrate:
+      allowed: [native__read_file, native__glob, native__grep, workflow__*]
+      blocked: [native__write_file, native__edit_file, native__bash]
+
+  # Iterate workflow (TDD-style) — worker: one agent per task, test_writing -> complete
   iterate:
     orchestrate:
       allowed: [native__read_file, native__glob, native__grep, workflow__*]
@@ -114,10 +129,6 @@ workflows:
     test:
       allowed: [native__read_file, native__bash(pytest*), native__bash(python -m pytest*), native__bash(ruff*)]
       blocked: [native__write_file, native__edit_file]
-
-    coverage:
-      allowed: [native__write_file, native__edit_file, native__read_file, native__glob, native__grep, native__bash(pytest*), serena__*]
-      blocked: []
 
     review:
       allowed: [native__read_file, native__glob, native__grep, native__bash(git*), native__bash(gh*), native__bash(mcp-call*)]

--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -175,8 +175,8 @@ workflows:
       allowed: [native__read_file, native__bash(pytest*), native__bash(python -m pytest*), native__bash(ruff*)]
       blocked: [native__write_file, native__edit_file]
     review:
-      allowed: [native__read_file, native__glob, native__grep, serena__*]
-      blocked: [native__write_file, native__edit_file, native__bash]
+      allowed: [native__read_file, native__glob, native__grep, serena__*, native__bash(git diff*), native__bash(git log*), native__bash(git show*), native__bash(git status*), native__bash(gh pr diff*), native__bash(gh pr view*), native__bash(pytest*)]
+      blocked: [native__write_file, native__edit_file]
     merge:
       allowed: [native__read_file, native__bash(git*), native__bash(gh*)]
       blocked: [native__write_file, native__edit_file]

--- a/hooks/native-tool-blocking.py
+++ b/hooks/native-tool-blocking.py
@@ -47,6 +47,46 @@ def block(reason: str):
     sys.exit(2)
 
 
+def _is_clean_mcp_call(cmd: str) -> bool:
+    """True iff `cmd` is a single mcp-call invocation with no shell chaining,
+    piping, command substitution, or redirection OUTSIDE its quoted arguments.
+
+    The router only ever sees the inner native__* call mcp-call forwards;
+    anything the outer shell could additionally run (``mcp-call ... ; rm -rf``)
+    never reaches the router's permission check, so it must be rejected here.
+    A ``&&`` inside the quoted JSON argument is the inner command (which the
+    router does police) and is fine.
+    """
+    import shlex
+
+    # backtick command substitution outside quotes -> reject
+    in_s = in_d = False
+    for ch in cmd:
+        if ch == "'" and not in_d:
+            in_s = not in_s
+        elif ch == '"' and not in_s:
+            in_d = not in_d
+        elif ch == "`" and not in_s and not in_d:
+            return False
+    try:
+        lex = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        tokens = list(lex)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+    first = tokens[0]
+    if first != "mcp-call" and not first.endswith("/mcp-call"):
+        return False
+    # any unquoted shell operator / grouping token -> reject (chaining, pipes,
+    # subshells, $()/<() substitution and redirects all surface as these)
+    for tok in tokens[1:]:
+        if tok and set(tok) <= set("&|;()<>"):
+            return False
+    return True
+
+
 def main():
     if ALWAYS_ALLOW:
         print(json.dumps(allow("ALWAYS_ALLOW bypass")))
@@ -65,10 +105,12 @@ def main():
         print(json.dumps(allow("Router-mediated")))
         return
 
-    # Rule 2: Bash with mcp-call prefix → allow (router access path)
+    # Rule 2: a single, un-chained mcp-call → allow (router access path). A
+    # compound command (mcp-call ... ; rm -rf) must NOT pass here: the extra
+    # commands would run in the agent's shell, never reaching the router.
     if tool_name == "Bash":
         cmd = tool_input.get("command", "").strip()
-        if cmd.startswith("mcp-call ") or cmd == "mcp-call" or cmd.startswith(MCP_CALL_PATH):
+        if _is_clean_mcp_call(cmd):
             print(json.dumps(allow("mcp-call")))
             return
 

--- a/hooks/native-tool-blocking.py
+++ b/hooks/native-tool-blocking.py
@@ -57,16 +57,31 @@ def _is_clean_mcp_call(cmd: str) -> bool:
     A ``&&`` inside the quoted JSON argument is the inner command (which the
     router does police) and is fine.
     """
+    # Newline/CR injection: shlex treats \n as whitespace and silently drops
+    # it, so `mcp-call ...\nrm -rf /` would tokenize clean while the shell runs
+    # both lines. Reject outright.
+    if "\n" in cmd or "\r" in cmd:
+        return False
+
     import shlex
 
-    # backtick command substitution outside quotes -> reject
-    in_s = in_d = False
+    # backtick command substitution outside single quotes -> reject.
+    # Escape-aware: a backslash escapes the next char outside single quotes, so
+    # \" does not flip the double-quote state. A backtick is active substitution
+    # anywhere except inside single quotes (incl. inside double quotes).
+    in_s = in_d = escape = False
     for ch in cmd:
+        if escape:
+            escape = False
+            continue
+        if ch == "\\" and not in_s:
+            escape = True
+            continue
         if ch == "'" and not in_d:
             in_s = not in_s
         elif ch == '"' and not in_s:
             in_d = not in_d
-        elif ch == "`" and not in_s and not in_d:
+        elif ch == "`" and not in_s:
             return False
     try:
         lex = shlex.shlex(cmd, posix=True, punctuation_chars=True)

--- a/lib/controller.py
+++ b/lib/controller.py
@@ -601,8 +601,15 @@ class Controller:
         # Register in permissions system
         self.permissions.register_agent(agent_id, role)
 
+        # Bind the agent to the live workflow phase so per-phase permissions
+        # (not just its role) govern it. Registered once here in the shared
+        # daemon registry; propagate_phase keeps it current as phases advance,
+        # and later mcp-call traffic resolves this entry via _caller.
+        active_wf, active_phase = get_workflow_state()
+        if active_wf:
+            self.permissions.update_agent_phase(agent_id, active_wf, active_phase)
+
         # Assemble role-specific briefing (only default to iterate if no workflow active)
-        active_wf, _ = get_workflow_state()
         wf_override = "iterate" if role == "implementer" and not active_wf else None
         briefing = assemble_subagent_briefing(role, workflow_override=wf_override)
         caller_header = (

--- a/lib/controller.py
+++ b/lib/controller.py
@@ -665,21 +665,32 @@ class Controller:
             agent_type = args.get("agent_type", "")
             workflow_id = args.get("workflow_id")
 
-            # 1. Register in permissions system
-            info = self.permissions.register_agent(
-                agent_id=agent_id,
-                agent_type=agent_type,
-                roles=args.get("roles"),
-            )
+            # Idempotent: prepare_dispatch already registered this agent with its
+            # real role + live phase. A later registration (e.g. mcp-call's
+            # per-connection handshake, which carries AGENT_TYPE/WORKFLOW_ID env
+            # defaults) must ATTACH to that identity, not overwrite it.
+            existing = self.permissions.get_agent(agent_id)
+            if existing is not None:
+                info = existing
+                agent_type = existing.agent_type
+                workflow_id = existing.workflow
+                phase = existing.phase
+            else:
+                # 1. Register in permissions system
+                info = self.permissions.register_agent(
+                    agent_id=agent_id,
+                    agent_type=agent_type,
+                    roles=args.get("roles"),
+                )
 
-            # 2. Determine phase from workflow config (if applicable)
-            phase = None
-            if workflow_id:
-                config = self._workflow_configs.get(workflow_id)
-                if config:
-                    phase = config.initial_phase
-                    info.workflow = workflow_id
-                    info.phase = phase
+                # 2. Determine phase from workflow config (if applicable)
+                phase = None
+                if workflow_id:
+                    config = self._workflow_configs.get(workflow_id)
+                    if config:
+                        phase = config.initial_phase
+                        info.workflow = workflow_id
+                        info.phase = phase
 
             # 3. Record agent state
             agent_state = {

--- a/lib/permissions.py
+++ b/lib/permissions.py
@@ -309,7 +309,9 @@ class PermissionChecker:
                 benign_block = benign_block or resp
                 continue
             return False, resp
-        if allowed_count == 0 and benign_block is not None:
+        if allowed_count == 0:
+            # Nothing was explicitly allowed -- only benign ride-alongs, or a
+            # command that tokenized to no real sub-command. Fail closed.
             return False, benign_block
         return True, None
 

--- a/lib/permissions.py
+++ b/lib/permissions.py
@@ -118,6 +118,76 @@ def _matches_any(tool: str, args: dict, patterns: list[str]) -> tuple[bool, str]
     return False, ""
 
 
+# --- Compound bash-command policing ---------------------------------------
+# native__bash receives a full shell command string. Matching the whole string
+# against patterns like ``git diff*`` is unsound both ways: it blocks legitimate
+# compound commands (``cd /x && git diff``) and lets dangerous ones through
+# (``git status && rm -rf`` — the suffix never has to match an allow rule, and
+# the start-anchored superblock never sees it). So we decompose the command into
+# its constituent sub-commands and check each one independently.
+
+_CHAIN_OPS = {"&&", "||", ";", "|", "&"}
+# Always-safe sub-commands: navigation / no-ops / read-only stream filters.
+# None can delete or (absent a redirect, which we reject) write.
+_BENIGN_ARGV0 = {
+    "cd", "pwd", "true", ":", "echo",
+    "head", "tail", "cat", "wc", "grep", "sort", "uniq", "cut", "nl", "tr", "rev",
+}
+
+
+def _split_subcommands(command: str):
+    """Split a shell command into top-level sub-commands on control operators
+    (``&& || ; | &`` and newlines). Quote-aware. Returns a list, or None if the
+    command can't be tokenized (unbalanced quotes -> caller fails closed)."""
+    import shlex
+
+    subs: list[str] = []
+    for line in command.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lex = shlex.shlex(line, posix=True, punctuation_chars=True)
+            lex.whitespace_split = True
+            tokens = list(lex)
+        except ValueError:
+            return None
+        cur: list[str] = []
+        for tok in tokens:
+            if tok in _CHAIN_OPS or (tok and set(tok) <= {"&", "|", ";"}):
+                if cur:
+                    subs.append(" ".join(cur))
+                    cur = []
+            else:
+                cur.append(tok)
+        if cur:
+            subs.append(" ".join(cur))
+    return subs or [command]
+
+
+def _argv0(subcmd: str) -> str:
+    parts = subcmd.split()
+    return parts[0] if parts else ""
+
+
+def _has_substitution(command: str) -> bool:
+    return any(marker in command for marker in ("$(", "`", "<(", ">("))
+
+
+def _has_write_redirect(command: str) -> bool:
+    """True if the command writes to a file via ``>`` / ``>>`` (fd-dup like
+    ``2>&1`` is fine and not flagged)."""
+    import shlex
+
+    try:
+        lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        tokens = list(lex)
+    except ValueError:
+        return True
+    return any(tok in (">", ">>") for tok in tokens)
+
+
 class PermissionChecker:
     """Evaluates tool access rules from permissions.yaml.
 
@@ -145,10 +215,111 @@ class PermissionChecker:
     ) -> tuple[bool, BlockedResponse | None]:
         """Check if a tool call is allowed.
 
+        native__bash commands are decomposed into their constituent
+        sub-commands (split on shell control operators) and each is checked, so
+        a compound command is allowed only if EVERY part is allowed and NO part
+        is superblocked. Closes the prefix-injection hole and the over-strict
+        ``cd /x && git diff`` case (see _check_bash). All other tools use
+        _check_single unchanged.
+
         Returns:
             (True, None) if allowed.
             (False, BlockedResponse) if blocked.
         """
+        if tool == "native__bash":
+            return self._check_bash(args, agent)
+        return self._check_single(tool, args, agent)
+
+    def _check_bash(
+        self,
+        args: dict,
+        agent: AgentInfo | None,
+    ) -> tuple[bool, BlockedResponse | None]:
+        """Decompose a bash command and require every sub-command to pass."""
+        command = (args.get("command") or "").strip()
+        if not command:
+            return self._check_single("native__bash", args, agent)
+
+        agent_type = agent.agent_type if agent else ""
+        agent_id = agent.agent_id if agent else ""
+        workflow = agent.workflow if agent else None
+        phase = agent.phase if agent else None
+        phase_str = f"{workflow}/{phase}" if workflow and phase else ""
+
+        def deny(reason: str, rule: str):
+            return False, BlockedResponse(
+                reason=reason,
+                tool="native__bash",
+                agent_type=agent_type,
+                agent_id=agent_id,
+                phase=phase_str,
+                rule_that_blocked=rule,
+                guidance=_GUIDANCE["blocked"],
+            )
+
+        # "Unrestricted" = a bare native__bash grant applies to this caller. Probe
+        # with a token that can only match a bare grant, never an arg pattern like
+        # git diff* nor a superblock.
+        unrestricted, _ = self._check_single(
+            "native__bash", {"command": "\x00probe"}, agent
+        )
+
+        subs = _split_subcommands(command)
+        if subs is None:
+            # Can't safely decompose (unusual quoting / shell syntax). A caller
+            # with a bare native__bash grant already has full shell, so defer to
+            # the single-command check; a restricted caller fails closed.
+            if unrestricted:
+                return self._check_single("native__bash", args, agent)
+            return deny("unparseable shell command", "bash.unparseable")
+
+        # Restricted callers (bash scoped to specific programs) additionally
+        # cannot use command substitution or write redirection, which would
+        # smuggle work past the allowlist.
+        if not unrestricted:
+            if _has_substitution(command):
+                return deny(
+                    "command substitution is not permitted in this phase",
+                    "bash.substitution",
+                )
+            if _has_write_redirect(command):
+                return deny(
+                    "file redirection is not permitted in this phase",
+                    "bash.redirect",
+                )
+
+        # Every sub-command must pass. A superblocked sub-command always blocks
+        # the whole command. Benign navigation / read-only filters (cd, head, …)
+        # may ride along, but ONLY when at least one other sub-command is
+        # explicitly allowed — so a phase that blocks bash outright still blocks
+        # "echo" etc., while "cd /x && git diff" and "git log | head" work.
+        allowed_count = 0
+        benign_block = None
+        for sub in subs:
+            if not sub:
+                continue
+            ok, resp = self._check_single("native__bash", {"command": sub}, agent)
+            if ok:
+                allowed_count += 1
+                continue
+            reason = (resp.reason if resp else "") or ""
+            if reason.startswith("superblock"):
+                return False, resp
+            if _argv0(sub) in _BENIGN_ARGV0:
+                benign_block = benign_block or resp
+                continue
+            return False, resp
+        if allowed_count == 0 and benign_block is not None:
+            return False, benign_block
+        return True, None
+
+    def _check_single(
+        self,
+        tool: str,
+        args: dict,
+        agent: AgentInfo | None = None,
+    ) -> tuple[bool, BlockedResponse | None]:
+        """Check a single (non-compound) tool call against the layered rules."""
         rules = self._rules
         global_rules = rules.get("global", {})
         agent_type = agent.agent_type if agent else ""

--- a/tests/test_bash_command_policing.py
+++ b/tests/test_bash_command_policing.py
@@ -142,3 +142,13 @@ class TestHookMcpCallGate:
 
     def test_non_mcp_call_rejected(self, hook):
         assert not hook._is_clean_mcp_call("git diff")
+
+    def test_newline_injection_blocked(self, hook):
+        # shlex drops \n as whitespace; without a guard "mcp-call ...\nrm -rf /"
+        # tokenizes clean while the outer shell runs both lines.
+        assert not hook._is_clean_mcp_call("mcp-call native__read_file '{}'\nrm -rf /tmp/x")
+        assert not hook._is_clean_mcp_call("mcp-call git status\rrm -rf /tmp/x")
+
+    def test_backtick_in_double_quotes_blocked(self, hook):
+        # `cmd` inside double quotes is still active command substitution.
+        assert not hook._is_clean_mcp_call('mcp-call foo "`rm -rf /tmp/x`"')

--- a/tests/test_bash_command_policing.py
+++ b/tests/test_bash_command_policing.py
@@ -1,0 +1,144 @@
+"""Cheap-layer compound-bash policing: decompose a command into sub-commands and
+check each, so a compound command is allowed only if every part is allowed and
+no part is superblocked. Fixes both the over-strict case (cd && git diff) and
+the prefix-injection hole (git status && rm -rf)."""
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+PERMISSIONS_YAML = PROJECT_ROOT / "config" / "permissions.yaml"
+
+
+@pytest.fixture
+def checker():
+    from permissions import PermissionChecker
+    return PermissionChecker(PERMISSIONS_YAML)
+
+
+def _reviewer():
+    """Restricted: develop/review allows read-only git+pytest, agent blocks bare bash."""
+    from permissions import AgentInfo
+    return AgentInfo(agent_id="r", agent_type="reviewer", workflow="develop", phase="review")
+
+
+def _implementer():
+    """Permissive: bare native__bash via the global fallthrough."""
+    from permissions import AgentInfo
+    return AgentInfo(agent_id="i", agent_type="implementer")
+
+
+def _ok(checker, agent, cmd):
+    allowed, _ = checker.check("native__bash", {"command": cmd}, agent)
+    return allowed
+
+
+# ── Restricted phase (reviewer @ develop/review) ─────────────────────────────
+class TestRestricted:
+    def test_bare_allowed_command(self, checker):
+        assert _ok(checker, _reviewer(), "git diff --stat 8165456 HEAD")
+
+    def test_cd_prefixed_now_allowed(self, checker):           # was wrongly BLOCKED
+        assert _ok(checker, _reviewer(), "cd /home/x/repo && git diff --stat")
+
+    def test_pipe_to_benign_pager_allowed(self, checker):
+        assert _ok(checker, _reviewer(), "git log --oneline | head -5")
+
+    def test_chained_rm_now_blocked(self, checker):            # was wrongly ALLOWED (injection)
+        assert not _ok(checker, _reviewer(), "git status && rm -rf /tmp/__x__")
+
+    def test_semicolon_injection_blocked(self, checker):
+        assert not _ok(checker, _reviewer(), "git log ; rm -rf /tmp/__x__")
+
+    def test_command_substitution_blocked(self, checker):
+        assert not _ok(checker, _reviewer(), "git diff $(rm -rf /tmp/__x__)")
+
+    def test_backtick_substitution_blocked(self, checker):
+        assert not _ok(checker, _reviewer(), "git diff `rm -rf /tmp/__x__`")
+
+    def test_write_redirect_blocked(self, checker):
+        assert not _ok(checker, _reviewer(), "git diff > /tmp/__stolen__")
+
+    def test_pipe_to_sh_blocked(self, checker):
+        assert not _ok(checker, _reviewer(), "git log | sh")
+
+    def test_newline_injection_blocked(self, checker):
+        assert not _ok(checker, _reviewer(), "git diff\nrm -rf /tmp/__x__")
+
+    def test_disallowed_single_still_blocked(self, checker):   # unchanged behavior
+        assert not _ok(checker, _reviewer(), "ls -la")
+
+    def test_env_prefix_blocked(self, checker):
+        assert not _ok(checker, _reviewer(), "PATH=/tmp git diff")
+
+    def test_unparseable_fails_closed(self, checker):
+        # unbalanced quote -> shlex can't tokenize -> restricted fails closed
+        assert not _ok(checker, _reviewer(), 'git diff "unterminated')
+
+
+# ── Permissive phase (implementer, bare bash) ────────────────────────────────
+class TestPermissive:
+    def test_arbitrary_command_allowed(self, checker):
+        assert _ok(checker, _implementer(), "ls -la")
+
+    def test_substitution_allowed_when_permissive(self, checker):
+        assert _ok(checker, _implementer(), "git tag v$(cat VERSION)")
+
+    def test_injection_still_blocked_by_superblock(self, checker):   # per-sub superblock
+        assert not _ok(checker, _implementer(), "echo hi && rm -rf /tmp/__x__")
+
+    def test_bare_rm_blocked(self, checker):
+        assert not _ok(checker, _implementer(), "rm -rf /tmp/__x__")
+
+    def test_unparseable_falls_back_allowed(self, checker):
+        # a caller with a bare-bash grant already has full shell; an undecomposable
+        # command falls back to the single-command check rather than failing closed
+        assert _ok(checker, _implementer(), 'echo "unterminated')
+
+
+# ── Hook gate: native-tool-blocking only allows a clean single mcp-call ───────
+def _load_hook():
+    import importlib.util
+    from importlib.machinery import SourceFileLoader
+
+    path = PROJECT_ROOT / "hooks" / "native-tool-blocking.py"
+    loader = SourceFileLoader("ntb_hook", str(path))
+    spec = importlib.util.spec_from_loader("ntb_hook", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+class TestHookMcpCallGate:
+    @pytest.fixture
+    def hook(self):
+        return _load_hook()
+
+    def test_clean_mcp_call_allowed(self, hook):
+        assert hook._is_clean_mcp_call(
+            "mcp-call --caller-id=r native__read_file '{\"file_path\": \"/x\"}'"
+        )
+
+    def test_shell_alias_allowed(self, hook):
+        assert hook._is_clean_mcp_call("mcp-call --caller-id=r git diff --stat")
+
+    def test_inner_json_ampersand_allowed(self, hook):
+        # && inside the quoted JSON is the inner command (router polices it), not chaining
+        assert hook._is_clean_mcp_call(
+            "mcp-call --caller-id=i native__bash '{\"command\": \"git diff && pytest\"}'"
+        )
+
+    def test_chaining_blocked(self, hook):
+        assert not hook._is_clean_mcp_call("mcp-call native__read_file '{}' ; rm -rf /tmp/x")
+
+    def test_pipe_blocked(self, hook):
+        assert not hook._is_clean_mcp_call("mcp-call git log | sh")
+
+    def test_substitution_blocked(self, hook):
+        assert not hook._is_clean_mcp_call("mcp-call native__read_file $(rm -rf /tmp/x)")
+
+    def test_backtick_blocked(self, hook):
+        assert not hook._is_clean_mcp_call("mcp-call foo `rm -rf /tmp/x`")
+
+    def test_non_mcp_call_rejected(self, hook):
+        assert not hook._is_clean_mcp_call("git diff")

--- a/tests/test_develop_permissions.py
+++ b/tests/test_develop_permissions.py
@@ -125,10 +125,14 @@ class TestDevelopWorkflowSection:
         assert "native__edit_file" in blocked
 
     def test_review_blocked(self, config):
-        blocked = config["workflows"]["develop"]["review"]["blocked"]
-        assert "native__bash" in blocked
-        assert "native__write_file" in blocked
-        assert "native__edit_file" in blocked
+        review = config["workflows"]["develop"]["review"]
+        # Review blocks code changes...
+        assert "native__write_file" in review["blocked"]
+        assert "native__edit_file" in review["blocked"]
+        # ...but must NOT wholesale-block bash: the reviewer needs read-only git
+        # to inspect the PR diff (see test_review_binding_fix).
+        assert "native__bash" not in review["blocked"]
+        assert "native__bash(git diff*)" in review["allowed"]
 
     def test_merge_allowed_git_gh(self, config):
         allowed = config["workflows"]["develop"]["merge"]["allowed"]

--- a/tests/test_review_binding_fix.py
+++ b/tests/test_review_binding_fix.py
@@ -1,0 +1,108 @@
+"""Tests for two workflow fixes:
+
+1. develop/review reviewer must be able to run read-only git (review a PR diff)
+   while still being blocked from writing/pushing.
+2. Subagent role/phase binding: the dispatch hook (prepare_dispatch) binds the
+   agent to the live (workflow, phase) once, in the daemon's shared registry;
+   mcp-call must NOT re-register on every call (that would clobber the role with
+   AGENT_TYPE/WORKFLOW_ID env defaults).
+"""
+import importlib.util
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+PERMISSIONS_YAML = PROJECT_ROOT / "config" / "permissions.yaml"
+
+
+# ── Fix #1: develop/review needs read-only git ───────────────────────────────
+class TestDevelopReviewGit:
+    @pytest.fixture
+    def checker(self):
+        from permissions import PermissionChecker
+        return PermissionChecker(PERMISSIONS_YAML)
+
+    @staticmethod
+    def _reviewer():
+        from permissions import AgentInfo
+        return AgentInfo(agent_id="r", agent_type="reviewer",
+                         workflow="develop", phase="review")
+
+    def test_reviewer_can_git_diff(self, checker):
+        ok, _ = checker.check("native__bash", {"command": "git diff HEAD"}, self._reviewer())
+        assert ok, "reviewer must be able to run 'git diff' in develop/review"
+
+    def test_reviewer_can_gh_pr_diff(self, checker):
+        ok, _ = checker.check("native__bash", {"command": "gh pr diff 12"}, self._reviewer())
+        assert ok, "reviewer must be able to run 'gh pr diff' in develop/review"
+
+    def test_reviewer_cannot_write(self, checker):
+        ok, _ = checker.check("native__write_file", {"file_path": "/x.py"}, self._reviewer())
+        assert not ok, "reviewer must NOT write in develop/review"
+
+    def test_reviewer_cannot_git_push(self, checker):
+        ok, _ = checker.check("native__bash", {"command": "git push origin main"}, self._reviewer())
+        assert not ok, "reviewer must NOT push in develop/review"
+
+    def test_reviewer_cannot_arbitrary_bash(self, checker):
+        ok, _ = checker.check("native__bash", {"command": "rm -rf /tmp/x"}, self._reviewer())
+        assert not ok, "reviewer must NOT run arbitrary shell in develop/review"
+
+
+# ── Fix #2a: prepare_dispatch binds the live workflow/phase ──────────────────
+@pytest.fixture
+def controller():
+    from controller import Controller
+    with patch.object(Controller, "__init__", lambda self: None):
+        ctrl = Controller.__new__(Controller)
+        ctrl.permissions = MagicMock()
+        ctrl.permissions.register_agent.return_value = MagicMock(
+            agent_id="sub-abc123", agent_type="reviewer", roles=[],
+            workflow=None, phase=None)
+        ctrl._agent_state = {}
+        ctrl._agent_set_state = MagicMock()
+        ctrl._workflow_configs = {}
+        ctrl._state_lock = threading.RLock()
+        yield ctrl
+
+
+class TestPrepareDispatchBinding:
+    def test_binds_agent_to_live_workflow_phase(self, controller):
+        with patch("controller.assemble_subagent_briefing", return_value=""), \
+             patch("controller.get_workflow_state", return_value=("develop", "review")):
+            controller._prepare_dispatch({"agent_type": "reviewer"})
+        controller.permissions.update_agent_phase.assert_called_once()
+        ca = controller.permissions.update_agent_phase.call_args
+        assert ca.args[1] == "develop" and ca.args[2] == "review"
+
+    def test_no_binding_when_no_active_workflow(self, controller):
+        with patch("controller.assemble_subagent_briefing", return_value=""), \
+             patch("controller.get_workflow_state", return_value=(None, None)):
+            controller._prepare_dispatch({"agent_type": "reviewer"})
+        controller.permissions.update_agent_phase.assert_not_called()
+
+
+# ── Fix #2b: mcp-call must not re-register (shared daemon state) ──────────────
+def _load_mcp_call():
+    from importlib.machinery import SourceFileLoader
+    loader = SourceFileLoader("mcp_call_mod", str(PROJECT_ROOT / "bin" / "mcp-call"))
+    spec = importlib.util.spec_from_loader("mcp_call_mod", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+class TestMcpCallNoReregister:
+    def test_call_tool_does_not_register(self, monkeypatch):
+        mod = _load_mcp_call()
+        dc = MagicMock()
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=dc)
+        cm.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setattr(mod, "DaemonClient", MagicMock(return_value=cm))
+        mod.call_tool("native__read_file", {"_caller": "sub-x", "file_path": "/x"}, caller_id="sub-x")
+        dc.register.assert_not_called()
+        dc.call_tool.assert_called_once()

--- a/tests/test_review_binding_fix.py
+++ b/tests/test_review_binding_fix.py
@@ -95,8 +95,11 @@ def _load_mcp_call():
     return mod
 
 
-class TestMcpCallNoReregister:
-    def test_call_tool_does_not_register(self, monkeypatch):
+class TestMcpCallHandshake:
+    def test_call_tool_registers_for_handshake(self, monkeypatch):
+        """mcp-call must complete the DaemonClient registration handshake:
+        call_tool requires the client-side _registered flag. The daemon makes
+        register idempotent so this does not clobber the agent's role/phase."""
         mod = _load_mcp_call()
         dc = MagicMock()
         cm = MagicMock()
@@ -104,5 +107,31 @@ class TestMcpCallNoReregister:
         cm.__exit__ = MagicMock(return_value=False)
         monkeypatch.setattr(mod, "DaemonClient", MagicMock(return_value=cm))
         mod.call_tool("native__read_file", {"_caller": "sub-x", "file_path": "/x"}, caller_id="sub-x")
-        dc.register.assert_not_called()
+        dc.register.assert_called_once()
         dc.call_tool.assert_called_once()
+
+
+class TestRegisterAgentIdempotent:
+    """The clobber prevention lives in the daemon handler, not in mcp-call: an
+    already-registered agent (bound by prepare_dispatch) is preserved when a
+    later registration arrives with default values."""
+
+    def test_existing_registration_preserved(self, controller):
+        existing = MagicMock(agent_id="sub-x", agent_type="reviewer",
+                             roles=["reviewer"], workflow="develop", phase="review")
+        controller.permissions.get_agent.return_value = existing
+        controller.permissions.register_agent.reset_mock()
+        with patch("controller.assemble_subagent_briefing", return_value=""):
+            result = controller._handle_router("register_agent", {
+                "agent_id": "sub-x", "agent_type": "implementer", "workflow_id": "iterate"})
+        controller.permissions.register_agent.assert_not_called()
+        assert result["agent_type"] == "reviewer"
+        assert result["workflow_id"] == "develop"
+        assert result["phase"] == "review"
+
+    def test_new_registration_creates(self, controller):
+        controller.permissions.get_agent.return_value = None
+        with patch("controller.assemble_subagent_briefing", return_value=""):
+            controller._handle_router("register_agent", {
+                "agent_id": "sub-y", "agent_type": "implementer"})
+        controller.permissions.register_agent.assert_called_once()


### PR DESCRIPTION
Fixes surfaced by *exercising* the agent-swarm workflows (running them, not just reading config). Four
related changes to the router permission system + workflow config, each grounded in a reproduced problem
and verified on the live daemon.

## 1. develop/review reviewer couldn't `git diff` (73ceaaa)
`develop.review` blocked all `native__bash`, so a reviewer couldn't see the PR diff. Now allows read-only
git (diff/log/show/status), `gh pr diff/view`, and pytest; still blocks write/edit/push/arbitrary shell.
Also binds dispatched subagents to the live `(workflow, phase)` in `prepare_dispatch`.

## 2. Subagent role/phase binding clobber (1969b9e)
Subagents route tool calls through `mcp-call`, which re-registered on every call using
`AGENT_TYPE`/`WORKFLOW_ID` env defaults (implementer/iterate) that are never set — silently re-binding a
reviewer to implementer. Root cause: `register()` is both the daemon-side registration AND the client-side
handshake `call_tool` requires. Fix: keep mcp-call's handshake; make the daemon's `register_agent`
idempotent so an agent already registered at dispatch is preserved, not overwritten.

## 3. Compound bash command policing (cf1b7ad)
`fnmatch` on the whole command string was unsound both ways — it blocked legit compounds (`cd /x &&
git diff`) AND allowed dangerous ones (`git status && rm -rf` passed because it starts with an allowed
command; the start-anchored superblock never saw the suffix). A read-only reviewer could run `rm -rf`.
Fix: decompose the command (quote-aware `shlex`) and check each sub-command — every part allowed, none
superblocked; restricted phases also reject substitution/redirection; the native-tool-blocking hook now
requires a single un-chained `mcp-call`. A differential old-vs-new over a corpus shows: provably at least
as secure (zero dangerous new-allows; 14+ holes/evasions closed). Known limits + sandbox follow-up: #101.

## 4. Orchestrate as a first-class workflow (dd7c8a8)
`orchestrate` predates the workflow state engine + permission-gating, so it had no permissions block and
was conflated into the iterate engine's definition. Added a `workflows.orchestrate` block
(intake/design/orchestrate) so it's governed like every other modern workflow; dropped the orphan
`iterate.coverage` block. Engine definition-split + `lib/orchestrate.py` retirement tracked in #102.

## Verification
- Full test suite green except 3 pre-existing `test_paths` failures (confirmed unrelated via `git stash`).
  New tests: `tests/test_review_binding_fix.py`, `tests/test_bash_command_policing.py`.
- Live on the daemon: the full **develop** phase walk (all 11 phases reach terminal with correct per-phase
  enforcement), and the compound-bash policing (reviewer: `cd && git diff` allowed; `git status && rm -rf`,
  substitution, and redirection all blocked).

Follow-ups: #101 (robust bash policing / bwrap sandbox), #102 (orchestrate engine split + legacy retirement).
