### PR TITLE
fix: subagent onboarding (--caller-id) + router-correct spawn docs

### DIFF
--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -7,6 +7,21 @@ max_output_chars: 5000
 can_write_files: true
 ---
 
+## Operating Protocol (read this first)
+
+You have exactly one tool: `Bash`. Every real action runs through `mcp-call`:
+
+```
+mcp-call --caller-id=<YOUR_AGENT_ID> <tool> '<json_args>'
+```
+
+- `--caller-id` is **required on every call** — without it the router denies the call. **Your agent ID is in your task prompt** (look for "agent_id" / "caller-id"). Use it as the value.
+- If your task prompt did not give you an agent ID, **stop and report "not onboarded"** — do not invent an ID or call tools blindly.
+- Common calls:
+  - `mcp-call --caller-id=<id> native__read_file '{"file_path": "/abs/path"}'`
+  - `mcp-call --caller-id=<id> native__bash '{"command": "pytest -v tests/"}'`
+  - `mcp-call --caller-id=<id> serena__replace_content '{"relative_path": "src/foo.py", "needle": "old", "repl": "new", "mode": "literal"}'`
+
 <constraints>
 - Check `find_referencing_symbols` before modifying any function
 - Verify with `pytest` (show output) + `ruff check` before completion

--- a/hooks/native-tool-blocking.py
+++ b/hooks/native-tool-blocking.py
@@ -136,7 +136,10 @@ def main():
         if agent_id:
             block(
                 f"[SUBAGENT BLOCKED] '{tool_name}' not allowed. "
-                f"Use mcp-call via Bash: mcp-call {analogue} '<json_args>'"
+                f"Re-run it through mcp-call WITH your --caller-id. You are already "
+                f"registered — do NOT call register. Your agent id is in your task "
+                f"prompt; use it as the caller-id. "
+                f"Example: mcp-call --caller-id=<your-agent-id> {analogue} '<json_args>'"
             )
         else:
             block(f"[BLOCKED] '{tool_name}' blocked. Use mcp__router__{analogue} instead.")

--- a/hooks/native-tool-blocking.py
+++ b/hooks/native-tool-blocking.py
@@ -137,9 +137,8 @@ def main():
             block(
                 f"[SUBAGENT BLOCKED] '{tool_name}' not allowed. "
                 f"Re-run it through mcp-call WITH your --caller-id. You are already "
-                f"registered — do NOT call register. Your agent id is in your task "
-                f"prompt; use it as the caller-id. "
-                f"Example: mcp-call --caller-id=<your-agent-id> {analogue} '<json_args>'"
+                f"registered — do NOT call register. "
+                f"Example: mcp-call --caller-id={agent_id} {analogue} '<json_args>'"
             )
         else:
             block(f"[BLOCKED] '{tool_name}' blocked. Use mcp__router__{analogue} instead.")

--- a/lib/daemon_client.py
+++ b/lib/daemon_client.py
@@ -239,7 +239,11 @@ class DaemonClient:
                 and method not in _NO_REGISTER
                 and not method.startswith(("workflow/", "agent/"))
                 and not is_bootstrap_tool):
-            raise RuntimeError("Must call register() before tool calls")
+            raise RuntimeError(
+                "This mcp-call has no --caller-id, so it has no agent identity. "
+                "Re-run it with --caller-id=<your agent id> (it is in your task "
+                "prompt); mcp-call registers you automatically. Do not call register."
+            )
 
         self._request_id += 1
         request = {

--- a/skills/spawn/SKILL.md
+++ b/skills/spawn/SKILL.md
@@ -16,11 +16,11 @@ call tools via `mcp-call --caller-id=<its id>`. Two steps, never skip either:
    ```
    Task(
      subagent_type="<role>",
-     prompt=reg.briefing + "\n\n" + <task description + working dir>,
+     prompt=reg["briefing"] + "\n\n" + <task description + working dir>,
    )
    ```
 
-`reg.briefing` carries the agent's id, the `mcp-call`/`--caller-id` convention,
+`reg["briefing"]` carries the agent's id, the `mcp-call`/`--caller-id` convention,
 its role rules, and its workflow phases. **Without it the agent has no identity
 and its tool calls are denied.**
 

--- a/skills/spawn/SKILL.md
+++ b/skills/spawn/SKILL.md
@@ -1,21 +1,48 @@
 ---
 name: spawn
-description: How to spawn subagents correctly. Use this reference when you need to delegate work to a specialized agent.
+description: How to spawn subagents correctly under the router. Use when delegating work to a specialized agent.
 ---
+
+## How to Spawn (REQUIRED)
+
+Every subagent runs under the router: its only tool is `Bash(mcp*)`, so it must
+call tools via `mcp-call --caller-id=<its id>`. Two steps, never skip either:
+
+1. **Register** the agent to get its id + role/workflow briefing:
+   ```
+   reg = register_agent(agent_id="<task-id>", agent_type="<role>", workflow_id="<workflow>")
+   ```
+2. **Prepend the briefing** to the prompt and spawn with the role as `subagent_type`:
+   ```
+   Task(
+     subagent_type="<role>",
+     prompt=reg.briefing + "\n\n" + <task description + working dir>,
+   )
+   ```
+
+`reg.briefing` carries the agent's id, the `mcp-call`/`--caller-id` convention,
+its role rules, and its workflow phases. **Without it the agent has no identity
+and its tool calls are denied.**
+
+Do **NOT** spawn native subagent types (`Explore` / `general-purpose` / `Plan`).
+They use Claude Code's built-in tools, which the router blocks — they cannot
+reach `mcp-call` correctly and will flail.
 
 ## Agent Selection
 
-| Need | Agent | Model | subagent_type |
-|------|-------|-------|---------------|
-| Find code/files | explorer | haiku | Explore |
-| Web/doc research | researcher | haiku | general-purpose |
-| Plan changes | architect | sonnet | Plan |
-| Write code | implementer | sonnet | general-purpose |
-| Review changes | reviewer | sonnet | general-purpose |
-| Fix bugs | debugger | sonnet | general-purpose |
-| Git operations | git-agent | haiku | general-purpose |
+`agent_type` and `subagent_type` are the same role name.
 
-## Prompt Structure (REQUIRED)
+| Need | Role | Model |
+|------|------|-------|
+| Find code/files | explorer | haiku |
+| Web/doc research | researcher | haiku |
+| Plan changes | architect | sonnet |
+| Write code | implementer | sonnet |
+| Review changes | reviewer | sonnet |
+| Fix bugs | debugger | sonnet |
+| Git operations | git-agent | haiku |
+
+## Prompt Structure (after the briefing)
 1. **Task** -- one clear objective
 2. **Scope** -- exclusive file list (no other agent touches these)
 3. **Output** -- specific return format
@@ -25,11 +52,11 @@ description: How to spawn subagents correctly. Use this reference when you need 
 Never embed file content in prompts. Give intent + verification criteria.
 
 ## Model Selection
-- Can downgrade (sonnet -> haiku). Never upgrade without asking orchestrator.
+- Can downgrade (sonnet -> haiku). Never upgrade without asking the orchestrator.
 - Default to cheaper when unsure.
 
 ## Parallel Spawning
-Independent tasks -> multiple Task calls in ONE message block.
+Independent tasks -> register + `Task` each, multiple in ONE message block.
 Max 5 parallel agents.
 
 ## File Ownership
@@ -37,6 +64,8 @@ Each file modified by AT MOST one concurrent agent.
 Overlap -> serialize with `depends_on`, or merge into one task.
 
 ## Anti-Patterns
+- Don't spawn native subagent types (`Explore`/`general-purpose`/`Plan`) -- no router access
+- Don't spawn without registering and prepending the briefing
 - Don't spawn for one-liner tasks or <3 tool calls
 - Don't use opus for subagents (orchestrator only)
 - Don't give vague prompts ("look around")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -284,7 +284,7 @@ class TestDaemonClientConnection:
     def test_must_register_before_calls(self, mock_daemon):
         c = DaemonClient(port=mock_daemon.port, timeout=5.0)
         c.connect()
-        with pytest.raises(RuntimeError, match="Must call register"):
+        with pytest.raises(RuntimeError, match="caller-id"):
             c.call_tool("native__bash", {"command": "ls"})
         c.close()
 

--- a/tests/test_session_start_bootstrap.py
+++ b/tests/test_session_start_bootstrap.py
@@ -6,7 +6,7 @@ Bug A. `register_main_agent` calls `dc.call_tool("router__register_agent", ...)`
 which sends JSON-RPC method `tools/call`. The DaemonClient guard in
 `_call` requires `register()` first for any method that isn't in the
 narrow exempt set, so the bootstrap registration always raises
-`RuntimeError("caller-id() before tool calls")`. The hook
+`RuntimeError("Must call register() before tool calls")`. The hook
 swallows it and the main agent never gets phase-bound.
 
 Bug B. `auto_start_workflow` and `register_main_agent` both race the

--- a/tests/test_session_start_bootstrap.py
+++ b/tests/test_session_start_bootstrap.py
@@ -6,7 +6,7 @@ Bug A. `register_main_agent` calls `dc.call_tool("router__register_agent", ...)`
 which sends JSON-RPC method `tools/call`. The DaemonClient guard in
 `_call` requires `register()` first for any method that isn't in the
 narrow exempt set, so the bootstrap registration always raises
-`RuntimeError("Must call register() before tool calls")`. The hook
+`RuntimeError("caller-id() before tool calls")`. The hook
 swallows it and the main agent never gets phase-bound.
 
 Bug B. `auto_start_workflow` and `register_main_agent` both race the
@@ -93,7 +93,7 @@ class TestDaemonClientBootstrapToolExemption:
                 "roles": ["editor", "shell_full"],
             })
         except RuntimeError as e:
-            assert "Must call register" not in str(e), (
+            assert "caller-id" not in str(e), (
                 "Guard still blocks router__register_agent before register()"
             )
 
@@ -106,14 +106,14 @@ class TestDaemonClientBootstrapToolExemption:
                 "phase": "plan",
             })
         except RuntimeError as e:
-            assert "Must call register" not in str(e), (
+            assert "caller-id" not in str(e), (
                 "Guard still blocks router__update_agent_phase before register()"
             )
 
     def test_non_bootstrap_tool_still_guarded(self):
         """Guard must remain in place for any tool that isn't part of bootstrap."""
         dc = self._client_with_fake_sock()
-        with pytest.raises(RuntimeError, match="Must call register"):
+        with pytest.raises(RuntimeError, match="caller-id"):
             dc.call_tool("router__ping", {})
 
 

--- a/tests/test_session_start_bootstrap.py
+++ b/tests/test_session_start_bootstrap.py
@@ -93,9 +93,9 @@ class TestDaemonClientBootstrapToolExemption:
                 "roles": ["editor", "shell_full"],
             })
         except RuntimeError as e:
-            assert "caller-id" not in str(e), (
-                "Guard still blocks router__register_agent before register()"
-            )
+            if "caller-id" in str(e):
+                pytest.fail("Guard still blocks router__register_agent before register()")
+            raise
 
     def test_router_update_agent_phase_bypasses_guard(self):
         dc = self._client_with_fake_sock()
@@ -106,9 +106,9 @@ class TestDaemonClientBootstrapToolExemption:
                 "phase": "plan",
             })
         except RuntimeError as e:
-            assert "caller-id" not in str(e), (
-                "Guard still blocks router__update_agent_phase before register()"
-            )
+            if "caller-id" in str(e):
+                pytest.fail("Guard still blocks router__update_agent_phase before register()")
+            raise
 
     def test_non_bootstrap_tool_still_guarded(self):
         """Guard must remain in place for any tool that isn't part of bootstrap."""


### PR DESCRIPTION
Lands the subagent-onboarding fix that was stranded on a local branch (`feat/briefing-bootstrap`) — the original "agents can't start in a workflow" fix — rebased onto current `master` with the already-merged security commit dropped.

## What & why
Subagents restricted to `Bash(mcp*)` followed the native-tool-blocking redirect verbatim, omitted `--caller-id`, hit the no-caller-id error, then tried to self-register a nonexistent `register` tool — and never got phase-bound. Both onboarding messages now point at `--caller-id` and state the agent is already registered.

- `hooks/native-tool-blocking.py`: the Rule 3 block message now includes `--caller-id`, "already registered / do NOT call register", and an example.
- `lib/daemon_client.py`: the no-caller-id `RuntimeError` guides `--caller-id` instead of the old "Must call register()" message (4 test assertions updated to match).
- `agents/implementer.md`: an "Operating Protocol (read this first)" bootstrap block (reinforcement — agent definitions are session-loaded, so unvalidated in-session).
- `skills/spawn/SKILL.md`: rewritten to teach the router-correct `register → prepend briefing → Task(subagent_type=<role>)` pattern and drop the native subagent types that can't reach the router.

Measured (from the original commit): 5/5 fresh agents given only an id formed the correct `mcp-call --caller-id` call; pre-fix the same setup flailed.

## Notes
- Dropped the stacked `88c204c` (security/newline-injection) — byte-identical to master's `153266b`, already merged via #103.
- Fixed a docstring artifact in `tests/test_session_start_bootstrap.py` that a blind find-replace had mangled into `RuntimeError("caller-id() before tool calls")`.
- Out of scope (left for a focused cleanup): `tests/test_integration.py` has 3 pre-existing ruff findings (unused `time`/`patch` imports, an unused `args` in a mock handler) on `master` — not touched by this PR's commits.

## Testing
Full suite green: 1430 passed, 275 skipped, 0 failed.
