### PR TITLE
feat: workflow-run scorer (run_scorer.py) — 3-axis outcome/compliance/cost

### DIFF
--- a/lib/run_scorer.py
+++ b/lib/run_scorer.py
@@ -47,7 +47,12 @@ def _iso_to_ms(ts: Optional[str]) -> Optional[int]:
     if not ts:
         return None
     try:
-        return int(datetime.fromisoformat(ts).timestamp() * 1000)
+        parsed = datetime.fromisoformat(ts)
+        if parsed.tzinfo is None:
+            # A naive timestamp is read as UTC (not host-local) so epoch-ms is
+            # reproducible regardless of where the scorer runs.
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return int(parsed.timestamp() * 1000)
     except (ValueError, TypeError):
         return None
 
@@ -148,7 +153,8 @@ def score_compliance(events: list) -> ComplianceScore:
                 router += 1
         aid = e.get("agent_id") or "(none)"
         seqs.setdefault(aid, []).append(e.get("tool"))
-    violation_rate = (perm + wf) / total if total else 0.0
+    violations = sum(hist.get(name, 0) for name in _VIOLATION_ERRORS)
+    violation_rate = violations / total if total else 0.0
     return ComplianceScore(total_calls=total, errors=errors, permission_denied=perm,
                            workflow_errors=wf, router_errors=router,
                            violation_rate=violation_rate, error_histogram=hist,
@@ -173,7 +179,7 @@ def score_cost(events: list) -> CostScore:
     dur_n = 0
     for e in events:
         d = e.get("duration_ms")
-        if d:
+        if d is not None:
             dur_sum += d
             dur_n += 1
     return CostScore(wallclock_s=wall, duration_ms_sum=dur_sum,
@@ -216,10 +222,14 @@ def derive_window(conn: sqlite3.Connection, workflow_id: str,
     meaningful once controller.record_event tags events with workflow_id.
     """
     if match_prefix:
+        # Escape LIKE metacharacters in the user-supplied id so a literal '_'
+        # or '%' in a workflow_id cannot widen the prefix match.
+        esc = (workflow_id.replace("\\", "\\\\")
+               .replace("%", "\\%").replace("_", "\\_"))
         row = conn.execute(
             "SELECT MIN(timestamp), MAX(timestamp) FROM events "
-            "WHERE workflow_id = ? OR workflow_id LIKE ?",
-            (workflow_id, workflow_id + ":%"),
+            "WHERE workflow_id = ? OR workflow_id LIKE ? ESCAPE '\\'",
+            (workflow_id, esc + ":%"),
         ).fetchone()
     else:
         row = conn.execute(
@@ -265,7 +275,7 @@ def score_run(conn: sqlite3.Connection, start_ms: Optional[int] = None,
     out-of-band timestamps). Output carries a per-phase breakdown so the run is
     sliceable by phase, plus the distinct workflow_ids actually seen in-window.
     """
-    if (start_ms is None or end_ms is None) and workflow_id:
+    if start_ms is None and end_ms is None and workflow_id:
         win = derive_window(conn, workflow_id, match_prefix=match_prefix)
         if win is None:
             raise ValueError(f"no events tagged with workflow_id={workflow_id!r}")
@@ -351,10 +361,13 @@ def main(argv=None):
     args = ap.parse_args(argv)
 
     conn = sqlite3.connect(str(args.db))
-    outcome_md = Path(args.outcome_file).read_text() if args.outcome_file else None
-    rec = score_run(conn, args.start, args.end, workflow_id=args.workflow_id,
-                    match_prefix=args.match_prefix, outcome_md=outcome_md,
-                    model=args.model, label=args.label, workflow=args.workflow)
+    try:
+        outcome_md = Path(args.outcome_file).read_text() if args.outcome_file else None
+        rec = score_run(conn, args.start, args.end, workflow_id=args.workflow_id,
+                        match_prefix=args.match_prefix, outcome_md=outcome_md,
+                        model=args.model, label=args.label, workflow=args.workflow)
+    finally:
+        conn.close()
     if args.no_tool_seq:
         rec["compliance"].pop("tool_sequence", None)
     print(json.dumps(rec, indent=2, default=str))

--- a/lib/run_scorer.py
+++ b/lib/run_scorer.py
@@ -1,0 +1,364 @@
+"""run_scorer — score a workflow run on three independently-grounded axes.
+
+OUTCOME    — did the run meet its declared criterion: tests-pass ratio parsed
+             from the vault run ledger, or check_criteria() recomputed from
+             eval metrics. Recomputing is the point: a workflow's self-declared
+             "success" is never trusted; a claimed-vs-actual mismatch is itself
+             a workflow-quality signal.
+COMPLIANCE — did agents stay inside governance: PermissionDeniedError /
+             WorkflowError counts (governance breaches) + per-agent tool
+             sequence, from the SQLite events DB.
+COST       — wallclock (event timestamps) + summed per-call duration_ms.
+             Token cost is intentionally omitted: controller.record_event does
+             not yet populate the token columns, so all rows read 0 today.
+
+Every axis derives from artifacts that exist NOW — the events DB (compliance,
+cost) and the run ledger (outcome) — so the first scored comparison needs no
+new measured run. check_criteria() is reused from experiment_harness rather
+than reimplemented, keeping outcome scoring identical to what a live
+experiment run would compute.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+try:
+    from experiment_harness import check_criteria
+except ImportError:  # pragma: no cover - allow standalone use without harness
+    check_criteria = None
+
+
+# Error types that mean the model/agent broke a phase rule (vs infra noise like
+# RouterError / RequestTimeoutError, which are not the agent's fault).
+_VIOLATION_ERRORS = {"PermissionDeniedError", "WorkflowError"}
+
+
+# --- timestamp helpers ------------------------------------------------------
+
+def _iso_to_ms(ts: Optional[str]) -> Optional[int]:
+    """Parse an ISO-8601 timestamp to epoch-ms; None if unparseable."""
+    if not ts:
+        return None
+    try:
+        return int(datetime.fromisoformat(ts).timestamp() * 1000)
+    except (ValueError, TypeError):
+        return None
+
+
+def _ms_to_iso(ms: int) -> str:
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+
+
+# --- OUTCOME ----------------------------------------------------------------
+
+@dataclass
+class OutcomeScore:
+    tests_passed: int = 0
+    tests_total: int = 0
+    new_commits: int = 0
+    branches: int = 0
+    pass_ratio: float = 0.0
+    per_branch: list = field(default_factory=list)
+
+
+# | <branch> | <passed>/<total> [✓] | <new commits> | <note> |
+_ROW_RE = re.compile(
+    r"^\|\s*([^|]+?)\s*\|\s*(\d+)\s*/\s*(\d+)[^|]*\|\s*(\d+)\s*\|", re.MULTILINE
+)
+
+
+def parse_outcome_table(markdown: str) -> OutcomeScore:
+    """Parse a run-ledger Outcome table into an OutcomeScore.
+
+    Rows look like: ``| 02-autograd | 36/36 ✓ | 1 | note |``. The header
+    (``| Branch | Tests | ...``) and separator (``|---|---|``) rows do not
+    match the X/Y + integer-commits shape and are skipped naturally.
+    """
+    passed = total = commits = 0
+    per_branch = []
+    for m in _ROW_RE.finditer(markdown):
+        branch = m.group(1).strip()
+        p, t, c = int(m.group(2)), int(m.group(3)), int(m.group(4))
+        if branch.lower() == "branch":
+            continue
+        passed += p
+        total += t
+        commits += c
+        per_branch.append({"branch": branch, "tests_passed": p,
+                           "tests_total": t, "new_commits": c})
+    ratio = passed / total if total else 0.0
+    return OutcomeScore(tests_passed=passed, tests_total=total, new_commits=commits,
+                        branches=len(per_branch), pass_ratio=ratio, per_branch=per_branch)
+
+
+def recompute_outcome(criteria: list, metrics: dict):
+    """Independently recompute pass/fail from eval metrics (claimed-vs-actual).
+
+    Thin wrapper over experiment_harness.check_criteria so the scorer never
+    trusts a workflow's self-declared success. Returns a CriteriaResult.
+    """
+    if check_criteria is None:
+        raise RuntimeError("experiment_harness.check_criteria unavailable on path")
+    return check_criteria(criteria, metrics)
+
+
+# --- COMPLIANCE -------------------------------------------------------------
+
+@dataclass
+class ComplianceScore:
+    total_calls: int = 0
+    errors: int = 0
+    permission_denied: int = 0
+    workflow_errors: int = 0
+    router_errors: int = 0
+    violation_rate: float = 0.0
+    error_histogram: dict = field(default_factory=dict)
+    tool_sequence: dict = field(default_factory=dict)
+
+
+def score_compliance(events: list) -> ComplianceScore:
+    """Score governance compliance from event rows.
+
+    violation_rate counts genuine governance breaches (PermissionDeniedError +
+    WorkflowError) over total calls — RouterError / timeouts are infra noise
+    and excluded from the rate (but still surfaced in error_histogram).
+    """
+    total = len(events)
+    errors = perm = wf = router = 0
+    hist: dict = {}
+    seqs: dict = {}
+    for e in sorted(events, key=lambda r: r.get("timestamp") or ""):
+        et = e.get("error_type")
+        if e.get("status") == "error" or et:
+            errors += 1
+        if et:
+            hist[et] = hist.get(et, 0) + 1
+            if et == "PermissionDeniedError":
+                perm += 1
+            elif et == "WorkflowError":
+                wf += 1
+            elif et == "RouterError":
+                router += 1
+        aid = e.get("agent_id") or "(none)"
+        seqs.setdefault(aid, []).append(e.get("tool"))
+    violation_rate = (perm + wf) / total if total else 0.0
+    return ComplianceScore(total_calls=total, errors=errors, permission_denied=perm,
+                           workflow_errors=wf, router_errors=router,
+                           violation_rate=violation_rate, error_histogram=hist,
+                           tool_sequence=seqs)
+
+
+# --- COST -------------------------------------------------------------------
+
+@dataclass
+class CostScore:
+    wallclock_s: float = 0.0
+    duration_ms_sum: int = 0
+    calls_with_duration: int = 0
+    total_calls: int = 0
+
+
+def score_cost(events: list) -> CostScore:
+    """Score cost: wallclock (first->last event) + summed per-call duration_ms."""
+    ms_values = [m for m in (_iso_to_ms(e.get("timestamp")) for e in events) if m is not None]
+    wall = (max(ms_values) - min(ms_values)) / 1000 if len(ms_values) >= 2 else 0.0
+    dur_sum = 0
+    dur_n = 0
+    for e in events:
+        d = e.get("duration_ms")
+        if d:
+            dur_sum += d
+            dur_n += 1
+    return CostScore(wallclock_s=wall, duration_ms_sum=dur_sum,
+                     calls_with_duration=dur_n, total_calls=len(events))
+
+
+# --- window query -----------------------------------------------------------
+
+def query_window(conn: sqlite3.Connection, start_ms: int, end_ms: int) -> list:
+    """Return event rows (as dicts) whose timestamp falls within [start_ms, end_ms].
+
+    SQL bounds are loosened by 1s and the precise filter is applied in Python,
+    so microsecond/format quirks in the text timestamps can never drop a valid
+    in-window row.
+    """
+    lo = _ms_to_iso(start_ms - 1000)
+    hi = _ms_to_iso(end_ms + 1000)
+    cur = conn.execute(
+        "SELECT * FROM events WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp",
+        (lo, hi),
+    )
+    cols = [d[0] for d in cur.description]
+    rows = []
+    for r in cur.fetchall():
+        row = dict(zip(cols, r))
+        ms = _iso_to_ms(row.get("timestamp"))
+        if ms is not None and start_ms <= ms <= end_ms:
+            rows.append(row)
+    return rows
+
+
+def derive_window(conn: sqlite3.Connection, workflow_id: str,
+                  match_prefix: bool = False):
+    """Derive [start_ms, end_ms] for a run from its own tagged events.
+
+    Returns (start_ms, end_ms) from the MIN/MAX event timestamp carrying this
+    workflow_id, or None if nothing is tagged. With match_prefix=True the base
+    name also matches its per-instance ids ('iterate' -> 'iterate:sub-1'), so
+    `--workflow-id` alone can scope a run with no out-of-band timestamps. Only
+    meaningful once controller.record_event tags events with workflow_id.
+    """
+    if match_prefix:
+        row = conn.execute(
+            "SELECT MIN(timestamp), MAX(timestamp) FROM events "
+            "WHERE workflow_id = ? OR workflow_id LIKE ?",
+            (workflow_id, workflow_id + ":%"),
+        ).fetchone()
+    else:
+        row = conn.execute(
+            "SELECT MIN(timestamp), MAX(timestamp) FROM events WHERE workflow_id = ?",
+            (workflow_id,),
+        ).fetchone()
+    lo, hi = row or (None, None)
+    if lo is None or hi is None:
+        return None
+    return _iso_to_ms(lo), _iso_to_ms(hi)
+
+
+def score_by_phase(events: list) -> dict:
+    """Group events by recorded phase and score compliance+cost within each.
+
+    Makes a run sliceable per-phase. Phases only separate once events carry the
+    phase column (controller wiring); pre-wiring events bucket under '(none)'.
+    """
+    buckets: dict = {}
+    for e in events:
+        buckets.setdefault(e.get("phase") or "(none)", []).append(e)
+    out = {}
+    for phase, evs in buckets.items():
+        comp = asdict(score_compliance(evs))
+        comp.pop("tool_sequence", None)  # keep per-phase output compact
+        out[phase] = {"events": len(evs), "compliance": comp,
+                      "cost": asdict(score_cost(evs))}
+    return out
+
+
+# --- compose ----------------------------------------------------------------
+
+def score_run(conn: sqlite3.Connection, start_ms: Optional[int] = None,
+              end_ms: Optional[int] = None, *,
+              workflow_id: Optional[str] = None, match_prefix: bool = False,
+              outcome_md: Optional[str] = None, outcome: Optional[OutcomeScore] = None,
+              model: Optional[str] = None, label: Optional[str] = None,
+              workflow: Optional[str] = None) -> dict:
+    """Score one run, joining DB telemetry with ledger outcome.
+
+    Scope by an explicit [start_ms, end_ms] window, OR pass workflow_id to
+    derive the window from that run's own tagged events (self-describing — no
+    out-of-band timestamps). Output carries a per-phase breakdown so the run is
+    sliceable by phase, plus the distinct workflow_ids actually seen in-window.
+    """
+    if (start_ms is None or end_ms is None) and workflow_id:
+        win = derive_window(conn, workflow_id, match_prefix=match_prefix)
+        if win is None:
+            raise ValueError(f"no events tagged with workflow_id={workflow_id!r}")
+        start_ms, end_ms = win
+    if start_ms is None or end_ms is None:
+        raise ValueError("score_run needs an explicit window or a workflow_id to derive one")
+    events = query_window(conn, start_ms, end_ms)
+    compliance = score_compliance(events)
+    cost = score_cost(events)
+    if outcome is None and outcome_md is not None:
+        outcome = parse_outcome_table(outcome_md)
+    outcome_dict = asdict(outcome) if isinstance(outcome, OutcomeScore) else (outcome or {})
+    workflows_seen = sorted({e.get("workflow_id") for e in events if e.get("workflow_id")})
+    return {
+        "label": label,
+        "model": model,
+        "workflow": workflow or workflow_id,
+        "workflows_seen": workflows_seen,
+        "window": {"start_ms": start_ms, "end_ms": end_ms,
+                   "wallclock_s": (end_ms - start_ms) / 1000},
+        "outcome": outcome_dict,
+        "compliance": asdict(compliance),
+        "cost": asdict(cost),
+        "by_phase": score_by_phase(events),
+        "events_in_window": len(events),
+    }
+
+
+def _sub(b, a):
+    if a is None or b is None:
+        return None
+    return b - a
+
+
+def _g(rec: dict, *keys):
+    cur = rec
+    for k in keys:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(k)
+    return cur
+
+
+def compare(run_a: dict, run_b: dict) -> dict:
+    """Compute b-minus-a deltas on the scoring axes (b is the variant under test)."""
+    return {
+        "a": run_a.get("label"),
+        "b": run_b.get("label"),
+        "window_wallclock_s_delta": _sub(_g(run_b, "window", "wallclock_s"),
+                                         _g(run_a, "window", "wallclock_s")),
+        "wallclock_s_delta": _sub(_g(run_b, "cost", "wallclock_s"),
+                                  _g(run_a, "cost", "wallclock_s")),
+        "pass_ratio_delta": _sub(_g(run_b, "outcome", "pass_ratio"),
+                                 _g(run_a, "outcome", "pass_ratio")),
+        "new_commits_delta": _sub(_g(run_b, "outcome", "new_commits"),
+                                  _g(run_a, "outcome", "new_commits")),
+        "violation_rate_delta": _sub(_g(run_b, "compliance", "violation_rate"),
+                                     _g(run_a, "compliance", "violation_rate")),
+        "total_calls_delta": _sub(_g(run_b, "compliance", "total_calls"),
+                                  _g(run_a, "compliance", "total_calls")),
+    }
+
+
+# --- CLI --------------------------------------------------------------------
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Score a workflow run on outcome/compliance/cost from the events DB + ledger.")
+    ap.add_argument("--db", required=True, help="path to datastore.db")
+    ap.add_argument("--start", type=int, help="window start (epoch-ms)")
+    ap.add_argument("--end", type=int, help="window end (epoch-ms)")
+    ap.add_argument("--workflow-id",
+                    help="derive the window from events tagged with this workflow_id "
+                         "(self-describing; no --start/--end needed)")
+    ap.add_argument("--match-prefix", action="store_true",
+                    help="with --workflow-id, also match per-instance ids (base -> base:*)")
+    ap.add_argument("--outcome-file", help="markdown file containing an Outcome table")
+    ap.add_argument("--label")
+    ap.add_argument("--model")
+    ap.add_argument("--workflow")
+    ap.add_argument("--no-tool-seq", action="store_true",
+                    help="omit the (verbose) per-agent tool sequence from output")
+    args = ap.parse_args(argv)
+
+    conn = sqlite3.connect(str(args.db))
+    outcome_md = Path(args.outcome_file).read_text() if args.outcome_file else None
+    rec = score_run(conn, args.start, args.end, workflow_id=args.workflow_id,
+                    match_prefix=args.match_prefix, outcome_md=outcome_md,
+                    model=args.model, label=args.label, workflow=args.workflow)
+    if args.no_tool_seq:
+        rec["compliance"].pop("tool_sequence", None)
+    print(json.dumps(rec, indent=2, default=str))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_run_scorer.py
+++ b/tests/test_run_scorer.py
@@ -1,0 +1,259 @@
+"""Tests for run_scorer — three-axis workflow-run scoring.
+
+Fixtures encode the REAL shapes verified against disk: the run-1 ledger
+Outcome table (230/230) and the live events DB error types
+(PermissionDeniedError / WorkflowError / RouterError).
+"""
+import datetime as dt
+import sqlite3
+
+import pytest
+
+from run_scorer import (
+    OutcomeScore, parse_outcome_table,
+    ComplianceScore, score_compliance,
+    CostScore, score_cost,
+    query_window, score_run, compare, recompute_outcome,
+    derive_window, score_by_phase, _iso_to_ms,
+)
+
+
+# --- real run-1 Outcome table (from workflow-runs.md) -----------------------
+
+RUN1_OUTCOME_MD = """\
+### Outcome
+
+| Branch | Tests | New commits | Note |
+|---|---|---|---|
+| 01-skiplist | 29/29 ✓ | 0 | subagent took no action |
+| 02-autograd | 36/36 ✓ | 1 | added coverage |
+| 03-compiler | 76/76 ✓ | 1 | added adversarial coverage |
+| 04-allocator | 42/42 ✓ | 1 | buddy stress |
+| 05-vector-clocks | 47/47 ✓ | 1 | invariant tests |
+
+**Total: 230/230 tests pass.**
+"""
+
+
+def test_parse_outcome_table_real_format():
+    o = parse_outcome_table(RUN1_OUTCOME_MD)
+    assert isinstance(o, OutcomeScore)
+    assert o.tests_passed == 230
+    assert o.tests_total == 230
+    assert o.pass_ratio == 1.0
+    assert o.new_commits == 4
+    assert o.branches == 5
+
+
+def test_parse_outcome_table_ignores_header_and_separator():
+    o = parse_outcome_table(RUN1_OUTCOME_MD)
+    branches = {b["branch"] for b in o.per_branch}
+    assert "Branch" not in branches
+    assert "---" not in branches
+    assert branches == {"01-skiplist", "02-autograd", "03-compiler",
+                        "04-allocator", "05-vector-clocks"}
+
+
+def test_parse_outcome_table_partial_fail():
+    md = """
+| Branch | Tests | New commits | Note |
+|---|---|---|---|
+| a | 8/10 | 2 | two failing |
+| b | 5/5 ✓ | 0 | ok |
+"""
+    o = parse_outcome_table(md)
+    assert o.tests_passed == 13
+    assert o.tests_total == 15
+    assert o.new_commits == 2
+    assert o.branches == 2
+    assert o.pass_ratio == pytest.approx(13 / 15)
+
+
+# --- compliance -------------------------------------------------------------
+
+def _ev(agent_id="a1", tool="native__bash", backend="native", status="success",
+        error_type=None, duration_ms=None, ts="2026-05-03T15:00:00+00:00",
+        agent_type="implementer"):
+    return {"agent_id": agent_id, "tool": tool, "backend": backend, "status": status,
+            "error_type": error_type, "duration_ms": duration_ms, "timestamp": ts,
+            "agent_type": agent_type}
+
+
+def test_score_compliance_counts_governance_violations():
+    events = [
+        _ev(status="success"),
+        _ev(status="error", error_type="PermissionDeniedError"),
+        _ev(status="error", error_type="WorkflowError"),
+        _ev(status="error", error_type="RouterError"),
+        _ev(status="success"),
+    ]
+    c = score_compliance(events)
+    assert isinstance(c, ComplianceScore)
+    assert c.total_calls == 5
+    assert c.errors == 3
+    assert c.permission_denied == 1
+    assert c.workflow_errors == 1
+    assert c.router_errors == 1
+    # violation_rate counts governance breaches (perm + workflow), NOT infra (router)
+    assert c.violation_rate == pytest.approx(2 / 5)
+    assert c.error_histogram["PermissionDeniedError"] == 1
+
+
+def test_score_compliance_tool_sequence_per_agent_ordered():
+    events = [
+        _ev(agent_id="a1", tool="native__read_file", ts="2026-05-03T15:00:02+00:00"),
+        _ev(agent_id="a1", tool="native__write_file", ts="2026-05-03T15:00:00+00:00"),
+        _ev(agent_id="a2", tool="native__bash", ts="2026-05-03T15:00:05+00:00"),
+    ]
+    c = score_compliance(events)
+    # ordered by timestamp regardless of input order
+    assert c.tool_sequence["a1"] == ["native__write_file", "native__read_file"]
+    assert c.tool_sequence["a2"] == ["native__bash"]
+
+
+# --- cost -------------------------------------------------------------------
+
+def test_score_cost_wallclock_and_duration():
+    events = [
+        _ev(ts="2026-05-03T15:00:00+00:00", duration_ms=100),
+        _ev(ts="2026-05-03T15:05:00+00:00", duration_ms=None),
+        _ev(ts="2026-05-03T15:10:00+00:00", duration_ms=250),
+    ]
+    cost = score_cost(events)
+    assert isinstance(cost, CostScore)
+    assert cost.wallclock_s == pytest.approx(600.0)  # 10 minutes first->last
+    assert cost.duration_ms_sum == 350
+    assert cost.calls_with_duration == 2
+    assert cost.total_calls == 3
+
+
+# --- window query -----------------------------------------------------------
+
+@pytest.fixture
+def mem_db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY, timestamp TEXT, tool TEXT, "
+        "backend TEXT, status TEXT, duration_ms INTEGER, session_id TEXT, "
+        "agent_id TEXT, agent_type TEXT, workflow_id TEXT, error_type TEXT, "
+        "input_tokens INTEGER, output_tokens INTEGER, phase TEXT)"
+    )
+    rows = [
+        ("2026-05-03T14:00:00.000000+00:00", "native__bash", "native", "success", 10, "a1"),       # before
+        ("2026-05-03T15:00:00.123456+00:00", "native__read_file", "native", "success", 20, "a1"),  # in
+        ("2026-05-03T15:30:00.500000+00:00", "native__bash", "native", "error", 30, "a1"),         # in
+        ("2026-05-03T16:00:00.000000+00:00", "native__bash", "native", "success", 40, "a1"),       # after
+    ]
+    for ts, tool, backend, status, dur, aid in rows:
+        conn.execute(
+            "INSERT INTO events (timestamp,tool,backend,status,duration_ms,agent_id) "
+            "VALUES (?,?,?,?,?,?)", (ts, tool, backend, status, dur, aid))
+    conn.commit()
+    return conn
+
+
+def _ms(y, mo, d, h, mi, s=0):
+    return int(dt.datetime(y, mo, d, h, mi, s, tzinfo=dt.timezone.utc).timestamp() * 1000)
+
+
+def test_query_window_filters_by_time(mem_db):
+    start = _ms(2026, 5, 3, 15, 0, 0)
+    end = _ms(2026, 5, 3, 15, 59, 0)
+    rows = query_window(mem_db, start, end)
+    assert len(rows) == 2
+    assert {r["tool"] for r in rows} == {"native__read_file", "native__bash"}
+
+
+# --- compose ----------------------------------------------------------------
+
+def test_score_run_composes_three_axes(mem_db):
+    start = _ms(2026, 5, 3, 15, 0, 0)
+    end = _ms(2026, 5, 3, 15, 59, 0)
+    rec = score_run(mem_db, start, end, outcome_md=RUN1_OUTCOME_MD,
+                    model="claude-opus-4-7", label="run-x", workflow="orchestrate")
+    assert rec["label"] == "run-x"
+    assert rec["model"] == "claude-opus-4-7"
+    assert rec["outcome"]["tests_passed"] == 230
+    assert rec["compliance"]["total_calls"] == 2
+    assert rec["cost"]["total_calls"] == 2
+    assert rec["events_in_window"] == 2
+    assert rec["window"]["wallclock_s"] == pytest.approx((end - start) / 1000)
+
+
+# --- compare ----------------------------------------------------------------
+
+def test_compare_surfaces_deltas():
+    a = {"label": "run2", "window": {"wallclock_s": 4610.0}, "cost": {"wallclock_s": 4600.0},
+         "outcome": {"pass_ratio": 1.0, "new_commits": 4}, "compliance": {"violation_rate": 0.0, "total_calls": 500}}
+    b = {"label": "run4", "window": {"wallclock_s": 690.0}, "cost": {"wallclock_s": 680.0},
+         "outcome": {"pass_ratio": 1.0, "new_commits": 0}, "compliance": {"violation_rate": 0.1, "total_calls": 50}}
+    d = compare(a, b)
+    assert d["window_wallclock_s_delta"] == pytest.approx(690.0 - 4610.0)
+    assert d["new_commits_delta"] == -4          # run4 did NO commits despite being 6x faster
+    assert d["pass_ratio_delta"] == 0.0
+    assert d["violation_rate_delta"] == pytest.approx(0.1)
+
+
+# --- independence hook (claimed vs actual) ----------------------------------
+
+def test_recompute_outcome_flags_claimed_vs_actual():
+    criteria = [{"metric": "accuracy", "threshold": 0.9, "primary": True}]
+    # a workflow may CLAIM success, but recomputed criteria say otherwise
+    assert recompute_outcome(criteria, {"accuracy": 0.5}).primary_passed is False
+    assert recompute_outcome(criteria, {"accuracy": 0.95}).primary_passed is True
+
+
+# --- self-describing runs: derive window from tagged events -----------------
+
+def _tag(conn, ts, workflow_id, phase="", tool="native__bash", status="success",
+         error_type=None, agent_id="a1"):
+    conn.execute(
+        "INSERT INTO events (timestamp, tool, status, error_type, workflow_id, "
+        "phase, agent_id) VALUES (?,?,?,?,?,?,?)",
+        (ts, tool, status, error_type, workflow_id, phase, agent_id))
+    conn.commit()
+
+
+def test_derive_window_from_tagged_events(mem_db):
+    _tag(mem_db, "2026-05-03T15:10:00.000000+00:00", "iterate:sub-1", "implement")
+    _tag(mem_db, "2026-05-03T15:20:00.000000+00:00", "iterate:sub-1", "test")
+    win = derive_window(mem_db, "iterate:sub-1")
+    assert win == (_iso_to_ms("2026-05-03T15:10:00.000000+00:00"),
+                   _iso_to_ms("2026-05-03T15:20:00.000000+00:00"))
+
+
+def test_derive_window_prefix_matches_instances(mem_db):
+    _tag(mem_db, "2026-05-03T15:05:00+00:00", "iterate")
+    _tag(mem_db, "2026-05-03T15:25:00+00:00", "iterate:sub-9")
+    win = derive_window(mem_db, "iterate", match_prefix=True)
+    assert win == (_iso_to_ms("2026-05-03T15:05:00+00:00"),
+                   _iso_to_ms("2026-05-03T15:25:00+00:00"))
+
+
+def test_derive_window_none_when_untagged(mem_db):
+    assert derive_window(mem_db, "no-such-run") is None
+
+
+def test_score_by_phase_groups_compliance(mem_db):
+    events = [
+        _ev(ts="2026-05-03T15:00:00+00:00", agent_id="a1"),
+        _ev(ts="2026-05-03T15:00:01+00:00", status="error",
+            error_type="PermissionDeniedError", agent_id="a1"),
+    ]
+    events[0]["phase"] = "implement"
+    events[1]["phase"] = "test"
+    by_phase = score_by_phase(events)
+    assert by_phase["implement"]["compliance"]["total_calls"] == 1
+    assert by_phase["test"]["compliance"]["permission_denied"] == 1
+
+
+def test_score_run_scopes_by_workflow_id_and_breaks_down_by_phase(mem_db):
+    _tag(mem_db, "2026-05-03T15:15:00+00:00", "iterate:sub-1", "implement")
+    _tag(mem_db, "2026-05-03T15:16:00+00:00", "iterate:sub-1", "test",
+         status="error", error_type="PermissionDeniedError")
+    rec = score_run(mem_db, workflow_id="iterate:sub-1")
+    assert rec["workflows_seen"] == ["iterate:sub-1"]
+    assert set(rec["by_phase"]) == {"implement", "test"}
+    assert rec["by_phase"]["test"]["compliance"]["permission_denied"] == 1
+    # window was derived, not supplied
+    assert rec["window"]["start_ms"] == _iso_to_ms("2026-05-03T15:15:00+00:00")

--- a/tests/test_run_scorer.py
+++ b/tests/test_run_scorer.py
@@ -257,3 +257,52 @@ def test_score_run_scopes_by_workflow_id_and_breaks_down_by_phase(mem_db):
     assert rec["by_phase"]["test"]["compliance"]["permission_denied"] == 1
     # window was derived, not supplied
     assert rec["window"]["start_ms"] == _iso_to_ms("2026-05-03T15:15:00+00:00")
+
+
+# --- PR #120 review fixes ---------------------------------------------------
+
+def test_score_cost_counts_zero_duration():
+    # duration_ms == 0 is a real (instantaneous) call and must be counted;
+    # the old `if d:` guard silently dropped it. None still means "unknown".
+    events = [
+        _ev(ts="2026-05-03T15:00:00+00:00", duration_ms=0),
+        _ev(ts="2026-05-03T15:00:01+00:00", duration_ms=None),
+        _ev(ts="2026-05-03T15:00:02+00:00", duration_ms=120),
+    ]
+    cost = score_cost(events)
+    assert cost.calls_with_duration == 2   # the 0 and the 120, NOT the None
+    assert cost.duration_ms_sum == 120
+
+
+def test_iso_to_ms_treats_naive_timestamp_as_utc():
+    # A naive (tz-less) ISO timestamp must be read as UTC, not host-local, so
+    # the result is reproducible regardless of where the scorer runs.
+    naive = _iso_to_ms("2026-05-03T00:00:00")
+    aware = _iso_to_ms("2026-05-03T00:00:00+00:00")
+    assert naive == aware
+    expected = int(dt.datetime(2026, 5, 3, 0, 0, 0,
+                               tzinfo=dt.timezone.utc).timestamp() * 1000)
+    assert naive == expected
+
+
+def test_derive_window_prefix_escapes_like_wildcards(mem_db):
+    # workflow_id containing a literal _ must not be treated as a LIKE
+    # single-char wildcard: 'run_a' must NOT match 'runXa:1'.
+    _tag(mem_db, "2026-05-03T15:10:00+00:00", "run_a")
+    _tag(mem_db, "2026-05-03T15:11:00+00:00", "run_a:sub-1")
+    _tag(mem_db, "2026-05-03T15:40:00+00:00", "runXa:sub-9")  # unrelated decoy
+    win = derive_window(mem_db, "run_a", match_prefix=True)
+    # window spans only the run_a rows, never the runXa decoy at 15:40
+    assert win == (_iso_to_ms("2026-05-03T15:10:00+00:00"),
+                   _iso_to_ms("2026-05-03T15:11:00+00:00"))
+
+
+def test_score_run_partial_window_not_clobbered_by_workflow_id(mem_db):
+    # Only start_ms supplied (no end_ms) + a workflow_id: the partially-given
+    # window must NOT be silently replaced by the derived one. With end_ms
+    # missing the run is under-specified, so score_run raises rather than
+    # quietly overriding the caller's start_ms.
+    _tag(mem_db, "2026-05-03T15:15:00+00:00", "iterate:sub-1")
+    start = _ms(2026, 5, 3, 15, 0, 0)
+    with pytest.raises(ValueError):
+        score_run(mem_db, start_ms=start, end_ms=None, workflow_id="iterate:sub-1")


### PR DESCRIPTION
## What

`lib/run_scorer.py` — a standalone 3-axis scorer for empirically rating workflow runs, built on the events DB + the vault run ledger. The measurement layer for the "empirically rate workflows / automate R&D loops" goal.

**Axes:**
- **OUTCOME** — parses the run ledger's per-branch tests-pass table; `recompute_outcome` wraps `experiment_harness.check_criteria` so a run's self-declared success is independently re-checked (claimed-vs-actual is itself a signal).
- **COMPLIANCE** — `PermissionDeniedError` + `WorkflowError` counts (governance breaches; infra noise like `RouterError` excluded from the rate) + per-agent tool sequence, from the events DB.
- **COST** — wallclock + `duration_ms`. Tokens omitted (not available in the tool-call path).

**Self-describing runs:** `derive_window(conn, workflow_id)` scopes a run from its own tagged events — relies on the `workflow_id`/`phase` attribution already on master (`89b7d12`). `score_by_phase` gives a per-phase breakdown.

`run_scorer` is the first real consumer of `experiment_harness.check_criteria` outside the harness's own tests.

## Tests
15 new tests in `tests/test_run_scorer.py`. Full suite green (1467 passed / 275 skipped).

## Notes
- Additive only: new module + tests; no changes to existing code.
- Next: close the experiment engine↔harness seam (auto-run `run_eval` + gate `decide→done` on `check_criteria`) so a run auto-produces a scored record.