### PR TITLE
fix(dispatch): agent_delete clears perm store; mcp-call stops fabricating a default binding (#114/#116/#117)

### DIFF
--- a/bin/mcp-call
+++ b/bin/mcp-call
@@ -34,18 +34,25 @@ from daemon_client import DaemonClient
 def call_tool(name, arguments, caller_id=None):
     """Call a tool via the router daemon.
 
-    The agent's real role + live phase were registered at dispatch by the
-    agent-dispatch hook (prepare_dispatch). We still complete the DaemonClient
-    registration handshake here because it flips the client-side _registered
-    flag that call_tool requires. The daemon's register_agent handler is
-    idempotent, so this does NOT clobber the agent's role/phase — it attaches
-    this connection to the existing identity. The caller id also travels in
-    arguments["_caller"] for per-call permission resolution.
+    The agent's real role + live phase are registered out-of-band: at dispatch by
+    the agent-dispatch hook (prepare_dispatch) and/or by the orchestrator's
+    update_agent_phase. We still complete the DaemonClient registration handshake
+    here because it flips the client-side _registered flag that call_tool requires.
+    The daemon's register_agent handler ATTACHES to an existing identity (never
+    overwriting its role/phase), so re-running the handshake is safe.
+
+    We deliberately do NOT fabricate a role/workflow. Defaulting AGENT_TYPE/
+    WORKFLOW_ID to "implementer"/"iterate" silently fresh-binds an *unknown* id to
+    the iterate base on its first call (issues #116/#117) -- a wrong binding the
+    agent never asked for. When the env vars are unset we send empty values: an
+    unknown id then resolves as unbound (-> global/default-deny) until it is
+    explicitly bound, rather than inheriting iterate/implementer by accident.
+    The caller id also travels in arguments["_caller"] for per-call resolution.
     """
     with DaemonClient() as dc:
         if caller_id:
-            agent_type = os.environ.get("AGENT_TYPE", "implementer")
-            workflow_id = os.environ.get("WORKFLOW_ID", "iterate")
+            agent_type = os.environ.get("AGENT_TYPE", "")
+            workflow_id = os.environ.get("WORKFLOW_ID", "")
             session_id = os.environ.get("AGENT_SESSION_ID", f"mcp-call-{caller_id}")
             dc.register(
                 agent_id=caller_id,

--- a/lib/controller.py
+++ b/lib/controller.py
@@ -1000,6 +1000,11 @@ class Controller:
 
     def _agent_delete(self, args: dict) -> bool:
         agent_id = args.get("agent_id", "")
+        # "" is the main-agent id; an empty/missing arg must NOT silently
+        # de-register it (remove_agent("") would unbind the main session).
+        # Mirror _complete_dispatch's guard.
+        if not agent_id:
+            raise RouterError("agent_delete requires agent_id")
         with self._state_lock:
             self._agent_state.pop(agent_id, None)
         # Mirror _complete_dispatch: also drop the permission-store entry. Leaving

--- a/lib/controller.py
+++ b/lib/controller.py
@@ -1002,7 +1002,12 @@ class Controller:
         agent_id = args.get("agent_id", "")
         with self._state_lock:
             self._agent_state.pop(agent_id, None)
-            return True
+        # Mirror _complete_dispatch: also drop the permission-store entry. Leaving
+        # it pins the old identity -- register_agent ATTACHES to a surviving perm
+        # entry, so a deleted-then-re-registered id keeps its old agent_type/role
+        # until a daemon restart (issue #114).
+        self.permissions.remove_agent(agent_id)
+        return True
 
     def _agent_list(self, args: dict) -> list[str]:
         with self._state_lock:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -858,6 +858,18 @@ class TestAgentState:
         assert result["agent_type"] == "implementer"
         assert ctrl.permissions.get_agent("dd1").agent_type == "implementer"
 
+    def test_agent_delete_requires_agent_id(self, ctrl):
+        """#114 follow-up (PR #125 review): an empty agent_id must not de-register
+        the main agent -- "" is the main-agent id, so remove_agent("") would
+        unbind the live session. Guard mirrors _complete_dispatch."""
+        ctrl.handle_call(
+            "router__register_agent", {"agent_id": "", "agent_type": "implementer"}
+        )
+        with pytest.raises(RouterError, match="requires agent_id"):
+            ctrl.handle_call("workflow__agent_delete", {})
+        # The main-agent permission entry must survive.
+        assert ctrl.permissions.get_agent("") is not None
+
     def test_register_unknown_id_without_workflow_stays_unbound(self, ctrl_with_config):
         """#116/#117: an unknown id registered with no workflow (as bin/mcp-call
         now sends when AGENT_TYPE/WORKFLOW_ID are unset) must NOT be auto-bound to

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -833,6 +833,67 @@ class TestAgentState:
         agents = ctrl.handle_call("workflow__list_agents", {})
         assert set(agents) == {"a1", "a2"}
 
+    def test_agent_delete_clears_permission_store(self, ctrl):
+        """#114: agent_delete must drop the permission-store entry, not just the
+        display state -- otherwise a deleted id keeps its old agent_type because
+        register_agent attaches to the surviving perm entry."""
+        ctrl.handle_call(
+            "router__register_agent",
+            {"agent_id": "dd1", "agent_type": "git-agent"},
+        )
+        assert ctrl.permissions.get_agent("dd1") is not None
+
+        ctrl.handle_call("workflow__agent_delete", {"agent_id": "dd1"})
+        assert ctrl.permissions.get_agent("dd1") is None
+        assert ctrl.handle_call(
+            "workflow__agent_get_state", {"agent_id": "dd1"}
+        ) is None
+
+        # Re-register the SAME id with a different agent_type -> the new type
+        # must take (no stale-identity reuse).
+        result = ctrl.handle_call(
+            "router__register_agent",
+            {"agent_id": "dd1", "agent_type": "implementer"},
+        )
+        assert result["agent_type"] == "implementer"
+        assert ctrl.permissions.get_agent("dd1").agent_type == "implementer"
+
+    def test_register_unknown_id_without_workflow_stays_unbound(self, ctrl_with_config):
+        """#116/#117: an unknown id registered with no workflow (as bin/mcp-call
+        now sends when AGENT_TYPE/WORKFLOW_ID are unset) must NOT be auto-bound to
+        a workflow's initial phase -- it stays unbound (-> global/default-deny)
+        until update_agent_phase binds it."""
+        result = ctrl_with_config.handle_call(
+            "router__register_agent",
+            {"agent_id": "harness-x", "agent_type": "", "workflow_id": ""},
+        )
+        assert result["phase"] is None
+        agent = ctrl_with_config.permissions.get_agent("harness-x")
+        assert agent is not None
+        assert agent.workflow is None
+        assert agent.phase is None
+
+    def test_reregister_does_not_clobber_existing_binding(self, ctrl_with_config):
+        """#117: a per-call mcp-call handshake (which may still carry an
+        env-default agent_type/workflow_id) must ATTACH to an existing identity,
+        never overwrite its role/phase."""
+        ctrl_with_config.handle_call(
+            "router__register_agent",
+            {"agent_id": "w-keep", "agent_type": "git-agent"},
+        )
+        ctrl_with_config.handle_call(
+            "router__update_agent_phase",
+            {"agent_id": "w-keep", "workflow_id": "iterate", "phase": "review"},
+        )
+        # Simulate a stray re-register carrying the old env defaults.
+        ctrl_with_config.handle_call(
+            "router__register_agent",
+            {"agent_id": "w-keep", "agent_type": "implementer", "workflow_id": "iterate"},
+        )
+        agent = ctrl_with_config.permissions.get_agent("w-keep")
+        assert agent.agent_type == "git-agent"
+        assert agent.phase == "review"
+
 
 # --- Permissions ---
 

--- a/tests/test_mcp_call_binding.py
+++ b/tests/test_mcp_call_binding.py
@@ -8,6 +8,7 @@ unbound (-> global/default-deny) until it is explicitly bound.
 """
 import importlib.machinery
 import importlib.util
+import sys
 from pathlib import Path
 from unittest import mock
 
@@ -28,7 +29,14 @@ def _load_mcp_call():
 
 @pytest.fixture
 def mcp_call():
-    return _load_mcp_call()
+    # Loading bin/mcp-call runs its top-level `sys.path.insert(...)`; restore
+    # sys.path afterward so repeated fixture use does not accrete duplicate
+    # entries / shadow imports in larger runs (PR #125 review).
+    original_path = list(sys.path)
+    try:
+        return _load_mcp_call()
+    finally:
+        sys.path[:] = original_path
 
 
 def _patched_dc(mcp_call):

--- a/tests/test_mcp_call_binding.py
+++ b/tests/test_mcp_call_binding.py
@@ -1,0 +1,77 @@
+"""Tests for bin/mcp-call registration binding (issues #116/#117).
+
+bin/mcp-call must not fabricate a default agent_type/workflow_id. Defaulting to
+"implementer"/"iterate" silently fresh-binds an unknown caller id to the iterate
+base on its first call -- bypassing the orchestrator-intended binding. When the
+env vars are unset, mcp-call should send empty values so the daemon leaves the id
+unbound (-> global/default-deny) until it is explicitly bound.
+"""
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_MCP_CALL = Path(__file__).resolve().parent.parent / "bin" / "mcp-call"
+
+
+def _load_mcp_call():
+    # bin/mcp-call has no .py extension, so spec_from_file_location can't infer a
+    # loader -- supply a SourceFileLoader explicitly.
+    loader = importlib.machinery.SourceFileLoader("mcp_call_under_test", str(_MCP_CALL))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mcp_call():
+    return _load_mcp_call()
+
+
+def _patched_dc(mcp_call):
+    """Return (context-manager mock, inner dc mock) wired for `with DaemonClient()`."""
+    fake_dc = mock.MagicMock()
+    cm = mock.MagicMock()
+    cm.__enter__.return_value = fake_dc
+    cm.__exit__.return_value = False
+    return cm, fake_dc
+
+
+def test_no_env_defaults_does_not_fabricate_iterate_implementer(mcp_call, monkeypatch):
+    monkeypatch.delenv("AGENT_TYPE", raising=False)
+    monkeypatch.delenv("WORKFLOW_ID", raising=False)
+
+    cm, fake_dc = _patched_dc(mcp_call)
+    with mock.patch.object(mcp_call, "DaemonClient", return_value=cm):
+        mcp_call.call_tool("router__ping", {}, caller_id="harness-1")
+
+    assert fake_dc.register.call_count == 1
+    kwargs = fake_dc.register.call_args.kwargs
+    assert kwargs["agent_id"] == "harness-1"
+    # The whole point: NOT "implementer"/"iterate".
+    assert kwargs["agent_type"] == ""
+    assert kwargs["workflow_id"] == ""
+
+
+def test_env_binding_is_respected_when_set(mcp_call, monkeypatch):
+    monkeypatch.setenv("AGENT_TYPE", "git-agent")
+    monkeypatch.setenv("WORKFLOW_ID", "develop")
+
+    cm, fake_dc = _patched_dc(mcp_call)
+    with mock.patch.object(mcp_call, "DaemonClient", return_value=cm):
+        mcp_call.call_tool("router__ping", {}, caller_id="h2")
+
+    kwargs = fake_dc.register.call_args.kwargs
+    assert kwargs["agent_type"] == "git-agent"
+    assert kwargs["workflow_id"] == "develop"
+
+
+def test_no_caller_id_skips_registration(mcp_call):
+    cm, fake_dc = _patched_dc(mcp_call)
+    with mock.patch.object(mcp_call, "DaemonClient", return_value=cm):
+        mcp_call.call_tool("router__ping", {})
+
+    fake_dc.register.assert_not_called()


### PR DESCRIPTION
Fixes the dispatch-governance cluster surfaced in the 2026-06-02 iterate dogfood.

## #114 -- agent_delete leaked the permission store
Controller._agent_delete popped only the display state, so a deleted id kept its old agent_type (register_agent attaches to the surviving perm entry) -- you could not switch a caller role without a daemon restart. It now mirrors _complete_dispatch and also calls permissions.remove_agent(agent_id).

## #116 / #117 -- bin/mcp-call fabricated an iterate/implementer binding
bin/mcp-call re-registered the caller on every invocation with env-defaulted agent_type=implementer / workflow_id=iterate. For an id not already bound (daemon restart, throwaway sub-id, missing env), that fresh-bound it to the iterate base on its first call -- bypassing the orchestrator-intended phase gating. It now sends empty values when AGENT_TYPE/WORKFLOW_ID are unset: an unknown id resolves unbound (global / default-deny, the conservative floor) until explicitly bound; the daemon register handler still ATTACHES to an existing identity, so re-registration never clobbers a real binding.

Note: the full positive-binding fix for #116 (a SubagentStart hook binding the real harness id at dispatch) is the larger alternative described in the issue; this PR ships the conservative-default mitigation and tracks the hook as a follow-up.

## Tests
- tests/test_controller.py: agent_delete clears the perm store (re-register with a different type takes); unknown-id-without-workflow stays unbound; re-register never clobbers an existing binding.
- tests/test_mcp_call_binding.py (new): mcp-call sends empty (not implementer/iterate) when env unset; respects env when set; skips registration without a caller id.

144 passed, 1 skipped across controller/permissions/dispatch/session-start suites. No new ruff violations.

Closes #114
Closes #117
Mitigates #116 (full positive-binding hook tracked as a follow-up).