### PR TITLE
feat(telemetry): attribute every event to caller workflow + phase

### DIFF
--- a/lib/controller.py
+++ b/lib/controller.py
@@ -250,6 +250,8 @@ class Controller:
             "session_id": agent_info.session_id if agent_info else "",
             "agent_id": agent_info.agent_id if agent_info else "",
             "agent_type": agent_info.agent_type if agent_info else "",
+            "workflow_id": (agent_info.workflow or "") if agent_info else "",
+            "phase": (agent_info.phase or "") if agent_info else "",
         })
 
         return result
@@ -275,6 +277,8 @@ class Controller:
                 "session_id": agent_info.session_id if agent_info else "",
                 "agent_id": agent_info.agent_id if agent_info else "",
                 "agent_type": agent_info.agent_type if agent_info else "",
+                "workflow_id": (agent_info.workflow or "") if agent_info else "",
+                "phase": (agent_info.phase or "") if agent_info else "",
             })
         except Exception:
             log.warning("Failed to record error event for %s", tool)

--- a/lib/datastore.py
+++ b/lib/datastore.py
@@ -35,6 +35,7 @@ class EventRecord:
     output_tokens: int = 0
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
+    phase: str = ""
 
 
 @dataclass
@@ -76,7 +77,8 @@ CREATE TABLE IF NOT EXISTS events (
     input_tokens INTEGER DEFAULT 0,
     output_tokens INTEGER DEFAULT 0,
     cache_read_tokens INTEGER DEFAULT 0,
-    cache_creation_tokens INTEGER DEFAULT 0
+    cache_creation_tokens INTEGER DEFAULT 0,
+    phase TEXT DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
@@ -90,8 +92,8 @@ INSERT INTO events (
     session_id, agent_id, agent_type, workflow_id,
     error_type, was_summarized, original_size, summary_size,
     input_tokens, output_tokens, cache_read_tokens,
-    cache_creation_tokens
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    cache_creation_tokens, phase
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 _SELECT_COLUMNS = """\
@@ -99,7 +101,7 @@ timestamp, tool, backend, status, duration_ms,
     session_id, agent_id, agent_type, workflow_id,
     error_type, was_summarized, original_size, summary_size,
     input_tokens, output_tokens, cache_read_tokens,
-    cache_creation_tokens"""
+    cache_creation_tokens, phase"""
 
 
 class DataStore:
@@ -120,6 +122,16 @@ class DataStore:
         self._conn.execute("PRAGMA busy_timeout=5000")
         self._lock = threading.RLock()
         self._conn.executescript(_CREATE_SCHEMA)
+        self._migrate()
+
+    def _migrate(self) -> None:
+        """Add columns introduced after a DB was first created (idempotent)."""
+        with self._lock:
+            cols = {r[1] for r in self._conn.execute("PRAGMA table_info(events)")}
+            if "phase" not in cols:
+                self._conn.execute(
+                    "ALTER TABLE events ADD COLUMN phase TEXT DEFAULT ''"
+                )
 
     def record_event(self, event: dict) -> None:
         """Insert a single event.
@@ -153,6 +165,7 @@ class DataStore:
                     event.get("output_tokens", 0),
                     event.get("cache_read_tokens", 0),
                     event.get("cache_creation_tokens", 0),
+                    event.get("phase", ""),
                 ),
             )
             self._conn.commit()
@@ -296,4 +309,5 @@ class DataStore:
             output_tokens=row[14],
             cache_read_tokens=row[15],
             cache_creation_tokens=row[16],
+            phase=row[17],
         )

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 
 import pytest
 
-from lib.datastore import DataStore, DaySummary, EventRecord, ToolSummary
+from lib.datastore import DataStore, EventRecord
 
 
 @pytest.fixture
@@ -199,3 +199,57 @@ class TestDataStoreLifecycle:
         mode = s._conn.execute("PRAGMA journal_mode").fetchone()[0]
         assert mode == "wal"
         s.close()
+
+
+def test_migrate_adds_phase_column_to_pre_phase_db(tmp_path):
+    """A pre-phase events table gains the column via _migrate()'s ALTER branch.
+
+    The fresh-DB schema already includes `phase`, so _migrate() skips the ALTER
+    on a new DB; this exercises the backward-compat path for an existing DB.
+    """
+    import sqlite3
+
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            tool TEXT NOT NULL,
+            backend TEXT NOT NULL,
+            status TEXT NOT NULL,
+            duration_ms INTEGER DEFAULT 0,
+            session_id TEXT DEFAULT '',
+            agent_id TEXT DEFAULT '',
+            agent_type TEXT DEFAULT '',
+            workflow_id TEXT DEFAULT '',
+            error_type TEXT DEFAULT '',
+            was_summarized INTEGER DEFAULT 0,
+            original_size INTEGER DEFAULT 0,
+            summary_size INTEGER,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_creation_tokens INTEGER DEFAULT 0
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO events (timestamp, tool, backend, status) "
+        "VALUES ('2026-01-01T00:00:00Z', 'legacy_tool', 'native', 'success')"
+    )
+    conn.commit()
+    conn.close()
+
+    # Opening the store runs _migrate(), which must ALTER the phase column in.
+    store = DataStore(db_path)
+    try:
+        cols = {r[1] for r in store._conn.execute("PRAGMA table_info(events)")}
+        assert "phase" in cols, "migration did not add the phase column to a pre-phase DB"
+        # the pre-existing row survives and defaults phase to ''
+        events = store.query_events(tool="legacy_tool")
+        assert len(events) == 1
+        assert events[0].phase == ""
+    finally:
+        store.close()

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -39,6 +39,12 @@ class TestRecordAndQuery:
         assert events[0].backend == "native"
         assert isinstance(events[0], EventRecord)
 
+    def test_workflow_and_phase_captured(self, store):
+        store.record_event(_make_event(workflow_id="develop", phase="implement"))
+        events = store.get_session_events("sess-1")
+        assert events[0].workflow_id == "develop"
+        assert events[0].phase == "implement"
+
     def test_defaults(self, store):
         store.record_event({"tool": "x", "backend": "y", "status": "success"})
         events = store.query_events(tool="x")


### PR DESCRIPTION
Lands the per-event workflow/phase attribution stranded on a local branch (`feat/telemetry-attribution`), cherry-picked onto current `master`. The stacked onboarding/spawn commits go separately (onboarding in #110); the stacked security commit is already merged via #103.

## What & why
`handle_call` recorded `agent_id`/`agent_type` but never the caller's workflow or phase, so ~all events in a real session had `workflow_id=''` — making per-run / per-phase compliance unanswerable.

- `lib/controller.py`: stamp `workflow_id` + `phase` (from the resolved `AgentInfo`) on both success **and** error events.
- `lib/datastore.py`: add a `phase` column with an idempotent `_migrate()` ALTER (safe for the existing DB); thread phase through INSERT/SELECT/`record_event`/`_row_to_record`/`EventRecord`.
- `tests/test_datastore.py`: phase round-trip test.

This is the telemetry backbone the L1 conformance harness reads — the live driver (Slice 2) asserts events are stamped with the correct phase.

## Notes
- Pre-existing ruff findings in the touched files (on `master`, not introduced here): `controller.py:497` unused `timed_out`, `test_datastore.py:8` unused `DaySummary`/`ToolSummary` imports. Left for a focused lint cleanup.

## Testing
Full suite green: 1431 passed, 275 skipped, 0 failed (including the new round-trip test).
