### PR TITLE
fix(dispatch): bind standalone implementers to a per-worker iterate instance (#116)

### DIFF
--- a/lib/controller.py
+++ b/lib/controller.py
@@ -672,11 +672,14 @@ class Controller:
         self.permissions.remove_agent(agent_id)
         # Tear down the per-worker iterate instance that prepare_dispatch may have
         # started for a standalone implementer, so a finished worker does not
-        # orphan it in _workflow_state (#116/#124).
-        try:
-            self._wf_stop({"workflow_id": f"iterate:{agent_id}"})
-        except WorkflowError:
-            pass
+        # orphan it in _workflow_state (#116/#124). Only implementers get an
+        # instance; guard on membership so non-implementer dispatches do not pay
+        # for a raised+caught WorkflowError. _state_lock is an RLock, so holding
+        # it across the check and _wf_stop is reentrant and closes the race.
+        wf_id = f"iterate:{agent_id}"
+        with self._state_lock:
+            if wf_id in self._workflow_state:
+                self._wf_stop({"workflow_id": wf_id})
         return {"success": True, "agent_id": agent_id}
 
     # --- Router operations ---

--- a/lib/controller.py
+++ b/lib/controller.py
@@ -603,7 +603,7 @@ class Controller:
         role = agent_type.split(":")[-1] if ":" in agent_type else agent_type
 
         # Register in permissions system
-        self.permissions.register_agent(agent_id, role)
+        info = self.permissions.register_agent(agent_id, role)
 
         # Bind the agent to the live workflow phase so per-phase permissions
         # (not just its role) govern it. Registered once here in the shared
@@ -619,11 +619,18 @@ class Controller:
             self.permissions.update_agent_phase(agent_id, active_wf, active_phase)
             wf_override = None
         elif role == "implementer":
-            # Standalone implementer = iterate worker. The orchestrator starts and
-            # binds its engine instance -- it alone knows the real agent id at
-            # creation, whereas prepare_dispatch runs before the subagent exists.
-            # So surface the iterate briefing here but start NO instance (starting
-            # one would bind a throwaway sub-id the worker never uses -> orphans).
+            # Standalone implementer = iterate worker. Start a per-worker iterate
+            # instance keyed by this sub-id and bind the worker to it (via
+            # _wf_start), so iterate's phase gates govern the worker from its first
+            # mcp-call (#116). The briefing tells the worker to use this sub-id as
+            # its --caller-id, so binding here is correct -- the old "throwaway
+            # sub-id the worker never uses" rationale was wrong. _complete_dispatch
+            # tears the instance down so it does not orphan (#124).
+            if self._wf_config("iterate") is not None:
+                try:
+                    self._wf_start({"workflow_id": f"iterate:{agent_id}"}, agent_info=info)
+                except WorkflowError:
+                    pass  # instance already exists (re-dispatch) -- binding stands
             wf_override = "iterate"
         else:
             wf_override = None
@@ -663,6 +670,13 @@ class Controller:
                 self._agent_state[agent_id]["status"] = status
                 self._agent_state[agent_id]["completed_at"] = datetime.now(timezone.utc).isoformat()
         self.permissions.remove_agent(agent_id)
+        # Tear down the per-worker iterate instance that prepare_dispatch may have
+        # started for a standalone implementer, so a finished worker does not
+        # orphan it in _workflow_state (#116/#124).
+        try:
+            self._wf_stop({"workflow_id": f"iterate:{agent_id}"})
+        except WorkflowError:
+            pass
         return {"success": True, "agent_id": agent_id}
 
     # --- Router operations ---

--- a/lib/controller.py
+++ b/lib/controller.py
@@ -631,7 +631,12 @@ class Controller:
                     self._wf_start({"workflow_id": f"iterate:{agent_id}"}, agent_info=info)
                 except WorkflowError:
                     pass  # instance already exists (re-dispatch) -- binding stands
-            wf_override = "iterate"
+            # Pass the FULL per-instance id so the briefing's __WF_ID__ resolves to
+            # the workflow the worker is actually bound to (iterate:<agent_id>);
+            # assemble_subagent_briefing strips the suffix for the protocol lookup.
+            # Bare "iterate" would tell the worker to address a workflow that does
+            # not exist, so it could not advance/stop its own instance (#116).
+            wf_override = f"iterate:{agent_id}"
         else:
             wf_override = None
 

--- a/lib/controller.py
+++ b/lib/controller.py
@@ -627,10 +627,23 @@ class Controller:
             # sub-id the worker never uses" rationale was wrong. _complete_dispatch
             # tears the instance down so it does not orphan (#124).
             if self._wf_config("iterate") is not None:
+                wf_id = f"iterate:{agent_id}"
                 try:
-                    self._wf_start({"workflow_id": f"iterate:{agent_id}"}, agent_info=info)
+                    self._wf_start({"workflow_id": wf_id}, agent_info=info)
                 except WorkflowError:
-                    pass  # instance already exists (re-dispatch) -- binding stands
+                    # Instance already exists -- either a genuine re-dispatch of
+                    # this sub-id, or a truncated-uuid collision (sub-{uuid4[:8]},
+                    # 32-bit) with a different live worker. _wf_start's bind only
+                    # runs on a fresh start, so it did NOT bind THIS agent. Bind
+                    # it here to the instance's current phase; otherwise the new
+                    # worker proceeds unbound and permissions.check silently skips
+                    # all L1 phase gates for it. Binding (fail-safe: governed)
+                    # beats leaving it ungoverned in the collision case (#116).
+                    with self._state_lock:
+                        existing = self._workflow_state.get(wf_id)
+                        phase = existing.get("phase") if existing else None
+                    if phase:
+                        self.permissions.update_agent_phase(agent_id, wf_id, phase)
             # Pass the FULL per-instance id so the briefing's __WF_ID__ resolves to
             # the workflow the worker is actually bound to (iterate:<agent_id>);
             # assemble_subagent_briefing strips the suffix for the protocol lookup.

--- a/tests/test_dispatch_enforcement.py
+++ b/tests/test_dispatch_enforcement.py
@@ -101,6 +101,16 @@ class TestPrepareDispatch:
         controller._complete_dispatch({"agent_id": agent_id, "status": "completed"})
         assert wf_id not in controller._workflow_state
 
+    def test_complete_dispatch_skips_wf_stop_without_instance(self, controller):
+        """A dispatch with no per-worker iterate instance (a reviewer or any
+        non-implementer) completes WITHOUT invoking _wf_stop -- the membership
+        guard avoids raising/catching WorkflowError for the common case (PR #126
+        review feedback)."""
+        controller._agent_state["sub-noinst"] = {"status": "pending"}
+        controller._wf_stop = MagicMock()
+        controller._complete_dispatch({"agent_id": "sub-noinst", "status": "completed"})
+        controller._wf_stop.assert_not_called()
+
     def test_implementer_inherits_active_workflow(self, controller):
         """An implementer dispatched within an active workflow inherits it
         (does NOT auto-start iterate)."""

--- a/tests/test_dispatch_enforcement.py
+++ b/tests/test_dispatch_enforcement.py
@@ -64,16 +64,42 @@ class TestPrepareDispatch:
         assert controller._agent_state[agent_id]["status"] == "pending"
         assert controller._agent_state[agent_id]["description"] == "test task"
 
-    def test_standalone_implementer_no_autostart(self, controller):
-        """A standalone implementer gets the iterate briefing, but prepare_dispatch
-        starts NO workflow instance -- the orchestrator owns starting/binding the
-        worker's engine instance (it alone knows the real agent id at creation).
-        Auto-starting here bound a throwaway sub-id the worker never used."""
-        with patch("controller.get_workflow_state", return_value=(None, None)), \
-                patch("controller.assemble_subagent_briefing", return_value="") as brief:
-            controller._prepare_dispatch({"agent_type": "implementer"})
-        assert not any(k.startswith("iterate:") for k in controller._workflow_state)
-        assert brief.call_args.kwargs.get("workflow_override") == "iterate"
+    def test_standalone_implementer_starts_bound_iterate_instance(self, controller):
+        """A standalone implementer (no active workflow) gets a per-worker iterate
+        instance STARTED and is BOUND to its initial phase, so iterate's phase
+        gates govern the worker from its first mcp-call (#116). The briefing tells
+        the worker to use this sub-id as its --caller-id, so binding it here is
+        correct. Previously prepare_dispatch started no instance and left the
+        worker unbound -> governed by permissive agent-type rules, bypassing the
+        phase gates."""
+        controller._workflow_configs = {
+            "iterate": MagicMock(initial_phase="test_writing")
+        }
+        controller.permissions.register_agent.side_effect = (
+            lambda agent_id, role=None: MagicMock(
+                agent_id=agent_id, agent_type=role, roles=[])
+        )
+        with patch("controller.assemble_subagent_briefing", return_value=""), \
+                patch("controller.get_workflow_state", return_value=(None, None)):
+            result = controller._prepare_dispatch({"agent_type": "implementer"})
+        agent_id = result["agent_id"]
+        wf_id = f"iterate:{agent_id}"
+        assert wf_id in controller._workflow_state
+        assert controller._workflow_state[wf_id]["phase"] == "test_writing"
+        controller.permissions.update_agent_phase.assert_any_call(
+            agent_id, wf_id, "test_writing"
+        )
+
+    def test_complete_dispatch_stops_worker_iterate_instance(self, controller):
+        """complete_dispatch tears down the per-worker iterate instance keyed by
+        the agent id, so a finished standalone-implementer worker does not orphan
+        it in _workflow_state (#116 binding implies #124-style cleanup)."""
+        agent_id = "sub-deadbeef"
+        wf_id = f"iterate:{agent_id}"
+        controller._workflow_state[wf_id] = {"phase": "test_writing", "active_agents": {}}
+        controller._agent_state[agent_id] = {"status": "pending"}
+        controller._complete_dispatch({"agent_id": agent_id, "status": "completed"})
+        assert wf_id not in controller._workflow_state
 
     def test_implementer_inherits_active_workflow(self, controller):
         """An implementer dispatched within an active workflow inherits it

--- a/tests/test_dispatch_enforcement.py
+++ b/tests/test_dispatch_enforcement.py
@@ -90,6 +90,24 @@ class TestPrepareDispatch:
             agent_id, wf_id, "test_writing"
         )
 
+    def test_standalone_implementer_briefing_addresses_its_instance(self, controller):
+        """The worker's briefing must substitute __WF_ID__ with the full per-instance
+        id (iterate:<agent_id>) it is bound to -- not the bare base 'iterate', which
+        is not a live workflow the worker could advance or stop (PR #126 greptile P1).
+        assemble_subagent_briefing strips the suffix for protocol lookup but keeps
+        the full id for the __WF_ID__ substitution."""
+        controller._workflow_configs = {
+            "iterate": MagicMock(initial_phase="test_writing")
+        }
+        controller.permissions.register_agent.side_effect = (
+            lambda agent_id, role=None: MagicMock(
+                agent_id=agent_id, agent_type=role, roles=[])
+        )
+        with patch("controller.get_workflow_state", return_value=(None, None)):
+            result = controller._prepare_dispatch({"agent_type": "implementer"})
+        agent_id = result["agent_id"]
+        assert f"iterate:{agent_id}" in result["briefing"]
+
     def test_complete_dispatch_stops_worker_iterate_instance(self, controller):
         """complete_dispatch tears down the per-worker iterate instance keyed by
         the agent id, so a finished standalone-implementer worker does not orphan
@@ -150,13 +168,15 @@ class TestPrepareDispatch:
             assert kwargs.get("workflow_override") is None
 
     def test_wf_override_defaults_to_iterate(self, controller):
-        """iterate override should apply for implementers when no workflow active."""
+        """For a standalone implementer (no active workflow) the briefing override
+        is the per-instance iterate id (iterate:<agent_id>) -- the workflow the
+        worker is actually bound to, so __WF_ID__ addresses it (PR #126 greptile)."""
         with patch("controller.assemble_subagent_briefing") as mock_brief, \
              patch("controller.get_workflow_state", return_value=(None, None)):
             mock_brief.return_value = ""
-            controller._prepare_dispatch({"agent_type": "implementer"})
+            result = controller._prepare_dispatch({"agent_type": "implementer"})
             _, kwargs = mock_brief.call_args
-            assert kwargs.get("workflow_override") == "iterate"
+            assert kwargs.get("workflow_override") == f"iterate:{result['agent_id']}"
 
 
 class TestGetAgentBriefing:

--- a/tests/test_dispatch_enforcement.py
+++ b/tests/test_dispatch_enforcement.py
@@ -108,6 +108,37 @@ class TestPrepareDispatch:
         agent_id = result["agent_id"]
         assert f"iterate:{agent_id}" in result["briefing"]
 
+    def test_standalone_implementer_binds_on_instance_collision(self, controller):
+        """If iterate:<agent_id> already exists when prepare_dispatch starts a
+        worker (a truncated-uuid collision, or a re-dispatch of the sub-id),
+        _wf_start raises WorkflowError and its own bind never runs. The except
+        branch must still bind THIS agent to the live instance's CURRENT phase,
+        otherwise the new worker proceeds unbound and permissions.check silently
+        skips all L1 phase gates for it (PR #126 greptile P1)."""
+        controller._workflow_configs = {
+            "iterate": MagicMock(initial_phase="test_writing")
+        }
+        controller.permissions.register_agent.side_effect = (
+            lambda agent_id, role=None: MagicMock(
+                agent_id=agent_id, agent_type=role, roles=[])
+        )
+        with patch("controller.uuid.uuid4",
+                   return_value=MagicMock(hex="collide0deadbeef")):
+            wf_id = "iterate:sub-collide0"
+            # Pre-existing instance bound to a DIFFERENT prior worker, advanced
+            # past its initial phase.
+            controller._workflow_state[wf_id] = {
+                "phase": "implementing", "active_agents": {}}
+            with patch("controller.assemble_subagent_briefing", return_value=""), \
+                    patch("controller.get_workflow_state", return_value=(None, None)):
+                result = controller._prepare_dispatch({"agent_type": "implementer"})
+        agent_id = result["agent_id"]
+        assert agent_id == "sub-collide0"
+        # Bound to the existing instance's CURRENT phase, not left ungoverned.
+        controller.permissions.update_agent_phase.assert_any_call(
+            agent_id, wf_id, "implementing"
+        )
+
     def test_complete_dispatch_stops_worker_iterate_instance(self, controller):
         """complete_dispatch tears down the per-worker iterate instance keyed by
         the agent id, so a finished standalone-implementer worker does not orphan


### PR DESCRIPTION
## Summary

Fixes #116. A standalone `implementer` dispatched with **no active workflow** was registered role-only and **never workflow-bound**, so `permissions.check` skipped Level-1 phase rules and the worker ran under the permissive `agents.implementer` rules — able to `write_file`/`edit_file` at all times, bypassing iterate's `test`/`review` edit-blocks. This binds such workers to a per-worker `iterate:<agent_id>` instance at dispatch so the phase gates govern them from the first `mcp-call`.

## Root cause (corrected from the original ticket)

The ticket described a "first-call window" with a throwaway `sub-<uuid>` the worker never uses and a fresh harness-id registration. Verified against current code, that is **stale**:

- The dispatch hook (`hooks/agent-dispatch.py`) → `prepare_dispatch` mints `sub-<uuid>`, registers it, and briefs the worker (via `additionalContext`) to use `--caller-id=sub-<uuid>`. The worker uses *that* id; `register_agent`'s attach path preserves its binding. No fresh first-call registration (removed in #125).
- `permissions.check` applies L1 only `if workflow and phase`. `_prepare_dispatch` **Branch B** (no active workflow + `implementer`) left the agent `workflow=None/phase=None` — `wf_override="iterate"` changed only briefing text — and `lib/orchestrate.py` has no `update_agent_phase` call, so nothing bound it later. → L1 skipped permanently → governed by the permissive `agents.implementer` L2 rules.

## Change

- `lib/controller.py` `_prepare_dispatch` Branch B: start a per-worker `iterate:<agent_id>` instance and bind the worker via `_wf_start` (guarded on `_wf_config("iterate")`).
- `lib/controller.py` `_complete_dispatch`: stop that instance on completion so it does not orphan in `_workflow_state` (handles the orphan concern that previously justified not binding; bounded like #124).
- Branch A and non-implementer (reviewer, etc.) dispatch are unchanged.

## Tests

- `tests/test_dispatch_enforcement.py`: added `test_standalone_implementer_starts_bound_iterate_instance` and `test_complete_dispatch_stops_worker_iterate_instance` (TDD, red→green). Replaced the obsolete `test_standalone_implementer_no_autostart` (built on the disproven premise).
- Full suite: **1503 passed, 275 skipped, 0 failures**. No new lint.

## Follow-ups (deliberately out of scope)

1. Scope `get_workflow_state()` to the dispatcher rather than a global `_KNOWN_WORKFLOWS` scan (Branch A inherits whichever workflow is globally active). Riskier — needs investigation into whether iterate workers self-`workflow_start`.
2. Worker phase-advance compliance (L3 / #107): binding gates per the worker's *current* phase; a worker that never advances past `test_writing` won't hit the restrictive blocks. That's onboarding/compliance, not binding.
