### PR TITLE
fix(workflow): skip daemon-owned keys in _save_state so 'advance' stops crashing (#129)

### DIFF
--- a/lib/daemon_client.py
+++ b/lib/daemon_client.py
@@ -20,13 +20,17 @@ RECV_BUFFER = 8192
 DEFAULT_TIMEOUT = 30.0
 MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10 MB — matches daemon MAX_MESSAGE_SIZE
 
-# Keys that only the daemon controller should set — skip in _save_state loops.
-# "phase" is handled separately via workflow_advance_phase.
-# Note: started_at and _checkpoint_passed keys are also protected by the controller
-# but are currently managed in Python. They'll need migration to daemon APIs
-# (workflow_start, workflow_pass_checkpoint) for full production compatibility.
+# Keys that only the daemon controller sets — skip when re-persisting state via
+# workflow_set_value, which the daemon rejects for these. "phase" is handled
+# separately via workflow_advance_phase. These must stay a subset of
+# controller.PROTECTED_KEYS (the daemon's authoritative reject list);
+# test_save_state_protected_keys pins them so they cannot drift (#129).
+# NOTE: *_checkpoint_passed is also daemon-protected, but is intentionally NOT
+# listed here — develop_workflow manages those flags as client-side state via
+# workflow_set_value. Daemon-backed engines that take checkpoints through the
+# daemon API skip them locally in workflow_base._save_state instead.
 DAEMON_ONLY_KEYS = frozenset({
-    "phase", "active_agents", "completed_at",
+    "phase", "active_agents", "started_at", "completed_at",
     "agent_id", "agent_type", "session_id", "workflow_id",
 })
 

--- a/lib/workflow_base.py
+++ b/lib/workflow_base.py
@@ -15,6 +15,11 @@ from typing import Callable, FrozenSet, Optional, Any
 from daemon_client import DaemonClient, is_daemon_only_key
 from permission_store import PermissionStore, PhasePermissions
 
+# Suffix the daemon stamps on per-phase checkpoint flags via
+# workflow_pass_checkpoint. Mirrors controller._is_protected_key, which only
+# treats a *_checkpoint_passed key as daemon-owned when it has a phase prefix.
+_CHECKPOINT_PASSED_SUFFIX = "_checkpoint_passed"
+
 
 class KickbackReason(Enum):
     """Standard reasons for phase kickback."""
@@ -143,7 +148,14 @@ class WorkflowEngine:
             if "phase" in state:
                 dc.workflow_advance_phase(self.workflow_id, state["phase"])
             for key, value in state.items():
-                if is_daemon_only_key(key) or key.endswith("_checkpoint_passed"):
+                # Mirror controller._is_protected_key exactly: a *_checkpoint_passed
+                # key is daemon-owned only when it has a phase-name prefix (length
+                # strictly greater than the bare suffix), so a workflow-owned key
+                # literally named "_checkpoint_passed" is not swallowed here.
+                if is_daemon_only_key(key) or (
+                    len(key) > len(_CHECKPOINT_PASSED_SUFFIX)
+                    and key.endswith(_CHECKPOINT_PASSED_SUFFIX)
+                ):
                     continue
                 dc.workflow_set_value(self.workflow_id, key, value)
 

--- a/lib/workflow_base.py
+++ b/lib/workflow_base.py
@@ -131,12 +131,19 @@ class WorkflowEngine:
 
         Uses workflow_advance_phase for phase changes and skips other
         daemon-managed keys. All remaining keys use workflow_set_value.
+
+        advance() reads state back via get_state(), so the dict round-trips
+        daemon-owned keys: started_at (set at workflow_start) and
+        <phase>_checkpoint_passed (set via the daemon's workflow_pass_checkpoint).
+        The daemon rejects workflow_set_value for any of these, which would abort
+        the save *after* the phase already advanced — leaving the CLI reporting a
+        failure for a transition that actually happened (#129). Skip them here.
         """
         with DaemonClient() as dc:
             if "phase" in state:
                 dc.workflow_advance_phase(self.workflow_id, state["phase"])
             for key, value in state.items():
-                if is_daemon_only_key(key):
+                if is_daemon_only_key(key) or key.endswith("_checkpoint_passed"):
                     continue
                 dc.workflow_set_value(self.workflow_id, key, value)
 

--- a/tests/test_save_state_protected_keys.py
+++ b/tests/test_save_state_protected_keys.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Regression for #129.
+
+`workflow_base._save_state` re-persists a workflow's state dict via the daemon.
+`advance()` reads that dict back through `get_state()`, so it round-trips
+daemon-owned keys -- `started_at` (set at workflow_start) and
+`<phase>_checkpoint_passed` (set via the daemon's `workflow_pass_checkpoint`).
+The daemon rejects `workflow_set_value` for any key in
+`controller.PROTECTED_KEYS` (or a `*_checkpoint_passed` key), so re-writing one
+aborts the save *after* the phase already advanced: every `advance` exits
+non-zero with a traceback while the state actually moved.
+
+These tests pin the skip behaviour so it cannot regress.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import workflow_base
+from daemon_client import is_daemon_only_key
+from controller import PROTECTED_KEYS
+
+
+@pytest.mark.parametrize("key", sorted(PROTECTED_KEYS))
+def test_client_skips_every_daemon_protected_literal_key(key):
+    """Every literal key the daemon protects must be a daemon-only key, else
+    _save_state would issue a workflow_set_value the daemon rejects. Guards
+    against PROTECTED_KEYS / DAEMON_ONLY_KEYS drifting apart."""
+    assert is_daemon_only_key(key), (
+        f"{key!r} is in controller.PROTECTED_KEYS but is_daemon_only_key "
+        f"returns False, so _save_state would try to set it and the daemon "
+        f"would reject it"
+    )
+
+
+def test_save_state_does_not_rewrite_daemon_owned_keys():
+    """A state dict round-tripped from get_state carries started_at and a
+    <phase>_checkpoint_passed flag; _save_state must route phase through
+    advance_phase and skip all daemon-owned keys, persisting only the keys the
+    workflow actually owns."""
+    engine = workflow_base.WorkflowEngine.__new__(workflow_base.WorkflowEngine)
+    engine.workflow_id = "pr_comment"
+
+    dc = MagicMock()
+    client = MagicMock()
+    client.__enter__.return_value = dc
+
+    with patch.object(workflow_base, "DaemonClient", return_value=client):
+        engine._save_state({
+            "phase": "fix",
+            "started_at": "2026-01-01T00:00:00Z",
+            "understand_checkpoint_passed": True,
+            "active_agents": {},
+            "task": "do the thing",
+            "iteration": 1,
+        })
+
+    # Phase change is routed through advance_phase, never set_value.
+    dc.workflow_advance_phase.assert_called_once_with("pr_comment", "fix")
+    set_keys = {call.args[1] for call in dc.workflow_set_value.call_args_list}
+    assert "started_at" not in set_keys, "started_at is daemon-owned"
+    assert "understand_checkpoint_passed" not in set_keys, "checkpoint flag is daemon-owned"
+    assert "phase" not in set_keys
+    assert "active_agents" not in set_keys
+    # Workflow-owned keys are still persisted.
+    assert "task" in set_keys
+    assert "iteration" in set_keys

--- a/tests/test_save_state_protected_keys.py
+++ b/tests/test_save_state_protected_keys.py
@@ -66,3 +66,26 @@ def test_save_state_does_not_rewrite_daemon_owned_keys():
     # Workflow-owned keys are still persisted.
     assert "task" in set_keys
     assert "iteration" in set_keys
+
+
+def test_save_state_persists_bare_checkpoint_passed_key():
+    """The *_checkpoint_passed skip must mirror controller._is_protected_key's
+    length guard: only phase-prefixed keys are daemon-owned. A workflow-owned key
+    literally named "_checkpoint_passed" (no prefix) is NOT protected by the
+    daemon and must still be persisted (PR #131 review)."""
+    engine = workflow_base.WorkflowEngine.__new__(workflow_base.WorkflowEngine)
+    engine.workflow_id = "pr_comment"
+
+    dc = MagicMock()
+    client = MagicMock()
+    client.__enter__.return_value = dc
+
+    with patch.object(workflow_base, "DaemonClient", return_value=client):
+        engine._save_state({
+            "_checkpoint_passed": "owned-value",
+            "design_checkpoint_passed": True,
+        })
+
+    set_keys = {call.args[1] for call in dc.workflow_set_value.call_args_list}
+    assert "_checkpoint_passed" in set_keys, "bare suffix key is workflow-owned"
+    assert "design_checkpoint_passed" not in set_keys, "phase-prefixed flag is daemon-owned"


### PR DESCRIPTION
## What

Fixes #129 — `workflow_base._save_state` re-persisted daemon-owned keys via `workflow_set_value`, which the daemon rejects, so every `advance` exited non-zero **after** the phase had already transitioned.

## Root cause

`advance()` reads state back through `get_state()`, so the dict it re-persists round-trips keys the daemon owns:
- `started_at` — set at `workflow_start`
- `<phase>_checkpoint_passed` — set via the daemon's `workflow_pass_checkpoint`

`controller._wf_set_value` raises `WorkflowError("Protected key '…' cannot be set directly")` for any of these. The phase change (routed through `workflow_advance_phase`) had already landed, so the workflow moved but the CLI reported failure with a traceback.

Observed live while running `/pr-comment` (the `started_at` variant); the `*_checkpoint_passed` variant is the next protected key in the same loop.

## Fix

- `daemon_client.DAEMON_ONLY_KEYS`: add `started_at` (nothing client-side sets it).
- `workflow_base._save_state`: also skip `*_checkpoint_passed` keys locally.

`*_checkpoint_passed` is deliberately **not** added to the shared `is_daemon_only_key` helper: `develop_workflow` manages those flags as client-side state via `workflow_set_value` (a separate, pre-existing daemon-incompatibility — filed as its own issue). Only the daemon-backed engines that take checkpoints through the daemon API skip them.

## Tests

- Parity guard: every key in `controller.PROTECTED_KEYS` is a `DAEMON_ONLY_KEYS` member (catches future drift).
- `_save_state` unit test: a state dict carrying `started_at` + a `*_checkpoint_passed` flag routes phase through `advance_phase` and persists only workflow-owned keys.

Full suite green except the pre-existing, environment-only `test_paths::test_plugin_root_default` (fails identically on `master` from a worktree). ruff clean.
