### PR TITLE
feat: close experiment engine<->harness seam

### DIFF
--- a/lib/experiment_workflow.py
+++ b/lib/experiment_workflow.py
@@ -129,6 +129,27 @@ def advance_phase(target: str) -> dict:
                 f"Max iterations ({max_iter}) reached"
             )
 
+    # Hard gate: decide->done must independently re-verify success criteria.
+    # Recompute from RECORDED metrics rather than trusting last_eval_passed
+    # (claimed-vs-actual independent check, mirroring run_scorer). Empty
+    # success_criteria preserves prior behavior (gate passes) by convention.
+    if current == "decide" and target == "done":
+        import experiment_harness
+        criteria = state.get("success_criteria", [])
+        if criteria:
+            recorded = state.get("last_eval_metrics")
+            if not recorded:
+                raise ExperimentWorkflowError(
+                    "decide->done blocked: success criteria not met "
+                    "(no eval result recorded)"
+                )
+            recheck = experiment_harness.check_criteria(criteria, recorded)
+            if not recheck.passed:
+                raise ExperimentWorkflowError(
+                    "decide->done blocked: success criteria not met "
+                    f"(recomputed from recorded metrics: {recheck.details})"
+                )
+
     state["phase"] = target
 
     if target == "done":
@@ -167,6 +188,36 @@ def record_eval_result(metrics: dict, passed: bool) -> None:
             best[k] = max(best[k], v)
     state["best_metrics"] = best
     _set_state(state)
+
+
+def run_eval_phase(eval_path: str = "eval/") -> dict:
+    """Auto-run the eval harness during the eval phase.
+
+    The engine runs the eval itself rather than trusting the model to
+    self-report. Requires an active workflow in the "eval" phase. Runs the
+    harness, checks the recorded metrics against the configured success
+    criteria, records the result, and returns a structured summary.
+    """
+    import experiment_harness
+
+    state = _get_state()
+    if not state or not state.get("active"):
+        raise ExperimentWorkflowError("Workflow not active")
+    if state.get("phase") != "eval":
+        raise ExperimentWorkflowError(
+            f"run_eval_phase requires phase 'eval', got '{state.get('phase')}'"
+        )
+
+    result = experiment_harness.run_eval(Path(state["experiment_dir"]), eval_path)
+    criteria = experiment_harness.check_criteria(
+        state.get("success_criteria", []), result.metrics
+    )
+    record_eval_result(result.metrics, passed=criteria.passed)
+    return {
+        "metrics": result.metrics,
+        "passed": criteria.passed,
+        "criteria_details": criteria.details,
+    }
 
 
 def record_hypothesis(hypothesis: str, result: str) -> None:

--- a/lib/experiment_workflow.py
+++ b/lib/experiment_workflow.py
@@ -24,6 +24,22 @@ class ExperimentWorkflowError(Exception):
     """Error in experiment workflow logic."""
 
 
+def _criteria_pass(criteria: list, metrics: dict) -> bool:
+    """Decide whether eval metrics satisfy the success criteria.
+
+    Uses primary-criteria passing when at least one criterion is marked
+    primary; otherwise falls back to requiring ALL criteria to pass. This
+    closes the no-primary bypass where CriteriaResult.passed (== primary_passed)
+    is vacuously True when no criterion is primary, even if every criterion
+    fails. Empty criteria -> no primary -> all_passed is vacuously True ->
+    still passes (convention preserved).
+    """
+    import experiment_harness
+    result = experiment_harness.check_criteria(criteria, metrics)
+    has_primary = any(c.get("primary") for c in criteria)
+    return result.passed if has_primary else result.all_passed
+
+
 def _get_state() -> dict:
     with DaemonClient() as dc:
         return dc.workflow_get_state(WORKFLOW_ID) or {}
@@ -143,8 +159,8 @@ def advance_phase(target: str) -> dict:
                     "decide->done blocked: success criteria not met "
                     "(no eval result recorded)"
                 )
-            recheck = experiment_harness.check_criteria(criteria, recorded)
-            if not recheck.passed:
+            if not _criteria_pass(criteria, recorded):
+                recheck = experiment_harness.check_criteria(criteria, recorded)
                 raise ExperimentWorkflowError(
                     "decide->done blocked: success criteria not met "
                     f"(recomputed from recorded metrics: {recheck.details})"
@@ -208,14 +224,18 @@ def run_eval_phase(eval_path: str = "eval/") -> dict:
             f"run_eval_phase requires phase 'eval', got '{state.get('phase')}'"
         )
 
-    result = experiment_harness.run_eval(Path(state["experiment_dir"]), eval_path)
-    criteria = experiment_harness.check_criteria(
-        state.get("success_criteria", []), result.metrics
-    )
-    record_eval_result(result.metrics, passed=criteria.passed)
+    exp_dir = state.get("experiment_dir")
+    if not exp_dir:
+        raise ExperimentWorkflowError("Workflow state missing 'experiment_dir'")
+
+    result = experiment_harness.run_eval(Path(exp_dir), eval_path)
+    success_criteria = state.get("success_criteria", [])
+    criteria = experiment_harness.check_criteria(success_criteria, result.metrics)
+    passed = _criteria_pass(success_criteria, result.metrics)
+    record_eval_result(result.metrics, passed=passed)
     return {
         "metrics": result.metrics,
-        "passed": criteria.passed,
+        "passed": passed,
         "criteria_details": criteria.details,
     }
 

--- a/lib/experiment_workflow.py
+++ b/lib/experiment_workflow.py
@@ -154,7 +154,7 @@ def advance_phase(target: str) -> dict:
         criteria = state.get("success_criteria", [])
         if criteria:
             recorded = state.get("last_eval_metrics")
-            if not recorded:
+            if recorded is None:
                 raise ExperimentWorkflowError(
                     "decide->done blocked: success criteria not met "
                     "(no eval result recorded)"

--- a/tests/test_experiment_workflow.py
+++ b/tests/test_experiment_workflow.py
@@ -421,3 +421,98 @@ class TestDecideToDoneGate:
         advance_phase("done")
         assert state["active"] is False
         assert state["exit_reason"] == "success"
+
+
+class TestNoPrimaryCriteriaGate:
+    """PR #121 review: close the no-primary-criteria bypass.
+
+    When success_criteria is non-empty but NO criterion is marked primary,
+    CriteriaResult.passed (== primary_passed) is vacuously True even if every
+    criterion fails. The gate and run_eval_phase must fall back to all_passed.
+    """
+
+    def test_done_blocked_when_nonprimary_criteria_fail(self, mock_daemon):
+        from experiment_workflow import (
+            start_experiment, advance_phase, record_eval_result, ExperimentWorkflowError,
+        )
+
+        _, state = mock_daemon
+        # NON-empty criteria, NO primary, recorded metrics FAIL all of them.
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">="}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+        record_eval_result({"accuracy": 0.5}, passed=False)
+        for phase in ["journal", "decide"]:
+            advance_phase(phase)
+        with pytest.raises(ExperimentWorkflowError, match="criteria not met"):
+            advance_phase("done")
+        assert state.get("active") is not False
+
+    def test_done_allowed_when_nonprimary_criteria_pass(self, mock_daemon):
+        from experiment_workflow import (
+            start_experiment, advance_phase, record_eval_result,
+        )
+
+        mock_dc, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">="}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+        record_eval_result({"accuracy": 0.95}, passed=True)
+        for phase in ["journal", "decide"]:
+            advance_phase(phase)
+        advance_phase("done")
+        assert state["active"] is False
+        assert state["exit_reason"] == "success"
+        mock_dc.workflow_stop.assert_called_with("experiment")
+
+    def test_run_eval_phase_records_false_when_nonprimary_fail(self, mock_daemon):
+        from experiment_workflow import start_experiment, advance_phase, run_eval_phase
+
+        _, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">="}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+
+        fake = EvalResult(passed=True, metrics={"accuracy": 0.5})
+        with patch("experiment_harness.run_eval", return_value=fake):
+            out = run_eval_phase()
+
+        # Previously would record True (no primary -> primary_passed vacuously True).
+        assert out["passed"] is False
+        assert state["last_eval_passed"] is False
+
+    def test_run_eval_phase_records_true_when_nonprimary_pass(self, mock_daemon):
+        from experiment_workflow import start_experiment, advance_phase, run_eval_phase
+
+        _, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">="}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+
+        fake = EvalResult(passed=False, metrics={"accuracy": 0.95})
+        with patch("experiment_harness.run_eval", return_value=fake):
+            out = run_eval_phase()
+
+        assert out["passed"] is True
+        assert state["last_eval_passed"] is True
+
+    def test_run_eval_phase_missing_experiment_dir_raises(self, mock_daemon):
+        from experiment_workflow import (
+            start_experiment, advance_phase, run_eval_phase, ExperimentWorkflowError,
+        )
+
+        _, state = mock_daemon
+        start_experiment(experiment_dir="/tmp/exp", task="test")
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+        # Simulate state that lost experiment_dir.
+        state.pop("experiment_dir", None)
+
+        fake = EvalResult(passed=True, metrics={})
+        with patch("experiment_harness.run_eval", return_value=fake):
+            with pytest.raises(ExperimentWorkflowError, match="experiment_dir"):
+                run_eval_phase()

--- a/tests/test_experiment_workflow.py
+++ b/tests/test_experiment_workflow.py
@@ -516,3 +516,55 @@ class TestNoPrimaryCriteriaGate:
         with patch("experiment_harness.run_eval", return_value=fake):
             with pytest.raises(ExperimentWorkflowError, match="experiment_dir"):
                 run_eval_phase()
+
+
+class TestDoneGateMetricsDistinction:
+    """decide->done gate must distinguish None (no eval) from {} (empty eval).
+
+    Regression for PR #121 review: the guard used a falsy check that
+    conflated last_eval_metrics is None (no eval ran) with {} (empty eval).
+    """
+
+    def _advance_to_decide(self, mock_daemon, **start_kwargs):
+        from experiment_workflow import start_experiment, advance_phase
+
+        _, state = mock_daemon
+        start_experiment(experiment_dir="/tmp/exp", task="test", **start_kwargs)
+        for phase in ["plan", "work", "eval", "journal", "decide"]:
+            advance_phase(phase)
+        return state
+
+    def test_none_metrics_with_criteria_blocks_no_eval_recorded(self, mock_daemon):
+        from experiment_workflow import advance_phase, ExperimentWorkflowError
+
+        state = self._advance_to_decide(mock_daemon)
+        state["success_criteria"] = [{"metric": "accuracy", "threshold": 0.9}]
+        state["last_eval_metrics"] = None
+        with pytest.raises(ExperimentWorkflowError, match="no eval result recorded"):
+            advance_phase("done")
+        assert state.get("active") is not False
+
+    def test_empty_metrics_empty_criteria_allows_done(self, mock_daemon):
+        from experiment_workflow import advance_phase
+
+        mock_dc, state = mock_daemon
+        state = self._advance_to_decide(mock_daemon)
+        state["success_criteria"] = []
+        state["last_eval_metrics"] = {}
+        advance_phase("done")
+        assert state["phase"] == "done"
+        assert state["active"] is False
+        assert state["exit_reason"] == "success"
+        mock_dc.workflow_stop.assert_called_with("experiment")
+
+    def test_empty_metrics_with_criteria_blocks_criteria_not_met(self, mock_daemon):
+        from experiment_workflow import advance_phase, ExperimentWorkflowError
+
+        state = self._advance_to_decide(mock_daemon)
+        state["success_criteria"] = [{"metric": "accuracy", "threshold": 0.9}]
+        state["last_eval_metrics"] = {}
+        with pytest.raises(ExperimentWorkflowError) as exc:
+            advance_phase("done")
+        msg = str(exc.value)
+        assert "criteria not met" in msg
+        assert "no eval result recorded" not in msg

--- a/tests/test_experiment_workflow.py
+++ b/tests/test_experiment_workflow.py
@@ -273,3 +273,151 @@ class TestExperimentWorkflow:
 
         stop()
         mock_dc.workflow_advance_phase.assert_not_called()
+
+
+import experiment_harness  # noqa: E402
+from experiment_harness import EvalResult  # noqa: E402
+
+
+class TestEvalPhaseAutoRun:
+    """CHANGE 1: eval phase runs the harness itself rather than trusting self-report."""
+
+    def _to_eval(self, advance_phase):
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+
+    def test_run_eval_phase_auto_runs_harness_and_records(self, mock_daemon):
+        from experiment_workflow import start_experiment, advance_phase, run_eval_phase
+
+        _, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">=", "primary": True}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        self._to_eval(advance_phase)
+
+        fake = EvalResult(passed=True, metrics={"accuracy": 0.95})
+        with patch("experiment_harness.run_eval", return_value=fake) as mock_run:
+            out = run_eval_phase()
+
+        mock_run.assert_called_once()
+        assert out["passed"] is True
+        assert out["metrics"] == {"accuracy": 0.95}
+        assert any(d["metric"] == "accuracy" for d in out["criteria_details"])
+        assert state["last_eval_metrics"] == {"accuracy": 0.95}
+        assert state["last_eval_passed"] is True
+
+    def test_run_eval_phase_passed_reflects_criteria_not_result(self, mock_daemon):
+        from experiment_workflow import start_experiment, advance_phase, run_eval_phase
+
+        _, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">=", "primary": True}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        self._to_eval(advance_phase)
+
+        fake = EvalResult(passed=True, metrics={"accuracy": 0.5})
+        with patch("experiment_harness.run_eval", return_value=fake):
+            out = run_eval_phase()
+
+        assert out["passed"] is False
+        assert state["last_eval_passed"] is False
+
+    def test_run_eval_phase_requires_eval_phase(self, mock_daemon):
+        from experiment_workflow import (
+            start_experiment, advance_phase, run_eval_phase, ExperimentWorkflowError,
+        )
+
+        _, state = mock_daemon
+        start_experiment(experiment_dir="/tmp/exp", task="test")
+        advance_phase("plan")
+        fake = EvalResult(passed=True, metrics={})
+        with patch("experiment_harness.run_eval", return_value=fake):
+            with pytest.raises(ExperimentWorkflowError):
+                run_eval_phase()
+
+    def test_run_eval_phase_requires_active(self, mock_daemon):
+        from experiment_workflow import run_eval_phase, ExperimentWorkflowError
+
+        _, state = mock_daemon
+        with pytest.raises(ExperimentWorkflowError):
+            run_eval_phase()
+
+
+class TestDecideToDoneGate:
+    """CHANGE 2: decide->done independently re-verifies success criteria."""
+
+    def _drive_to_decide(self, advance_phase):
+        for phase in ["plan", "work", "eval", "journal", "decide"]:
+            advance_phase(phase)
+
+    def test_done_blocked_when_recorded_metrics_fail(self, mock_daemon):
+        from experiment_workflow import (
+            start_experiment, advance_phase, record_eval_result, ExperimentWorkflowError,
+        )
+
+        _, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">=", "primary": True}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+        record_eval_result({"accuracy": 0.5}, passed=False)
+        for phase in ["journal", "decide"]:
+            advance_phase(phase)
+        with pytest.raises(ExperimentWorkflowError, match="criteria not met"):
+            advance_phase("done")
+        assert state.get("active") is not False
+
+    def test_done_blocked_when_no_eval_recorded(self, mock_daemon):
+        from experiment_workflow import (
+            start_experiment, advance_phase, ExperimentWorkflowError,
+        )
+
+        _, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">=", "primary": True}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        self._drive_to_decide(advance_phase)
+        with pytest.raises(ExperimentWorkflowError, match="criteria not met"):
+            advance_phase("done")
+
+    def test_done_blocked_when_claimed_pass_but_metrics_fail(self, mock_daemon):
+        from experiment_workflow import (
+            start_experiment, advance_phase, record_eval_result, ExperimentWorkflowError,
+        )
+
+        _, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">=", "primary": True}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+        record_eval_result({"accuracy": 0.5}, passed=True)
+        for phase in ["journal", "decide"]:
+            advance_phase(phase)
+        with pytest.raises(ExperimentWorkflowError, match="criteria not met"):
+            advance_phase("done")
+
+    def test_done_allowed_when_metrics_pass(self, mock_daemon):
+        from experiment_workflow import (
+            start_experiment, advance_phase, record_eval_result,
+        )
+
+        mock_dc, state = mock_daemon
+        criteria = [{"metric": "accuracy", "threshold": 0.9, "comparison": ">=", "primary": True}]
+        start_experiment(experiment_dir="/tmp/exp", task="test", success_criteria=criteria)
+        for phase in ["plan", "work", "eval"]:
+            advance_phase(phase)
+        record_eval_result({"accuracy": 0.95}, passed=True)
+        for phase in ["journal", "decide"]:
+            advance_phase(phase)
+        advance_phase("done")
+        assert state["active"] is False
+        assert state["exit_reason"] == "success"
+        mock_dc.workflow_stop.assert_called_with("experiment")
+
+    def test_done_allowed_when_no_criteria(self, mock_daemon):
+        from experiment_workflow import start_experiment, advance_phase
+
+        mock_dc, state = mock_daemon
+        start_experiment(experiment_dir="/tmp/exp", task="test")
+        for phase in ["plan", "work", "eval", "journal", "decide"]:
+            advance_phase(phase)
+        advance_phase("done")
+        assert state["active"] is False
+        assert state["exit_reason"] == "success"


### PR DESCRIPTION
Closes the seam between the experiment workflow engine and the eval harness (open-recommendations.md "Close the experiment engine<->harness seam" — the recorded next step after the run_scorer PR).

## Changes (lib/experiment_workflow.py)
- **`run_eval_phase(eval_path="eval/")`** — the engine now runs the eval itself in the eval phase: `experiment_harness.run_eval(...)` -> `check_criteria(success_criteria, metrics)` -> `record_eval_result(metrics, passed=criteria.passed)`. No longer trusts the model to self-report.
- **Hard-gate `decide -> done`** in `advance_phase`: independently recomputes `check_criteria` from recorded `last_eval_metrics` and refuses the transition (raises `ExperimentWorkflowError`) unless the recompute passes. Does not trust `last_eval_passed` alone — claimed-vs-actual, mirroring run_scorer. Empty `success_criteria` preserves prior pass-through behavior.

## Tests
28 pass (19 pre-existing + 9 new): `TestEvalPhaseAutoRun` (4) and `TestDecideToDoneGate` (5), covering the auto-run, the no-eval / failing / claimed-pass-but-actual-fail gate cases, and the empty-criteria convention. ruff clean.