### PR TITLE
test(conformance): static all-workflow governance CI gate (#106)

### DIFF
--- a/tests/test_conformance_static.py
+++ b/tests/test_conformance_static.py
@@ -1,0 +1,57 @@
+"""Static workflow-governance conformance gate (#106).
+
+Runs lib.conformance.analyze() across ALL workflow configs and asserts the
+per-workflow governance matrix against a documented baseline. This is the
+config-derived, no-LLM CI entrypoint: a workflow newly losing governance
+(fail-open) fails CI, and a known gap getting fixed also fails -- forcing a
+deliberate baseline update either way. Complements the live driver
+(test_conformance_live.py), which exercises one workflow end-to-end.
+
+Current known gaps are tracked in #106 (and surfaced by `python3 -m lib.conformance`):
+  - pr_comment: no workflows['pr_comment'] block in permissions.yaml -> L1 skipped.
+  - develop:    phase 'complete' declared in YAML but absent at L1.
+  - experiment: phase 'done' declared in YAML but absent at L1.
+  - debug:      in _KNOWN_WORKFLOWS but has no workflow YAML (phantom).
+"""
+
+from lib.conformance import analyze
+
+# Workflows whose declared phases are NOT fully governed at L1 today. Each is a
+# known, tracked gap (#106). A workflow entering or leaving this set should fail
+# the matrix test below, so the baseline is updated deliberately.
+KNOWN_FAIL_OPEN = {"develop", "experiment", "pr_comment"}
+
+# _KNOWN_WORKFLOWS entries that have no workflow YAML.
+KNOWN_PHANTOM = {"debug"}
+
+# Workflows that must stay fully governed -- a regression here is a real defect.
+CORE_GOVERNED = {"simple", "iterate", "orchestrate"}
+
+
+def test_fail_open_matrix_matches_baseline():
+    """The set of fail-open workflows must equal the documented baseline."""
+    result = analyze()
+    fail_open = {r.name for r in result["workflows"] if r.fail_open}
+    assert fail_open == KNOWN_FAIL_OPEN, (
+        "workflow governance conformance changed -- "
+        f"newly fail-open: {sorted(fail_open - KNOWN_FAIL_OPEN)}; "
+        f"newly fixed (update KNOWN_FAIL_OPEN): {sorted(KNOWN_FAIL_OPEN - fail_open)}"
+    )
+
+
+def test_phantom_known_matches_baseline():
+    """_KNOWN_WORKFLOWS entries without a YAML must equal the documented baseline."""
+    result = analyze()
+    assert set(result["phantom_known"]) == KNOWN_PHANTOM, (
+        f"phantom _KNOWN_WORKFLOWS changed: {sorted(result['phantom_known'])}"
+    )
+
+
+def test_core_workflows_stay_governed():
+    """simple, iterate, orchestrate must remain fully governed (not fail-open)."""
+    by_name = {r.name: r for r in analyze()["workflows"]}
+    for wf in CORE_GOVERNED:
+        assert wf in by_name, f"{wf} workflow config is missing"
+        assert not by_name[wf].fail_open, (
+            f"{wf} regressed to fail-open: {by_name[wf].notes}"
+        )

--- a/tests/test_conformance_static.py
+++ b/tests/test_conformance_static.py
@@ -14,6 +14,8 @@ Current known gaps are tracked in #106 (and surfaced by `python3 -m lib.conforma
   - debug:      in _KNOWN_WORKFLOWS but has no workflow YAML (phantom).
 """
 
+import pytest
+
 from lib.conformance import analyze
 
 # Workflows whose declared phases are NOT fully governed at L1 today. Each is a
@@ -28,10 +30,16 @@ KNOWN_PHANTOM = {"debug"}
 CORE_GOVERNED = {"simple", "iterate", "orchestrate"}
 
 
-def test_fail_open_matrix_matches_baseline():
+@pytest.fixture(scope="module")
+def conformance():
+    """analyze() reads + regex-parses several config files; compute it once and
+    share across the module's tests rather than re-running per test."""
+    return analyze()
+
+
+def test_fail_open_matrix_matches_baseline(conformance):
     """The set of fail-open workflows must equal the documented baseline."""
-    result = analyze()
-    fail_open = {r.name for r in result["workflows"] if r.fail_open}
+    fail_open = {r.name for r in conformance["workflows"] if r.fail_open}
     assert fail_open == KNOWN_FAIL_OPEN, (
         "workflow governance conformance changed -- "
         f"newly fail-open: {sorted(fail_open - KNOWN_FAIL_OPEN)}; "
@@ -39,17 +47,19 @@ def test_fail_open_matrix_matches_baseline():
     )
 
 
-def test_phantom_known_matches_baseline():
+def test_phantom_known_matches_baseline(conformance):
     """_KNOWN_WORKFLOWS entries without a YAML must equal the documented baseline."""
-    result = analyze()
-    assert set(result["phantom_known"]) == KNOWN_PHANTOM, (
-        f"phantom _KNOWN_WORKFLOWS changed: {sorted(result['phantom_known'])}"
+    phantom = set(conformance["phantom_known"])
+    assert phantom == KNOWN_PHANTOM, (
+        "phantom _KNOWN_WORKFLOWS changed -- "
+        f"new: {sorted(phantom - KNOWN_PHANTOM)}; "
+        f"gone (update KNOWN_PHANTOM): {sorted(KNOWN_PHANTOM - phantom)}"
     )
 
 
-def test_core_workflows_stay_governed():
+def test_core_workflows_stay_governed(conformance):
     """simple, iterate, orchestrate must remain fully governed (not fail-open)."""
-    by_name = {r.name: r for r in analyze()["workflows"]}
+    by_name = {r.name: r for r in conformance["workflows"]}
     for wf in CORE_GOVERNED:
         assert wf in by_name, f"{wf} workflow config is missing"
         assert not by_name[wf].fail_open, (


### PR DESCRIPTION
## Summary

First increment of #106 (L1 conformance — all workflows + CI). Adds a **static, config-derived governance gate** that runs across *every* workflow config and is CI-runnable (no daemon, no LLM).

`tests/test_conformance_static.py` runs `lib.conformance.analyze()` and asserts:
- the set of **fail-open** workflows equals a documented baseline (`{develop, experiment, pr_comment}`);
- the **phantom** `_KNOWN_WORKFLOWS` set (entries with no YAML) equals `{debug}`;
- **core** workflows (`simple`, `iterate`, `orchestrate`) stay fully governed.

A workflow newly losing governance *or* a known gap getting fixed both fail the gate, forcing a deliberate baseline update either way. This is also the first test coverage for `lib/conformance.py`.

## Current known gaps (encoded as baseline, tracked in #106)

These are surfaced by `python3 -m lib.conformance` and now gated:
- `pr_comment` — no `workflows['pr_comment']` block in permissions.yaml → L1 skipped (ungoverned).
- `develop` — phase `complete` declared in YAML but absent at L1.
- `experiment` — phase `done` declared in YAML but absent at L1.
- `debug` — in `_KNOWN_WORKFLOWS` but has no workflow YAML (phantom).

## Scope / follow-ups

- **Live-driver generalization** (drive each governed workflow end-to-end against the daemon, beyond `simple`) is the remaining #106 piece. It builds on the `_derive_gating` helper from #104 (PR #127), so it's **sequenced after #127 merges** to avoid duplicating that helper across branches.
- The hard shapes (orchestrate spawned-agent governance, pr_comment review state, experiment self-test) need a scoping decision and are deliberately out of this increment.
