### PR TITLE
fix: hooks.json portability + test_paths scan hygiene

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/fearsidhe/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0/hooks/agent-dispatch.py",
+            "command": "python3 ${AGENT_SWARM_ROOT}/hooks/agent-dispatch.py",
             "timeout": 5
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/fearsidhe/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0/hooks/agent-dispatch.py",
+            "command": "python3 ${AGENT_SWARM_ROOT}/hooks/agent-dispatch.py",
             "timeout": 5
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/fearsidhe/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0/hooks/native-tool-blocking.py",
+            "command": "python3 ${AGENT_SWARM_ROOT}/hooks/native-tool-blocking.py",
             "timeout": 3
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/fearsidhe/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0/hooks/pre-compacting.py",
+            "command": "python3 ${AGENT_SWARM_ROOT}/hooks/pre-compacting.py",
             "timeout": 5
           }
         ]
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/fearsidhe/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0/hooks/session-start.py",
+            "command": "python3 ${AGENT_SWARM_ROOT}/hooks/session-start.py",
             "timeout": 10
           }
         ]
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/fearsidhe/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0/hooks/session-end.py",
+            "command": "python3 ${AGENT_SWARM_ROOT}/hooks/session-end.py",
             "timeout": 30
           }
         ]

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -264,7 +264,7 @@ class TestPythonFilesNoHardcodedPluginPaths:
         files = []
         for py_file in PROJECT_ROOT.rglob("*.py"):
             rel = py_file.relative_to(PROJECT_ROOT)
-            skip_dirs = {"__pycache__", ".worktrees", "docs"}
+            skip_dirs = {"__pycache__", ".worktrees", "docs", ".venv", ".git", "tests"}
             if any(part in skip_dirs for part in rel.parts):
                 continue
             files.append(py_file)


### PR DESCRIPTION
Fixes the 3 long-standing `test_paths.py` failures — and the first one was a real portability bug, not test noise.

## `hooks.json` — real portability bug
Every hook command was hardcoded to `python3 /home/<user>/.claude/plugins/cache/fearsidhe-plugins/agent-swarm/1.0.0/hooks/...`. The cache-resolved path had leaked back into the committed dev source, so the plugin would not run for any other user, machine, or version. Restored the `${AGENT_SWARM_ROOT}` placeholder (the form `.mcp.json` already uses); `bin/sync-to-cache` resolves it to the absolute cache path when syncing dev → cache, so the cache copy still works.

## `test_paths.py` — scan hygiene
`TestPythonFilesNoHardcodedPluginPaths`'s fixture `rglob("*.py")`'d the whole tree, skipping only `__pycache__`/`.worktrees`/`docs` — so it linted third-party source under `.venv/` (pytest/coverage) and flagged their example paths, and it didn't honor its own docstring ("excluding tests"). Now skips `.venv`/`.git`/`tests`.

## Testing
Full suite green: 1390 passed, 275 skipped, 0 failed. The 3 `test_paths.py` failures are fixed, not dismissed.
