### PR TITLE
fix(dispatch): use full uuid4 entropy for agent_id, not a 32-bit prefix (#130)

### DIFF
--- a/lib/controller.py
+++ b/lib/controller.py
@@ -596,8 +596,12 @@ class Controller:
 
         description = args.get("description", "")
 
-        # Generate agent ID
-        agent_id = f"sub-{uuid.uuid4().hex[:8]}"
+        # Generate agent ID. Use the full uuid4 hex (128-bit), not a truncated
+        # prefix: agent_id keys the permission registry and the per-worker
+        # iterate:{agent_id} instance, so a collision entangles two concurrent
+        # workers in one AgentInfo / workflow instance -- silent governance
+        # bypass and mid-flight teardown (#130).
+        agent_id = f"sub-{uuid.uuid4().hex}"
 
         # Extract role from agent_type (e.g., "agent-swarm:implementer" -> "implementer")
         role = agent_type.split(":")[-1] if ":" in agent_type else agent_type
@@ -631,14 +635,15 @@ class Controller:
                 try:
                     self._wf_start({"workflow_id": wf_id}, agent_info=info)
                 except WorkflowError:
-                    # Instance already exists -- either a genuine re-dispatch of
-                    # this sub-id, or a truncated-uuid collision (sub-{uuid4[:8]},
-                    # 32-bit) with a different live worker. _wf_start's bind only
-                    # runs on a fresh start, so it did NOT bind THIS agent. Bind
-                    # it here to the instance's current phase; otherwise the new
-                    # worker proceeds unbound and permissions.check silently skips
-                    # all L1 phase gates for it. Binding (fail-safe: governed)
-                    # beats leaving it ungoverned in the collision case (#116).
+                    # Instance already exists -- a re-dispatch of this sub-id, or
+                    # (now astronomically unlikely, post-#130 full-entropy ids) an
+                    # agent_id collision with a different live worker. _wf_start's
+                    # bind only runs on a fresh start, so it did NOT bind THIS
+                    # agent. Bind it here to the instance's current phase;
+                    # otherwise the new worker proceeds unbound and
+                    # permissions.check silently skips all L1 phase gates for it.
+                    # Binding (fail-safe: governed) beats leaving it ungoverned
+                    # (#116; collision space narrowed by #130).
                     with self._state_lock:
                         existing = self._workflow_state.get(wf_id)
                         phase = existing.get("phase") if existing else None

--- a/tests/test_dispatch_enforcement.py
+++ b/tests/test_dispatch_enforcement.py
@@ -1,4 +1,5 @@
 """Tests for agent dispatch enforcement — prepare_dispatch and briefing retrieval."""
+import re
 import pytest
 from unittest.mock import patch, MagicMock
 from pathlib import Path
@@ -39,7 +40,6 @@ class TestPrepareDispatch:
         a truncated 32-bit prefix. Truncation makes birthday collisions between
         concurrent workers plausible, and a collision entangles two workers in a
         single AgentInfo / iterate instance -- silent governance bypass (#130)."""
-        import re
         result = controller._prepare_dispatch({"agent_type": "implementer"})
         assert re.fullmatch(r"sub-[0-9a-f]{32}", result["agent_id"]), (
             f"agent_id {result['agent_id']!r} is not a full-entropy uuid4 hex"

--- a/tests/test_dispatch_enforcement.py
+++ b/tests/test_dispatch_enforcement.py
@@ -34,6 +34,17 @@ class TestPrepareDispatch:
         assert result["success"] is True
         assert result["agent_id"].startswith("sub-")
 
+    def test_agent_id_uses_full_uuid_entropy(self, controller):
+        """agent_id must carry full uuid4 entropy (128-bit / 32 hex chars), not
+        a truncated 32-bit prefix. Truncation makes birthday collisions between
+        concurrent workers plausible, and a collision entangles two workers in a
+        single AgentInfo / iterate instance -- silent governance bypass (#130)."""
+        import re
+        result = controller._prepare_dispatch({"agent_type": "implementer"})
+        assert re.fullmatch(r"sub-[0-9a-f]{32}", result["agent_id"]), (
+            f"agent_id {result['agent_id']!r} is not a full-entropy uuid4 hex"
+        )
+
     def test_returns_briefing(self, controller):
         with patch("controller.assemble_subagent_briefing", return_value="BRIEFING"):
             result = controller._prepare_dispatch({"agent_type": "implementer"})
@@ -110,7 +121,7 @@ class TestPrepareDispatch:
 
     def test_standalone_implementer_binds_on_instance_collision(self, controller):
         """If iterate:<agent_id> already exists when prepare_dispatch starts a
-        worker (a truncated-uuid collision, or a re-dispatch of the sub-id),
+        worker (an agent_id collision, or a re-dispatch of the sub-id),
         _wf_start raises WorkflowError and its own bind never runs. The except
         branch must still bind THIS agent to the live instance's CURRENT phase,
         otherwise the new worker proceeds unbound and permissions.check silently
@@ -122,9 +133,10 @@ class TestPrepareDispatch:
             lambda agent_id, role=None: MagicMock(
                 agent_id=agent_id, agent_type=role, roles=[])
         )
+        fake_hex = "c0111de0deadbeefcafef00dba5eba11"
         with patch("controller.uuid.uuid4",
-                   return_value=MagicMock(hex="collide0deadbeef")):
-            wf_id = "iterate:sub-collide0"
+                   return_value=MagicMock(hex=fake_hex)):
+            wf_id = f"iterate:sub-{fake_hex}"
             # Pre-existing instance bound to a DIFFERENT prior worker, advanced
             # past its initial phase.
             controller._workflow_state[wf_id] = {
@@ -133,7 +145,7 @@ class TestPrepareDispatch:
                     patch("controller.get_workflow_state", return_value=(None, None)):
                 result = controller._prepare_dispatch({"agent_type": "implementer"})
         agent_id = result["agent_id"]
-        assert agent_id == "sub-collide0"
+        assert agent_id == f"sub-{fake_hex}"
         # Bound to the existing instance's CURRENT phase, not left ungoverned.
         controller.permissions.update_agent_phase.assert_any_call(
             agent_id, wf_id, "implementing"


### PR DESCRIPTION
## What

Fixes #130 — widen `agent_id` from a truncated 32-bit prefix to the full 128-bit uuid4 hex.

## Root cause

```python
agent_id = f"sub-{uuid.uuid4().hex[:8]}"   # 32 bits
```

`agent_id` keys both the permission registry (`register_agent` → `AgentInfo`) and the per-worker `iterate:{agent_id}` workflow instance. A birthday collision between concurrently active workers (plausible in a 32-bit space) entangles two physically distinct workers:

- they resolve to the **same** `AgentInfo`, so a phase advance for one silently re-governs the other;
- `_wf_start` raises `WorkflowError` for the second worker (the binding-side symptom #126 made fail-safe);
- `_complete_dispatch` tears down `iterate:{agent_id}` when **either** finishes, stripping the still-running worker's governance.

These are exactly the greptile P1/P2 findings on #126; `4bac757` made the binding fail-safe but left the root entropy issue, which this closes.

## Fix

```python
agent_id = f"sub-{uuid.uuid4().hex}"       # 128 bits
```

Also refreshes the `#126` except-branch comment (collision space is now negligible; the defensive bind stays as cheap insurance for a re-dispatch of the same id).

## Tests

- `test_agent_id_uses_full_uuid_entropy` pins the `sub-[0-9a-f]{32}` format (RED before the change).
- The `#126` collision test now derives its expected id from the mocked full hex rather than a truncated prefix; behaviour under collision is unchanged.

Full suite green except the pre-existing, environment-only `test_paths::test_plugin_root_default` (fails identically on `master` from a worktree). No new ruff findings.
