### PR TITLE
Workflow governance: bind workflow_start callers + L1 conformance checker + cleanup

### DIFF
--- a/lib/conformance.py
+++ b/lib/conformance.py
@@ -1,0 +1,121 @@
+"""Static workflow-governance conformance checks (Layer 1 of the conformance harness, #104).
+
+Verifies — WITHOUT the daemon — that each workflow's declared governance is actually
+*enforceable*: the three config sources have to agree.
+
+  * config/workflows/<wf>.yaml         — declared intent (the phases of the workflow)
+  * config/permissions.yaml workflows  — the L1 (workflow/phase) enforcement layer
+  * lib/permission_query.py _KNOWN_WORKFLOWS — the recognition gate
+
+Why it matters: PermissionChecker.check resolves a cascade
+(superblock -> workflows[wf][phase] -> agents[type] -> roles -> global -> default-deny),
+where L1 is `if workflow in wf_config and phase in wf_config[workflow]`. A workflow that
+declares phases but is missing from _KNOWN_WORKFLOWS, or has no workflows[<wf>] block in
+permissions.yaml, never reaches its L1 layer — the phase restrictions silently fall through
+to the agent-type/role/global layers (fail-open). This check flags that statically.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+_REPO = Path(__file__).resolve().parent.parent
+_WORKFLOWS_DIR = _REPO / "config" / "workflows"
+_PERMISSIONS = _REPO / "config" / "permissions.yaml"
+_PERMISSION_QUERY = _REPO / "lib" / "permission_query.py"
+
+
+@dataclass
+class WorkflowConformance:
+    """Static governance-enforceability report for one workflow YAML."""
+    name: str
+    known: bool                                  # listed in _KNOWN_WORKFLOWS
+    has_perms_block: bool                        # has a workflows[name] block in permissions.yaml
+    yaml_phases: list = field(default_factory=list)
+    perms_phases: list = field(default_factory=list)
+    missing_phases: list = field(default_factory=list)   # declared in YAML, absent at L1
+    extra_phases: list = field(default_factory=list)      # present at L1, not declared in YAML
+    fail_open: bool = False                      # declares phases but L1 is unreachable/incomplete
+    notes: list = field(default_factory=list)
+
+
+def _load_known_workflows() -> set:
+    m = re.search(r"_KNOWN_WORKFLOWS\s*=\s*\[(.*?)\]", _PERMISSION_QUERY.read_text(), re.S)
+    return set(re.findall(r'"([^"]+)"', m.group(1))) if m else set()
+
+
+def _load_workflow_yamls() -> dict:
+    out = {}
+    for path in sorted(_WORKFLOWS_DIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text())
+        if not isinstance(data, dict) or "name" not in data:
+            continue
+        out[data["name"]] = [
+            p["name"] for p in data.get("phases", [])
+            if isinstance(p, dict) and "name" in p
+        ]
+    return out
+
+
+def _load_permissions_workflows() -> dict:
+    data = yaml.safe_load(_PERMISSIONS.read_text()) or {}
+    wf = data.get("workflows", {}) or {}
+    return {name: list(block.keys()) for name, block in wf.items() if isinstance(block, dict)}
+
+
+def analyze() -> dict:
+    """Return {'workflows': [WorkflowConformance...], 'phantom_known': [names...]}.
+
+    phantom_known = entries in _KNOWN_WORKFLOWS that have no workflow YAML.
+    """
+    known = _load_known_workflows()
+    yamls = _load_workflow_yamls()
+    perms = _load_permissions_workflows()
+
+    reports = []
+    for name, yaml_phases in sorted(yamls.items()):
+        is_known = name in known
+        perms_phases = perms.get(name)
+        has_block = perms_phases is not None
+        missing = [ph for ph in yaml_phases if ph not in (perms_phases or [])]
+        extra = [ph for ph in (perms_phases or []) if ph not in yaml_phases]
+        fail_open = (not is_known) or (not has_block) or bool(missing)
+        notes = []
+        if not is_known:
+            notes.append("absent from _KNOWN_WORKFLOWS -> not recognized at runtime (fail-open)")
+        if not has_block:
+            notes.append(f"no workflows['{name}'] block in permissions.yaml -> L1 layer skipped (fail-open)")
+        if missing:
+            notes.append(f"phases declared in YAML but absent at L1: {missing}")
+        if extra:
+            notes.append(f"phases enforced at L1 but not declared in YAML: {extra}")
+        reports.append(WorkflowConformance(
+            name=name, known=is_known, has_perms_block=has_block,
+            yaml_phases=yaml_phases, perms_phases=perms_phases or [],
+            missing_phases=missing, extra_phases=extra,
+            fail_open=fail_open, notes=notes,
+        ))
+
+    phantom_known = sorted(known - set(yamls))
+    return {"workflows": reports, "phantom_known": phantom_known}
+
+
+def _main() -> None:
+    result = analyze()
+    print("Workflow governance conformance (static):\n")
+    for r in result["workflows"]:
+        flag = "FAIL-OPEN" if r.fail_open else "ok"
+        print(f"  [{flag:9}] {r.name}")
+        print(f"             known={r.known}  perms_block={r.has_perms_block}")
+        for note in r.notes:
+            print(f"             - {note}")
+    if result["phantom_known"]:
+        print(f"\n  _KNOWN_WORKFLOWS entries with no workflow YAML: {result['phantom_known']}")
+
+
+if __name__ == "__main__":
+    _main()

--- a/lib/controller.py
+++ b/lib/controller.py
@@ -202,7 +202,7 @@ class Controller:
             elif prefix == "router":
                 raw_result = self._handle_router(tool_name, clean_args)
             elif prefix == "workflow":
-                raw_result = self._handle_workflow(tool_name, clean_args)
+                raw_result = self._handle_workflow(tool_name, clean_args, agent_info)
             else:
                 raw_result = self._handle_backend(prefix, tool_name, clean_args)
         except PermissionDeniedError:
@@ -733,9 +733,12 @@ class Controller:
 
     # --- Workflow state operations ---
 
-    def _handle_workflow(self, tool_name: str, args: dict) -> Any:
+    def _handle_workflow(self, tool_name: str, args: dict, agent_info=None) -> Any:
+        # workflow_start binds the calling agent to the workflow it starts, so
+        # the caller is actually governed by it (not its stale prior binding).
+        if tool_name == "workflow_start":
+            return self._wf_start(args, agent_info)
         dispatch = {
-            "workflow_start": self._wf_start,
             "workflow_stop": self._wf_stop,
             "workflow_is_active": self._wf_is_active,
             "workflow_get_state": self._wf_get_state,
@@ -753,7 +756,7 @@ class Controller:
             raise RouterError(f"Unknown workflow tool: {tool_name}")
         return handler(args)
 
-    def _wf_start(self, args: dict) -> dict:
+    def _wf_start(self, args: dict, agent_info=None) -> dict:
         wf_id = args.get("workflow_id", "")
         with self._state_lock:
             if wf_id in self._workflow_state:
@@ -771,6 +774,13 @@ class Controller:
             clean["active_agents"] = {}
             clean["phase"] = config.initial_phase if config else ""
             self._workflow_state[wf_id] = clean
+            # Bind the caller to the workflow it just started so the permission
+            # layer + propagate_phase govern it; without this the caller keeps
+            # its stale session-start binding and never follows this workflow.
+            if agent_info is not None and clean["phase"]:
+                self.permissions.update_agent_phase(
+                    agent_info.agent_id, wf_id, clean["phase"]
+                )
             self.data.record_event({
                 "tool": "workflow__workflow_start",
                 "backend": "workflow",

--- a/lib/permission_query.py
+++ b/lib/permission_query.py
@@ -11,7 +11,7 @@ from permission_store import PermissionStore
 
 
 # Known workflow IDs to check when no specific ID given
-_KNOWN_WORKFLOWS = ["iterate", "debug", "pr_comment", "implementer", "simple", "develop", "experiment", "orchestrate"]
+_KNOWN_WORKFLOWS = ["iterate", "debug", "pr_comment", "simple", "develop", "experiment", "orchestrate"]
 
 
 def get_active_workflow_id() -> Optional[str]:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -833,3 +833,19 @@ class TestTelemetry:
         events = ctrl.data.query_events(tool="native__read_file")
         assert len(events) >= 1
         assert events[0].status == "success"
+
+
+class TestWorkflowStartBinding:
+    def test_workflow_start_binds_caller(self, ctrl_with_config):
+        c = ctrl_with_config
+        agent = c.permissions.register_agent("orch", "pm")
+        assert agent.workflow != "iterate"  # not bound to it yet
+        c._wf_start({"workflow_id": "iterate"}, agent)
+        bound = c.permissions.get_agent("orch")
+        assert bound.workflow == "iterate"
+        assert bound.phase == "test_writing"  # iterate's initial phase
+
+    def test_workflow_start_without_caller_is_safe(self, ctrl_with_config):
+        c = ctrl_with_config
+        c._wf_start({"workflow_id": "iterate"}, None)  # no caller -> no binding, no crash
+        assert "iterate" in c._workflow_state


### PR DESCRIPTION
Three related pieces of workflow-governance work from one session: fix the binding that stopped started workflows from governing their caller, add the first slice of the L1 conformance harness, and a small config cleanup it surfaced.

## 1. Fix — bind the caller on `workflow_start` (`5634a6e`)
`_wf_start` created the workflow state but never bound the caller, so an agent that *started* a workflow kept its stale session-start binding and was never governed by the workflow it just started. Threads `agent_info` through `handle_call → _handle_workflow → _wf_start` and calls `permissions.update_agent_phase(agent_id, wf_id, initial_phase)`. New tests: `TestWorkflowStartBinding` (binds caller to the initial phase; no-caller path is safe).

## 2. Add — static conformance checker, #104 Slice 1 (`2a52327`)
`lib/conformance.py` verifies — without the daemon — that each workflow's three config layers agree:
- `config/workflows/<wf>.yaml` (declared phases)
- `config/permissions.yaml` `workflows[wf]` (the L1 enforcement layer in the cascade)
- `lib/permission_query.py:_KNOWN_WORKFLOWS` (recognition gate)

It flags **fail-open** workflows — declared phases with no enforceable L1 block, which silently fall through to agent-type/role/global. On its first run it found `pr_comment` (fully fail-open, WIP), `debug` (missing its YAML), `develop`/`experiment` terminal-phase gaps, and the stale `iterate` `orchestrate` phase.

## 3. Cleanup — drop phantom `implementer` from `_KNOWN_WORKFLOWS` (`680017c`)
`implementer` is an agent-type, not a workflow (no YAML, no permissions block), so it only made `get_active_workflow_id()` probe a workflow nothing starts. **Deliberately left alone:** the `orchestrate` phase under `workflows['iterate']` looks like dead config but is the pre-#102 orchestrator path, still exercised by `tests/test_implementer_only_enforcement.py` — it rides with the #102 split, not this PR.

## Deferred / follow-ups
- `iterate` `orchestrate` phase → #102
- `debug` needs a workflow YAML (real workflow, currently fail-open on several phases)
- `pr_comment` stays WIP; its orphan `pr_review` permissions block governs nothing
- Conformance Slice 2 (live scripted driver against the daemon) is next

## Testing
Full suite green except 3 **pre-existing** `test_paths.py` failures (hard-coded-path lint flagging `test_bash_command_policing.py` + `.venv/` files — present on `master`, unrelated). No new failures.
