### PR TITLE
test: characterization-test backfill for untested lib modules

### DIFF
--- a/tests/backfill/test_connection_pool.py
+++ b/tests/backfill/test_connection_pool.py
@@ -12,7 +12,6 @@ no pytest-asyncio dependency.
 import asyncio
 import sys
 import types
-from pathlib import Path
 from types import SimpleNamespace
 
 # ---------------------------------------------------------------------------
@@ -24,10 +23,6 @@ from types import SimpleNamespace
 # sys.modules['config'] with a stub that exposes BackendConfig so the import
 # works without touching lib/ at all.
 # ---------------------------------------------------------------------------
-_ROOT = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(_ROOT))
-sys.path.insert(0, str(_ROOT / "lib"))
-
 if "config" not in sys.modules or not hasattr(sys.modules["config"], "BackendConfig"):
     _stub_config = types.ModuleType("config")
 
@@ -39,7 +34,10 @@ if "config" not in sys.modules or not hasattr(sys.modules["config"], "BackendCon
     sys.modules["config"] = _stub_config
 
 # Now safe to import from lib
-from connection_pool import AsyncConnection, ConnectionPool, ConnectionContextManager  # noqa: E402
+from lib.connection_pool import AsyncConnection, ConnectionPool  # noqa: E402
+# Import from bare 'errors' (not lib.errors): connection_pool's internal
+# `from errors import ConnectionError` binds that module object, and the
+# exception class identity must match for pytest.raises.
 from errors import ConnectionError as RouterConnectionError  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -244,7 +242,7 @@ def test_pool_acquire_blocks_when_semaphore_exhausted():
         await asyncio.wait_for(pool.start(), timeout=10.0)
 
         async def hold_conn(ready_ev, release_ev):
-            async with pool.acquire() as conn:
+            async with pool.acquire():
                 ready_ev.set()
                 await release_ev.wait()
 

--- a/tests/backfill/test_connection_pool.py
+++ b/tests/backfill/test_connection_pool.py
@@ -1,0 +1,379 @@
+"""Characterization tests for lib/connection_pool.py.
+
+These tests pin the EXISTING behavior of AsyncConnection, ConnectionPool, and
+ConnectionContextManager.  The subprocess seam is faked using a trivial
+Python echo-server that reads JSON-RPC lines and echoes them back (writing a
+``result`` field so futures resolve).
+
+All coroutines are driven with asyncio.run() inside plain test functions —
+no pytest-asyncio dependency.
+"""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+# ---------------------------------------------------------------------------
+# Path / module fixup — must happen BEFORE any lib imports.
+#
+# lib/connection_pool.py does `from config import BackendConfig`.
+# There is a config/ directory at the project root that Python discovers as a
+# namespace package, which wins over any actual module.  We pre-populate
+# sys.modules['config'] with a stub that exposes BackendConfig so the import
+# works without touching lib/ at all.
+# ---------------------------------------------------------------------------
+_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_ROOT))
+sys.path.insert(0, str(_ROOT / "lib"))
+
+if "config" not in sys.modules or not hasattr(sys.modules["config"], "BackendConfig"):
+    _stub_config = types.ModuleType("config")
+
+    class _BackendConfigStub:
+        """Stub satisfying the type annotation; tests use SimpleNamespace instead."""
+        pass
+
+    _stub_config.BackendConfig = _BackendConfigStub
+    sys.modules["config"] = _stub_config
+
+# Now safe to import from lib
+from connection_pool import AsyncConnection, ConnectionPool, ConnectionContextManager  # noqa: E402
+from errors import ConnectionError as RouterConnectionError  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(
+    *,
+    command=None,
+    name="test-backend",
+    request_timeout=2.0,
+    max_concurrent=2,
+    pool_size=2,
+):
+    """Return a minimal BackendConfig-shaped namespace."""
+    if command is None:
+        # A trivial JSON-RPC echo server: read a line, respond with
+        # {"jsonrpc":"2.0","id":<id>,"result":{"echo":true,"method":<method>}}
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys, json\n"
+                "for line in sys.stdin:\n"
+                "    line=line.strip()\n"
+                "    if not line: continue\n"
+                "    req=json.loads(line)\n"
+                "    resp={'jsonrpc':'2.0','id':req['id'],'result':{'echo':True,'method':req['method']}}\n"
+                "    sys.stdout.write(json.dumps(resp)+'\\n')\n"
+                "    sys.stdout.flush()\n"
+            ),
+        ]
+    cfg = SimpleNamespace(
+        name=name,
+        command=command,
+        request_timeout=request_timeout,
+        max_concurrent=max_concurrent,
+        pool_size=pool_size,
+    )
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# AsyncConnection — is_connected state machine
+# ---------------------------------------------------------------------------
+
+
+def test_is_connected_false_before_start():
+    """is_connected must be False immediately after construction."""
+    cfg = _make_config()
+    conn = AsyncConnection(cfg)
+    assert conn.is_connected is False
+
+
+def test_is_connected_true_after_start():
+    """is_connected must be True after a successful start()."""
+    async def scenario():
+        cfg = _make_config()
+        conn = AsyncConnection(cfg)
+        await asyncio.wait_for(conn.start(), timeout=5.0)
+        try:
+            assert conn.is_connected is True
+        finally:
+            await conn.close()
+
+    asyncio.run(scenario())
+
+
+def test_is_connected_false_after_close():
+    """is_connected must be False after close()."""
+    async def scenario():
+        cfg = _make_config()
+        conn = AsyncConnection(cfg)
+        await asyncio.wait_for(conn.start(), timeout=5.0)
+        await conn.close()
+        assert conn.is_connected is False
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# AsyncConnection — send_request when not connected
+# ---------------------------------------------------------------------------
+
+
+def test_send_request_raises_when_not_connected():
+    """send_request before start() raises RouterConnectionError."""
+    async def scenario():
+        cfg = _make_config()
+        conn = AsyncConnection(cfg)
+        try:
+            await asyncio.wait_for(
+                conn.send_request("tools/call", {}),
+                timeout=2.0,
+            )
+            assert False, "Expected RouterConnectionError"
+        except RouterConnectionError:
+            pass  # expected
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# AsyncConnection — JSON-RPC multiplexing: two in-flight requests
+# ---------------------------------------------------------------------------
+
+
+def test_send_request_multiplexing_correlates_responses():
+    """Two concurrent send_request calls must each get the right response.
+
+    The echo-server reflects the method name back in result.method, so we can
+    verify each caller received the matching response.
+    """
+    async def scenario():
+        cfg = _make_config()
+        conn = AsyncConnection(cfg)
+        await asyncio.wait_for(conn.start(), timeout=5.0)
+        try:
+            t1 = asyncio.create_task(conn.send_request("method/alpha", {"x": 1}))
+            t2 = asyncio.create_task(conn.send_request("method/beta", {"x": 2}))
+            r1, r2 = await asyncio.wait_for(asyncio.gather(t1, t2), timeout=5.0)
+            assert r1["result"]["method"] == "method/alpha"
+            assert r2["result"]["method"] == "method/beta"
+        finally:
+            await conn.close()
+
+    asyncio.run(scenario())
+
+
+def test_send_request_returns_result_dict():
+    """send_request should return the full JSON-RPC response dict."""
+    async def scenario():
+        cfg = _make_config()
+        conn = AsyncConnection(cfg)
+        await asyncio.wait_for(conn.start(), timeout=5.0)
+        try:
+            resp = await asyncio.wait_for(
+                conn.send_request("tools/call", {"name": "x"}),
+                timeout=5.0,
+            )
+            assert isinstance(resp, dict)
+            assert "result" in resp
+            assert resp["result"]["echo"] is True
+        finally:
+            await conn.close()
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# ConnectionPool — start / close
+# ---------------------------------------------------------------------------
+
+
+def test_pool_start_creates_connections():
+    """pool.start() creates pool_size connected AsyncConnection instances."""
+    async def scenario():
+        cfg = _make_config(pool_size=2, max_concurrent=2)
+        pool = ConnectionPool(cfg)
+        await asyncio.wait_for(pool.start(), timeout=10.0)
+        try:
+            assert len(pool._connections) == 2
+            for conn in pool._connections:
+                assert conn.is_connected is True
+        finally:
+            await pool.close()
+
+    asyncio.run(scenario())
+
+
+def test_pool_close_shuts_down_all_connections():
+    """pool.close() must disconnect every connection in the pool."""
+    async def scenario():
+        cfg = _make_config(pool_size=2, max_concurrent=2)
+        pool = ConnectionPool(cfg)
+        await asyncio.wait_for(pool.start(), timeout=10.0)
+        connections_snapshot = list(pool._connections)
+        await pool.close()
+        # After close, each connection must report not-connected
+        for conn in connections_snapshot:
+            assert conn.is_connected is False
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# ConnectionPool — semaphore backpressure
+# ---------------------------------------------------------------------------
+
+
+def test_pool_acquire_blocks_when_semaphore_exhausted():
+    """With max_concurrent = N, the N+1-th acquire must block.
+
+    We hold N connections in the critical section long enough to demonstrate
+    that the extra acquire times out (i.e. it cannot proceed).
+    """
+    N = 2
+
+    async def scenario():
+        cfg = _make_config(pool_size=N, max_concurrent=N)
+        pool = ConnectionPool(cfg)
+        await asyncio.wait_for(pool.start(), timeout=10.0)
+
+        async def hold_conn(ready_ev, release_ev):
+            async with pool.acquire() as conn:
+                ready_ev.set()
+                await release_ev.wait()
+
+        # Acquire all N slots
+        ready_events = [asyncio.Event() for _ in range(N)]
+        rel_events = [asyncio.Event() for _ in range(N)]
+        tasks = [
+            asyncio.create_task(hold_conn(ready_events[i], rel_events[i]))
+            for i in range(N)
+        ]
+
+        # Wait until all N slots are taken
+        await asyncio.wait_for(
+            asyncio.gather(*[e.wait() for e in ready_events]),
+            timeout=5.0,
+        )
+
+        # The N+1-th acquire should time out (semaphore blocks)
+        blocked = False
+        try:
+            await asyncio.wait_for(pool._acquire_connection(), timeout=0.3)
+        except asyncio.TimeoutError:
+            blocked = True
+        finally:
+            for e in rel_events:
+                e.set()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await pool.close()
+
+        assert blocked, "Expected the N+1-th acquire to block"
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# ConnectionPool — get_stats shape and counts
+# ---------------------------------------------------------------------------
+
+
+def test_get_stats_returns_documented_shape():
+    """get_stats() must return a dict with the expected keys."""
+    EXPECTED_KEYS = {
+        "active_connections",
+        "available_connections",
+        "in_flight_requests",
+        "total_requests",
+        "max_concurrent",
+        "pool_size",
+    }
+
+    async def scenario():
+        cfg = _make_config(pool_size=2, max_concurrent=2)
+        pool = ConnectionPool(cfg)
+        await asyncio.wait_for(pool.start(), timeout=10.0)
+        try:
+            stats = pool.get_stats()
+            assert isinstance(stats, dict)
+            assert EXPECTED_KEYS == set(stats.keys())
+        finally:
+            await pool.close()
+
+    asyncio.run(scenario())
+
+
+def test_get_stats_counts_after_start():
+    """After start, stats should reflect pool_size and zero in-flight."""
+    async def scenario():
+        cfg = _make_config(pool_size=2, max_concurrent=3)
+        pool = ConnectionPool(cfg)
+        await asyncio.wait_for(pool.start(), timeout=10.0)
+        try:
+            stats = pool.get_stats()
+            assert stats["active_connections"] == 2
+            assert stats["available_connections"] == 2
+            assert stats["in_flight_requests"] == 0
+            assert stats["total_requests"] == 0
+            assert stats["max_concurrent"] == 3
+            assert stats["pool_size"] == 2
+        finally:
+            await pool.close()
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# ConnectionContextManager — releases on normal exit
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_releases_on_normal_exit():
+    """After exiting `async with pool.acquire()`, the connection is back in the queue."""
+    async def scenario():
+        cfg = _make_config(pool_size=1, max_concurrent=1)
+        pool = ConnectionPool(cfg)
+        await asyncio.wait_for(pool.start(), timeout=10.0)
+        try:
+            async with pool.acquire():
+                pass  # normal exit
+            # Connection should have been returned; we can acquire again without timeout
+            async with pool.acquire() as conn:
+                assert conn.is_connected is True
+        finally:
+            await pool.close()
+
+    asyncio.run(scenario())
+
+
+def test_context_manager_releases_on_exception():
+    """ConnectionContextManager releases the connection even when an exception is raised."""
+    async def scenario():
+        cfg = _make_config(pool_size=1, max_concurrent=1)
+        pool = ConnectionPool(cfg)
+        await asyncio.wait_for(pool.start(), timeout=10.0)
+        try:
+            try:
+                async with pool.acquire():
+                    raise ValueError("deliberate")
+            except ValueError:
+                pass  # expected
+
+            # After the exception, the connection should be released so a
+            # second acquire does not time out (pool_size=1, max_concurrent=1).
+            acquire_task = pool._acquire_connection()
+            conn = await asyncio.wait_for(acquire_task, timeout=1.0)
+            try:
+                assert conn.is_connected is True
+            finally:
+                await pool._release_connection(conn)
+        finally:
+            await pool.close()
+
+    asyncio.run(scenario())

--- a/tests/backfill/test_jsonl_extractor.py
+++ b/tests/backfill/test_jsonl_extractor.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""
+Characterization tests for lib/jsonl_extractor.py.
+Tests pin current behavior of token extraction and JSONL parsing.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import pytest
+import time
+
+# Add lib to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "lib"))
+
+from jsonl_extractor import (
+    get_file_hash,
+    load_progress,
+    save_progress,
+    is_file_processed,
+    mark_file_processed,
+    extract_session_info,
+    parse_jsonl_line,
+    extract_tokens_from_message,
+    extract_tool_call,
+    process_jsonl_file,
+    merge_session_into_telemetry,
+)
+
+from telemetry_schema_v2 import default_telemetry_v2
+
+
+class TestParseJsonlLine:
+    """Test parse_jsonl_line behavior."""
+
+    def test_parse_valid_json_object(self):
+        """Valid JSON object line is parsed."""
+        line_dict = {"type": "assistant", "message": "hello"}
+        line = json.dumps(line_dict)
+        result = parse_jsonl_line(line)
+        assert result == line_dict
+
+    def test_parse_valid_json_with_nested_usage(self):
+        """Valid JSON with nested usage data is parsed."""
+        line_dict = {
+            "type": "assistant",
+            "message": {"usage": {"input_tokens": 5, "output_tokens": 10}},
+        }
+        line = json.dumps(line_dict)
+        result = parse_jsonl_line(line)
+        assert result == line_dict
+
+    def test_parse_invalid_json(self):
+        """Invalid JSON returns None."""
+        result = parse_jsonl_line("{invalid json}")
+        assert result is None
+
+    def test_parse_empty_line(self):
+        """Empty line returns None."""
+        result = parse_jsonl_line("")
+        assert result is None
+
+    def test_parse_whitespace_only(self):
+        """Whitespace-only line returns None."""
+        result = parse_jsonl_line("   \n")
+        assert result is None
+
+
+class TestExtractTokensFromMessage:
+    """Test extract_tokens_from_message behavior."""
+
+    def test_extract_from_usage_field(self):
+        """Extracts tokens from top-level usage field."""
+        msg = {"usage": {"input_tokens": 5, "output_tokens": 10}}
+        result = extract_tokens_from_message(msg)
+        assert result is not None
+        assert result["input"] == 5
+        assert result["output"] == 10
+        assert result["source"] == "jsonl"
+
+    def test_extract_from_nested_message_usage(self):
+        """Extracts tokens from message.usage field."""
+        msg = {"message": {"usage": {"input_tokens": 3, "output_tokens": 7}}}
+        result = extract_tokens_from_message(msg)
+        assert result is not None
+        assert result["input"] == 3
+        assert result["output"] == 7
+
+    def test_extract_with_cache_tokens(self):
+        """Extracts cache tokens when present."""
+        msg = {
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "cache_read_input_tokens": 5,
+                "cache_creation_input_tokens": 3,
+            }
+        }
+        result = extract_tokens_from_message(msg)
+        assert result is not None
+        assert result["cache_read"] == 5
+        assert result["cache_creation"] == 3
+
+    def test_extract_no_usage(self):
+        """Message without usage returns None."""
+        msg = {"type": "user", "content": "hello"}
+        result = extract_tokens_from_message(msg)
+        assert result is None
+
+    def test_extract_empty_usage(self):
+        """Message with empty usage dict returns None (if usage is falsy)."""
+        # NOTE: empty dict {} is falsy in the "if usage:" check, so returns None
+        msg = {"usage": {}}
+        result = extract_tokens_from_message(msg)
+        assert result is None
+
+    def test_extract_malformed_usage_crashes(self):
+        """Message with non-dict usage causes AttributeError (no graceful handling)."""
+        # NOTE: possible bug — function does not check isinstance(usage, dict)
+        msg = {"usage": "not a dict"}
+        with pytest.raises(AttributeError):
+            extract_tokens_from_message(msg)
+
+
+class TestExtractToolCall:
+    """Test extract_tool_call behavior."""
+
+    def test_extract_native_tool(self):
+        """Extracts native tool name and backend."""
+        msg = {
+            "content": [
+                {"type": "tool_use", "name": "my_tool", "id": "call_1"}
+            ]
+        }
+        result = extract_tool_call(msg)
+        assert result is not None
+        tool_name, backend = result
+        assert tool_name == "my_tool"
+        assert backend == "native"
+
+    def test_extract_mcp_router_tool(self):
+        """Extracts mcp__router__ tool and backend."""
+        msg = {
+            "content": [
+                {"type": "tool_use", "name": "mcp__router__native__bash", "id": "call_1"}
+            ]
+        }
+        result = extract_tool_call(msg)
+        assert result is not None
+        tool_name, backend = result
+        assert tool_name == "mcp__router__native__bash"
+        assert backend == "native"
+
+    def test_extract_mcp_plugin_tool(self):
+        """Extracts mcp__plugin_ tool and backend."""
+        msg = {
+            "content": [
+                {"type": "tool_use", "name": "mcp__plugin_context7__fetch", "id": "call_1"}
+            ]
+        }
+        result = extract_tool_call(msg)
+        assert result is not None
+        tool_name, backend = result
+        assert tool_name == "mcp__plugin_context7__fetch"
+        # Backend extraction from plugin_ name
+        assert backend == "context7"
+
+    def test_no_tool_use_in_content(self):
+        """Non-tool-use message returns None."""
+        msg = {"content": [{"type": "text", "text": "hello"}]}
+        result = extract_tool_call(msg)
+        assert result is None
+
+    def test_no_content_field(self):
+        """Message without content returns None."""
+        msg = {"type": "text"}
+        result = extract_tool_call(msg)
+        assert result is None
+
+    def test_multiple_content_items(self):
+        """Extracts first tool_use from multiple content items."""
+        msg = {
+            "content": [
+                {"type": "text", "text": "Processing"},
+                {"type": "tool_use", "name": "first_tool", "id": "call_1"},
+                {"type": "tool_use", "name": "second_tool", "id": "call_2"},
+            ]
+        }
+        result = extract_tool_call(msg)
+        assert result is not None
+        tool_name, backend = result
+        assert tool_name == "first_tool"
+
+
+class TestGetFileHash:
+    """Test get_file_hash behavior."""
+
+    def test_hash_same_file_same_mtime(self, tmp_path):
+        """Hash is stable for same file and mtime."""
+        f = tmp_path / "test.txt"
+        f.write_text("content")
+        hash1 = get_file_hash(f)
+        hash2 = get_file_hash(f)
+        assert hash1 == hash2
+
+    def test_hash_changes_with_mtime(self, tmp_path):
+        """Hash changes when file mtime changes."""
+        f = tmp_path / "test.txt"
+        f.write_text("content")
+        hash1 = get_file_hash(f)
+        
+        # Change mtime
+        time.sleep(0.01)  # Small delay to ensure mtime difference
+        os.utime(f, None)  # Touch file to update mtime
+        hash2 = get_file_hash(f)
+        
+        assert hash1 != hash2
+
+    def test_hash_changes_with_size(self, tmp_path):
+        """Hash changes when file size changes."""
+        f = tmp_path / "test.txt"
+        f.write_text("content")
+        hash1 = get_file_hash(f)
+        
+        # Modify file
+        time.sleep(0.01)
+        f.write_text("longer content now")
+        hash2 = get_file_hash(f)
+        
+        assert hash1 != hash2
+
+    def test_hash_format(self, tmp_path):
+        """Hash is 12-character hex string."""
+        f = tmp_path / "test.txt"
+        f.write_text("content")
+        h = get_file_hash(f)
+        assert len(h) == 12
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+class TestProgressTracking:
+    """Test progress tracking functions."""
+
+    def test_mark_file_with_real_temp_file(self, tmp_path):
+        """Mark and check with real temp file."""
+        progress = {"processed": {}}
+        f = tmp_path / "session.jsonl"
+        f.write_text("line1\n")
+        
+        tokens = {"input": 100, "output": 50}
+        mark_file_processed(f, progress, tokens)
+        
+        # Now it should be marked as processed
+        assert is_file_processed(f, progress)
+        
+        # Verify structure
+        file_key = str(f)
+        assert file_key in progress["processed"]
+        assert "hash" in progress["processed"][file_key]
+        assert "processed_at" in progress["processed"][file_key]
+        assert progress["processed"][file_key]["tokens"] == tokens
+
+    def test_mark_file_updates_hash_on_change(self, tmp_path):
+        """File is no longer marked processed if content changes."""
+        progress = {"processed": {}}
+        f = tmp_path / "session.jsonl"
+        f.write_text("content1\n")
+        
+        tokens = {"input": 100, "output": 50}
+        mark_file_processed(f, progress, tokens)
+        assert is_file_processed(f, progress)
+        
+        # Change file
+        time.sleep(0.01)
+        f.write_text("content2\n")
+        
+        # Now hash should not match
+        assert not is_file_processed(f, progress)
+
+
+class TestExtractSessionInfo:
+    """Test extract_session_info behavior."""
+
+    def test_extract_from_path(self, tmp_path):
+        """Extracts session ID from file path."""
+        f = tmp_path / "my_session.jsonl"
+        f.write_text("")
+        
+        info = extract_session_info(f)
+        assert info["session_id"] == "my_session"
+        assert info["path"] == str(f)
+        assert "date" in info
+
+    def test_extract_with_date_in_filename(self, tmp_path):
+        """Extracts date from filename if present."""
+        f = tmp_path / "2026-01-15_session.jsonl"
+        f.write_text("")
+        
+        info = extract_session_info(f)
+        assert info["date"] == "2026-01-15"
+
+    def test_extract_uses_mtime_if_no_date(self, tmp_path):
+        """Falls back to file mtime if no date in filename."""
+        f = tmp_path / "session_no_date.jsonl"
+        f.write_text("")
+        
+        info = extract_session_info(f)
+        # Should have a date from mtime
+        assert "date" in info
+        assert len(info["date"]) == 10  # YYYY-MM-DD format
+
+
+class TestProcessJsonlFile:
+    """Test process_jsonl_file behavior."""
+
+    def test_process_empty_file(self, tmp_path):
+        """Processing empty file returns structure with zero tokens."""
+        f = tmp_path / "empty.jsonl"
+        f.write_text("")
+        
+        result = process_jsonl_file(f)
+        assert result["session_id"] == "empty"
+        assert result["tokens"]["input"] == 0
+        assert result["tokens"]["output"] == 0
+        assert result["calls"]["total"] == 0
+        assert result["line_count"] == 0
+
+    def test_process_file_with_single_message(self, tmp_path):
+        """Processing file with one token-bearing message."""
+        f = tmp_path / "session.jsonl"
+        msg = {"type": "assistant", "usage": {"input_tokens": 5, "output_tokens": 10}}
+        f.write_text(json.dumps(msg) + "\n")
+        
+        result = process_jsonl_file(f)
+        assert result["tokens"]["input"] == 5
+        assert result["tokens"]["output"] == 10
+        assert result["line_count"] == 1
+
+    def test_process_file_with_tool_call(self, tmp_path):
+        """Processing file with tool calls counts them."""
+        f = tmp_path / "session.jsonl"
+        msg = {
+            "type": "assistant",
+            "content": [{"type": "tool_use", "name": "my_tool", "id": "c1"}],
+        }
+        f.write_text(json.dumps(msg) + "\n")
+        
+        result = process_jsonl_file(f)
+        assert result["calls"]["total"] == 1
+        assert "my_tool" in result["calls"]["by_tool"]
+
+    def test_process_file_with_mixed_lines(self, tmp_path):
+        """Processing file with valid and invalid lines."""
+        f = tmp_path / "mixed.jsonl"
+        lines = [
+            json.dumps({"type": "user", "usage": {"input_tokens": 1, "output_tokens": 0}}),
+            "invalid json here",  # This line should be skipped
+            json.dumps({"type": "assistant", "usage": {"input_tokens": 2, "output_tokens": 3}}),
+        ]
+        f.write_text("\n".join(lines) + "\n")
+        
+        result = process_jsonl_file(f)
+        # Should sum tokens from valid lines only
+        assert result["tokens"]["input"] == 3
+        assert result["tokens"]["output"] == 3
+        # Invalid line still counts toward line_count (not skipped in counting)
+        assert result["line_count"] == 3
+
+    def test_process_file_with_timestamps(self, tmp_path):
+        """Processing file extracts start and end times."""
+        f = tmp_path / "timestamps.jsonl"
+        ts1 = "2026-01-15T10:00:00Z"
+        ts2 = "2026-01-15T10:05:00Z"
+        lines = [
+            json.dumps({"type": "user", "timestamp": ts1}),
+            json.dumps({"type": "assistant", "ts": ts2}),
+        ]
+        f.write_text("\n".join(lines))
+        
+        result = process_jsonl_file(f)
+        assert result["start"] is not None
+        assert result["end"] is not None
+
+
+class TestMergeSessionIntoTelemetry:
+    """Test merge_session_into_telemetry behavior."""
+
+    def test_merge_creates_day_entry(self, tmp_path):
+        """Merging creates day entry if missing."""
+        telemetry = default_telemetry_v2()
+        f = tmp_path / "session.jsonl"
+        f.write_text("")
+        session_data = {
+            "date": "2026-01-15",
+            "session_id": "session1",
+            "tokens": {"input": 10, "output": 20, "source": "jsonl"},
+            "calls": {"total": 2},
+            "path": str(f),
+        }
+        
+        merge_session_into_telemetry(telemetry, session_data)
+        
+        assert "2026-01-15" in telemetry["days"]
+        assert "session1" in telemetry["days"]["2026-01-15"]["sessions"]
+
+    def test_merge_accumulates_tokens(self, tmp_path):
+        """Merging accumulates tokens across sessions."""
+        telemetry = default_telemetry_v2()
+        f1 = tmp_path / "s1.jsonl"
+        f2 = tmp_path / "s2.jsonl"
+        f1.write_text("")
+        f2.write_text("")
+        
+        session1 = {
+            "date": "2026-01-15",
+            "session_id": "s1",
+            "tokens": {"input": 10, "output": 20, "source": "jsonl"},
+            "calls": {"total": 1},
+            "path": str(f1),
+        }
+        session2 = {
+            "date": "2026-01-15",
+            "session_id": "s2",
+            "tokens": {"input": 5, "output": 10, "source": "jsonl"},
+            "calls": {"total": 1},
+            "path": str(f2),
+        }
+        
+        merge_session_into_telemetry(telemetry, session1)
+        merge_session_into_telemetry(telemetry, session2)
+        
+        day_tokens = telemetry["days"]["2026-01-15"]["tokens"]
+        assert day_tokens["input"] == 15
+        assert day_tokens["output"] == 30
+
+    def test_merge_accumulates_calls(self, tmp_path):
+        """Merging accumulates tool calls."""
+        telemetry = default_telemetry_v2()
+        f = tmp_path / "s1.jsonl"
+        f.write_text("")
+        
+        session = {
+            "date": "2026-01-15",
+            "session_id": "s1",
+            "tokens": {"input": 0, "output": 0, "source": "jsonl"},
+            "calls": {"total": 3, "by_tool": {"bash": 2, "grep": 1}},
+            "path": str(f),
+        }
+        
+        merge_session_into_telemetry(telemetry, session)
+        
+        day_calls = telemetry["days"]["2026-01-15"]["calls"]
+        assert day_calls["total"] == 3
+        assert day_calls["by_tool"]["bash"] == 2
+        assert day_calls["by_tool"]["grep"] == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/backfill/test_jsonl_extractor.py
+++ b/tests/backfill/test_jsonl_extractor.py
@@ -7,7 +7,6 @@ Tests pin current behavior of token extraction and JSONL parsing.
 import json
 import os
 import pytest
-import time
 
 from lib.jsonl_extractor import (
     get_file_hash,
@@ -203,9 +202,10 @@ class TestGetFileHash:
         f.write_text("content")
         hash1 = get_file_hash(f)
         
-        # Change mtime
-        time.sleep(0.01)  # Small delay to ensure mtime difference
-        os.utime(f, None)  # Touch file to update mtime
+        # Change mtime explicitly (sleep-based touch is flaky on coarse
+        # filesystem timestamp resolutions)
+        stat = f.stat()
+        os.utime(f, (stat.st_atime, stat.st_mtime + 1.0))
         hash2 = get_file_hash(f)
         
         assert hash1 != hash2
@@ -216,8 +216,7 @@ class TestGetFileHash:
         f.write_text("content")
         hash1 = get_file_hash(f)
         
-        # Modify file
-        time.sleep(0.01)
+        # Modify file (size change alone changes the hash; no sleep needed)
         f.write_text("longer content now")
         hash2 = get_file_hash(f)
         
@@ -264,9 +263,11 @@ class TestProgressTracking:
         mark_file_processed(f, progress, tokens)
         assert is_file_processed(f, progress)
         
-        # Change file
-        time.sleep(0.01)
+        # Change file; bump mtime explicitly (same size, and sleep-based
+        # mtime changes are flaky on coarse timestamp resolutions)
         f.write_text("content2\n")
+        stat = f.stat()
+        os.utime(f, (stat.st_atime, stat.st_mtime + 1.0))
         
         # Now hash should not match
         assert not is_file_processed(f, progress)

--- a/tests/backfill/test_jsonl_extractor.py
+++ b/tests/backfill/test_jsonl_extractor.py
@@ -6,20 +6,11 @@ Tests pin current behavior of token extraction and JSONL parsing.
 
 import json
 import os
-import sys
-from datetime import datetime, timezone
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import pytest
 import time
 
-# Add lib to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "lib"))
-
-from jsonl_extractor import (
+from lib.jsonl_extractor import (
     get_file_hash,
-    load_progress,
-    save_progress,
     is_file_processed,
     mark_file_processed,
     extract_session_info,
@@ -30,7 +21,7 @@ from jsonl_extractor import (
     merge_session_into_telemetry,
 )
 
-from telemetry_schema_v2 import default_telemetry_v2
+from lib.telemetry_schema_v2 import default_telemetry_v2
 
 
 class TestParseJsonlLine:

--- a/tests/backfill/test_mcp_native.py
+++ b/tests/backfill/test_mcp_native.py
@@ -1,0 +1,569 @@
+"""
+Characterization tests for lib/mcp_native.py.
+
+These tests pin the CURRENT behavior of the module.  They were written
+after the module existed and are expected to PASS on first run.  If a
+behavior looks surprising, a "# NOTE: possible bug" comment is left but
+the test still pins what the code actually does today.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the project root is on sys.path so 'from lib.mcp_native import ...'
+# works regardless of how pytest is invoked.
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from lib.mcp_native import (
+    read_file,
+    write_file,
+    edit_file,
+    glob_files,
+    grep_files,
+    run_bash,
+    NativeToolRegistry,
+    MCPNativeServer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tree(tmp_path: Path) -> dict:
+    """Create a small file tree used by glob/grep tests.
+
+    Returns a dict mapping logical names to absolute Path objects.
+    """
+    (tmp_path / "sub").mkdir()
+    a = tmp_path / "alpha.py"
+    b = tmp_path / "beta.txt"
+    c = tmp_path / "sub" / "gamma.py"
+
+    a.write_text("# alpha module\nHELLO = 'world'\n", encoding="utf-8")
+    b.write_text("just some text\nno code here\n", encoding="utf-8")
+    c.write_text("# gamma module\nHELLO = 'universe'\n", encoding="utf-8")
+
+    return {"alpha": a, "beta": b, "gamma": c}
+
+
+# ===========================================================================
+# read_file
+# ===========================================================================
+
+class TestReadFile:
+
+    def test_full_read(self, tmp_path):
+        f = tmp_path / "sample.txt"
+        f.write_text("line1\nline2\nline3\n", encoding="utf-8")
+
+        result = read_file(str(f))
+
+        assert result["success"] is True
+        assert result["content"] == "line1\nline2\nline3\n"
+
+    def test_offset_and_limit_window(self, tmp_path):
+        f = tmp_path / "multiline.txt"
+        f.write_text("a\nb\nc\nd\ne\n", encoding="utf-8")
+
+        # offset=1, limit=2 → lines b and c
+        result = read_file(str(f), offset=1, limit=2)
+
+        assert result["success"] is True
+        assert result["content"] == "b\nc\n"
+
+    def test_offset_only(self, tmp_path):
+        f = tmp_path / "multiline.txt"
+        f.write_text("a\nb\nc\n", encoding="utf-8")
+
+        result = read_file(str(f), offset=1)
+
+        assert result["success"] is True
+        assert result["content"] == "b\nc\n"
+
+    def test_limit_only(self, tmp_path):
+        f = tmp_path / "multiline.txt"
+        f.write_text("a\nb\nc\n", encoding="utf-8")
+
+        result = read_file(str(f), limit=2)
+
+        assert result["success"] is True
+        assert result["content"] == "a\nb\n"
+
+    def test_missing_file_returns_error(self, tmp_path):
+        missing = str(tmp_path / "does_not_exist.txt")
+        result = read_file(missing)
+
+        # Current behavior: success=False with an error string
+        assert result["success"] is False
+        assert "error" in result
+        assert missing in result["error"] or "not found" in result["error"].lower()
+
+
+# ===========================================================================
+# write_file
+# ===========================================================================
+
+class TestWriteFile:
+
+    def test_creates_file(self, tmp_path):
+        f = tmp_path / "new.txt"
+        result = write_file(str(f), "hello\n")
+
+        assert result["success"] is True
+        assert f.read_text(encoding="utf-8") == "hello\n"
+
+    def test_creates_parent_dirs(self, tmp_path):
+        f = tmp_path / "deep" / "nested" / "file.txt"
+        result = write_file(str(f), "deep content")
+
+        assert result["success"] is True
+        assert f.exists()
+        assert f.read_text(encoding="utf-8") == "deep content"
+
+    def test_overwrites_existing_file(self, tmp_path):
+        f = tmp_path / "existing.txt"
+        f.write_text("old content", encoding="utf-8")
+
+        result = write_file(str(f), "new content")
+
+        assert result["success"] is True
+        assert f.read_text(encoding="utf-8") == "new content"
+
+
+# ===========================================================================
+# edit_file
+# ===========================================================================
+
+class TestEditFile:
+
+    def test_single_occurrence_replaced(self, tmp_path):
+        f = tmp_path / "edit_me.txt"
+        f.write_text("foo bar foo", encoding="utf-8")
+
+        result = edit_file(str(f), "foo", "baz")
+
+        assert result["success"] is True
+        # replace_all defaults to False → only first occurrence
+        assert f.read_text(encoding="utf-8") == "baz bar foo"
+
+    def test_replace_all(self, tmp_path):
+        f = tmp_path / "edit_me.txt"
+        f.write_text("foo bar foo baz foo", encoding="utf-8")
+
+        result = edit_file(str(f), "foo", "qux", replace_all=True)
+
+        assert result["success"] is True
+        assert f.read_text(encoding="utf-8") == "qux bar qux baz qux"
+
+    def test_old_string_not_found_returns_error(self, tmp_path):
+        f = tmp_path / "no_match.txt"
+        f.write_text("nothing to see here", encoding="utf-8")
+
+        result = edit_file(str(f), "NONEXISTENT", "replacement")
+
+        # Current behavior: success=False with error message
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_missing_file_returns_error(self, tmp_path):
+        missing = str(tmp_path / "ghost.txt")
+        result = edit_file(missing, "x", "y")
+
+        assert result["success"] is False
+        assert "error" in result
+
+
+# ===========================================================================
+# glob_files
+# ===========================================================================
+
+class TestGlobFiles:
+
+    def test_simple_pattern(self, tmp_path):
+        _make_tree(tmp_path)
+
+        result = glob_files("*.py", path=str(tmp_path))
+
+        assert result["success"] is True
+        names = {Path(p).name for p in result["files"]}
+        assert "alpha.py" in names
+        # beta.txt is not a .py file
+        assert "beta.txt" not in names
+
+    def test_recursive_pattern(self, tmp_path):
+        _make_tree(tmp_path)
+
+        result = glob_files("**/*.py", path=str(tmp_path))
+
+        assert result["success"] is True
+        names = {Path(p).name for p in result["files"]}
+        assert "alpha.py" in names
+        assert "gamma.py" in names
+
+    def test_no_matches_returns_empty_list(self, tmp_path):
+        _make_tree(tmp_path)
+
+        result = glob_files("*.rb", path=str(tmp_path))
+
+        assert result["success"] is True
+        assert result["files"] == []
+
+
+# ===========================================================================
+# grep_files
+# ===========================================================================
+
+class TestGrepFiles:
+
+    def test_files_mode(self, tmp_path):
+        _make_tree(tmp_path)
+
+        result = grep_files("HELLO", path=str(tmp_path), output_mode="files")
+
+        assert result["success"] is True
+        names = {Path(p).name for p in result["files"]}
+        assert "alpha.py" in names
+        assert "gamma.py" in names
+        # beta.txt does not contain HELLO
+        assert "beta.txt" not in names
+
+    def test_content_mode(self, tmp_path):
+        _make_tree(tmp_path)
+
+        result = grep_files("HELLO", path=str(tmp_path), output_mode="content")
+
+        assert result["success"] is True
+        assert "output" in result
+        assert "HELLO" in result["output"]
+
+    def test_case_insensitive(self, tmp_path):
+        _make_tree(tmp_path)
+
+        # Pattern in lowercase, actual content is uppercase HELLO
+        result = grep_files("hello", path=str(tmp_path), case_insensitive=True)
+
+        assert result["success"] is True
+        assert len(result["files"]) >= 1
+
+    def test_case_sensitive_misses(self, tmp_path):
+        _make_tree(tmp_path)
+
+        # With case sensitivity on, lowercase "hello" should not match "HELLO"
+        result = grep_files("hello", path=str(tmp_path), case_insensitive=False)
+
+        assert result["success"] is True
+        # alpha.py and gamma.py contain HELLO (uppercase), not hello
+        names = {Path(p).name for p in result["files"]}
+        assert "alpha.py" not in names
+
+    def test_file_glob_filter(self, tmp_path):
+        _make_tree(tmp_path)
+
+        # Only search .py files; beta.txt would match "text" but we filter it out
+        result = grep_files(
+            "text",
+            path=str(tmp_path),
+            file_glob="*.txt",
+            output_mode="files",
+        )
+
+        assert result["success"] is True
+        names = {Path(p).name for p in result["files"]}
+        assert "beta.txt" in names
+        assert "alpha.py" not in names
+
+    def test_no_match_returns_empty_files(self, tmp_path):
+        _make_tree(tmp_path)
+
+        result = grep_files("ZZZNOMATCH", path=str(tmp_path))
+
+        assert result["success"] is True
+        assert result["files"] == []
+
+
+# ===========================================================================
+# run_bash
+# ===========================================================================
+
+class TestRunBash:
+
+    def test_simple_echo(self):
+        result = run_bash("echo ok")
+
+        assert result["success"] is True
+        assert result["stdout"].strip() == "ok"
+        assert result["exit_code"] == 0
+
+    def test_nonzero_exit(self):
+        result = run_bash("exit 42")
+
+        assert result["success"] is False
+        assert result["exit_code"] == 42
+
+    def test_cwd_respected(self, tmp_path):
+        result = run_bash("pwd", cwd=str(tmp_path))
+
+        assert result["success"] is True
+        # Resolve both to handle symlinks (e.g. /tmp on macOS)
+        assert Path(result["stdout"].strip()).resolve() == tmp_path.resolve()
+
+    def test_stderr_captured(self):
+        result = run_bash("echo err >&2; exit 1")
+
+        assert result["exit_code"] != 0
+        assert "err" in result["stderr"]
+
+    def test_stdout_and_stderr_keys_present(self):
+        result = run_bash("echo hello")
+
+        assert "stdout" in result
+        assert "stderr" in result
+        assert "exit_code" in result
+
+
+# ===========================================================================
+# NativeToolRegistry
+# ===========================================================================
+
+class TestNativeToolRegistry:
+
+    EXPECTED_TOOLS = {"read_file", "write_file", "edit_file", "glob", "grep", "bash"}
+
+    def test_list_tools_returns_expected_names(self):
+        registry = NativeToolRegistry()
+        tools = registry.list_tools()
+
+        assert isinstance(tools, list)
+        assert set(tools) == self.EXPECTED_TOOLS
+
+    def test_list_tools_returns_copy(self):
+        registry = NativeToolRegistry()
+        tools = registry.list_tools()
+        tools.append("INJECTED")
+
+        # Internal list must be unaffected
+        assert "INJECTED" not in registry.list_tools()
+
+    def test_get_schema_known_tool(self):
+        registry = NativeToolRegistry()
+        schema = registry.get_schema("read_file")
+
+        assert isinstance(schema, dict)
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert "file_path" in schema["properties"]
+        assert "required" in schema
+        assert "file_path" in schema["required"]
+
+    def test_get_schema_has_correct_shape_for_bash(self):
+        registry = NativeToolRegistry()
+        schema = registry.get_schema("bash")
+
+        assert schema["type"] == "object"
+        assert "command" in schema["properties"]
+        assert "command" in schema["required"]
+
+    def test_get_schema_unknown_tool_returns_none(self):
+        registry = NativeToolRegistry()
+        result = registry.get_schema("nonexistent_tool")
+
+        assert result is None
+
+    def test_get_description_known_tool(self):
+        registry = NativeToolRegistry()
+        desc = registry.get_description("write_file")
+
+        assert isinstance(desc, str)
+        assert len(desc) > 0
+
+    def test_get_description_unknown_tool_returns_none(self):
+        registry = NativeToolRegistry()
+        result = registry.get_description("nonexistent_tool")
+
+        assert result is None
+
+
+# ===========================================================================
+# MCPNativeServer — properties
+# ===========================================================================
+
+class TestMCPNativeServerProperties:
+
+    def test_default_name(self):
+        server = MCPNativeServer()
+        assert server.name == "native"
+
+    def test_custom_name(self):
+        server = MCPNativeServer(name="my-server")
+        assert server.name == "my-server"
+
+    def test_version_is_string(self):
+        server = MCPNativeServer()
+        assert isinstance(server.version, str)
+        assert len(server.version) > 0
+
+    def test_default_timeout(self):
+        server = MCPNativeServer()
+        assert server.timeout == 120
+
+    def test_custom_timeout(self):
+        server = MCPNativeServer(timeout=30)
+        assert server.timeout == 30
+
+    def test_working_dir_default_none(self):
+        server = MCPNativeServer()
+        assert server.working_dir is None
+
+    def test_tools_property_structure(self):
+        server = MCPNativeServer()
+        tools = server.tools
+
+        assert isinstance(tools, list)
+        assert len(tools) == 6  # read_file, write_file, edit_file, glob, grep, bash
+
+        for t in tools:
+            assert "name" in t
+            assert "description" in t
+            assert "inputSchema" in t
+
+
+# ===========================================================================
+# MCPNativeServer.handle_raw_request / handle_request
+# ===========================================================================
+
+class TestMCPNativeServerRequests:
+
+    def test_invalid_json_returns_parse_error(self):
+        server = MCPNativeServer()
+        response = server.handle_raw_request("{not valid json")
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] is None
+        assert "error" in response
+        assert response["error"]["code"] == -32700
+
+    def test_handle_initialize_request(self):
+        server = MCPNativeServer()
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }
+        response = server.handle_request(request)
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 1
+        assert "result" in response
+        result = response["result"]
+        assert "protocolVersion" in result
+        assert result["serverInfo"]["name"] == "native"
+
+    def test_handle_tools_list_request(self):
+        server = MCPNativeServer()
+        request = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }
+        response = server.handle_request(request)
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 2
+        assert "result" in response
+        assert "tools" in response["result"]
+        tool_names = {t["name"] for t in response["result"]["tools"]}
+        assert "read_file" in tool_names
+        assert "bash" in tool_names
+
+    def test_handle_unknown_method_returns_method_not_found(self):
+        server = MCPNativeServer()
+        request = {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "nonexistent/method",
+            "params": {}
+        }
+        response = server.handle_request(request)
+
+        assert "error" in response
+        assert response["error"]["code"] == -32601
+
+    def test_handle_missing_method_returns_invalid_request(self):
+        server = MCPNativeServer()
+        request = {"jsonrpc": "2.0", "id": 4}  # no "method" key
+        response = server.handle_request(request)
+
+        assert "error" in response
+        assert response["error"]["code"] == -32600
+
+    def test_handle_tools_call_read_file(self, tmp_path):
+        server = MCPNativeServer()
+        f = tmp_path / "hello.txt"
+        f.write_text("characterization test content\n", encoding="utf-8")
+
+        request = {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {"file_path": str(f)}
+            }
+        }
+        response = server.handle_request(request)
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 5
+        assert "result" in response
+        result = response["result"]
+        assert "content" in result
+        assert isinstance(result["content"], list)
+        assert result["content"][0]["type"] == "text"
+        assert "characterization test content" in result["content"][0]["text"]
+
+
+# ===========================================================================
+# MCPNativeServer.call_tool
+# ===========================================================================
+
+class TestMCPNativeServerCallTool:
+
+    def test_call_tool_read_file_dispatches(self, tmp_path):
+        server = MCPNativeServer()
+        f = tmp_path / "dispatch.txt"
+        f.write_text("dispatch test\n", encoding="utf-8")
+
+        result = server.call_tool("read_file", {"file_path": str(f)})
+
+        assert "content" in result
+        assert result["content"][0]["type"] == "text"
+        assert "dispatch test" in result["content"][0]["text"]
+        assert "isError" not in result or result.get("isError") is False
+
+    def test_call_tool_unknown_name_returns_error(self):
+        server = MCPNativeServer()
+        result = server.call_tool("totally_unknown", {})
+
+        assert result.get("isError") is True
+        assert "Unknown tool" in result["content"][0]["text"]
+
+    def test_call_tool_write_then_read(self, tmp_path):
+        server = MCPNativeServer()
+        f = tmp_path / "roundtrip.txt"
+
+        write_result = server.call_tool("write_file", {
+            "file_path": str(f),
+            "content": "round-trip content\n"
+        })
+        assert write_result.get("isError") is not True
+
+        read_result = server.call_tool("read_file", {"file_path": str(f)})
+        assert "round-trip content" in read_result["content"][0]["text"]

--- a/tests/backfill/test_mcp_native.py
+++ b/tests/backfill/test_mcp_native.py
@@ -7,17 +7,8 @@ behavior looks surprising, a "# NOTE: possible bug" comment is left but
 the test still pins what the code actually does today.
 """
 
-import json
-import sys
 from pathlib import Path
 
-import pytest
-
-# Ensure the project root is on sys.path so 'from lib.mcp_native import ...'
-# works regardless of how pytest is invoked.
-PROJECT_ROOT = Path(__file__).parent.parent.parent
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 from lib.mcp_native import (
     read_file,

--- a/tests/backfill/test_telemetry_schema_v2.py
+++ b/tests/backfill/test_telemetry_schema_v2.py
@@ -2,7 +2,7 @@
 """Characterization tests for lib.telemetry_schema_v2."""
 
 import json
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 from lib.telemetry_schema_v2 import (
     default_token_data, default_call_data, default_summarization_data,
     default_timing_data, default_day_data, default_aggregate_data, default_telemetry_v2,
@@ -281,7 +281,7 @@ class TestRecomputeAggregates:
         today = date.today()
         day_recent = ensure_day(tel, today.isoformat())
         day_recent["tokens"]["input"] = 100
-        day_old = ensure_day(tel, "2026-01-01")
+        day_old = ensure_day(tel, (today - timedelta(days=10)).isoformat())
         day_old["tokens"]["input"] = 1000
         recompute_aggregates(tel)
         last_7 = tel["aggregates"]["last_7_days"]

--- a/tests/backfill/test_telemetry_schema_v2.py
+++ b/tests/backfill/test_telemetry_schema_v2.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Characterization tests for lib.telemetry_schema_v2."""
+
+import json
+from datetime import datetime, date
+from lib.telemetry_schema_v2 import (
+    default_token_data, default_call_data, default_summarization_data,
+    default_timing_data, default_day_data, default_aggregate_data, default_telemetry_v2,
+    ensure_day, update_timing_stats, update_summarization_rate,
+    add_to_filters, merge_tokens, merge_calls, recompute_aggregates, update_filter_options,
+    load_telemetry_v2, save_telemetry_v2,
+)
+
+
+class TestDefaultTokenData:
+    def test_returns_empty_structure(self):
+        tokens = default_token_data()
+        assert tokens["input"] == 0
+        assert tokens["output"] == 0
+        assert tokens["cache_read"] == 0
+        assert tokens["cache_creation"] == 0
+        assert tokens["source"] == "router"
+
+    def test_accepts_source_parameter(self):
+        tokens = default_token_data(source="jsonl")
+        assert tokens["source"] == "jsonl"
+
+    def test_returns_dict(self):
+        tokens = default_token_data()
+        assert isinstance(tokens, dict)
+
+
+class TestDefaultCallData:
+    def test_returns_empty_structure(self):
+        calls = default_call_data()
+        assert calls["total"] == 0
+        assert calls["by_tool"] == {}
+        assert calls["by_backend"] == {}
+
+    def test_returns_dict(self):
+        calls = default_call_data()
+        assert isinstance(calls, dict)
+
+
+class TestDefaultSummarizationData:
+    def test_returns_empty_structure(self):
+        summ = default_summarization_data()
+        assert summ["offered"] == 0
+        assert summ["accepted"] == 0
+        assert summ["rejected"] == 0
+        assert summ["acceptance_rate"] == 0.0
+        assert summ["tokens_saved_est"] == 0
+
+
+class TestDefaultTimingData:
+    def test_returns_empty_structure(self):
+        timing = default_timing_data()
+        assert timing["avg_response_ms"] == 0.0
+        assert timing["p95_response_ms"] == 0.0
+        assert timing["by_backend"] == {}
+
+
+class TestDefaultDayData:
+    def test_returns_empty_structure(self):
+        day = default_day_data()
+        assert "tokens" in day
+        assert "calls" in day
+        assert "summarization" in day
+        assert "timing" in day
+        assert day["sessions"] == []
+        assert day["by_session"] == {}
+
+
+class TestDefaultAggregateData:
+    def test_returns_empty_structure(self):
+        agg = default_aggregate_data()
+        assert "tokens" in agg
+        assert "calls" in agg
+        assert "summarization" in agg
+
+
+class TestDefaultTelemetryV2:
+    def test_returns_empty_structure(self):
+        tel = default_telemetry_v2()
+        assert tel["version"] == "2.0"
+        assert isinstance(tel.get("days", {}), dict)
+        assert isinstance(tel.get("aggregates", {}), dict)
+        assert isinstance(tel.get("filters", {}), dict)
+
+    def test_has_default_aggregates(self):
+        tel = default_telemetry_v2()
+        aggs = tel.get("aggregates", {})
+        assert "all_time" in aggs
+        assert "last_7_days" in aggs
+        assert "last_30_days" in aggs
+
+
+class TestEnsureDay:
+    def test_creates_missing_day(self):
+        tel = default_telemetry_v2()
+        day_data = ensure_day(tel, "2026-06-10")
+        assert "2026-06-10" in tel.get("days", {})
+        assert day_data["tokens"]["input"] == 0
+
+    def test_returns_existing_day_unchanged(self):
+        tel = default_telemetry_v2()
+        day_data1 = ensure_day(tel, "2026-06-10")
+        day_data1["tokens"]["input"] = 100
+        day_data2 = ensure_day(tel, "2026-06-10")
+        assert day_data2["tokens"]["input"] == 100
+
+    def test_creates_days_dict_if_missing(self):
+        tel = {"version": "2.0"}
+        ensure_day(tel, "2026-06-10")
+        assert "days" in tel
+        assert "2026-06-10" in tel["days"]
+
+
+class TestUpdateTimingStats:
+    def test_creates_backend_entry(self):
+        timing = default_timing_data()
+        update_timing_stats(timing, "claude", 100)
+        assert "claude" in timing["by_backend"]
+        assert timing["by_backend"]["claude"]["count"] == 1
+        assert timing["by_backend"]["claude"]["avg_ms"] == 100
+        assert timing["by_backend"]["claude"]["total_ms"] == 100
+
+    def test_accumulates_multiple_latencies(self):
+        timing = default_timing_data()
+        update_timing_stats(timing, "claude", 100)
+        update_timing_stats(timing, "claude", 200)
+        update_timing_stats(timing, "claude", 300)
+        stats = timing["by_backend"]["claude"]
+        assert stats["count"] == 3
+        assert stats["total_ms"] == 600
+        assert stats["avg_ms"] == 200.0
+        assert stats["p95_ms"] == 300
+
+    def test_multiple_backends_independent(self):
+        timing = default_timing_data()
+        update_timing_stats(timing, "claude", 100)
+        update_timing_stats(timing, "gpt", 200)
+        assert timing["by_backend"]["claude"]["avg_ms"] == 100
+        assert timing["by_backend"]["gpt"]["avg_ms"] == 200
+
+
+class TestUpdateSummarizationRate:
+    def test_calculates_acceptance_rate(self):
+        summ = default_summarization_data()
+        summ["offered"] = 10
+        summ["accepted"] = 7
+        update_summarization_rate(summ)
+        assert summ["acceptance_rate"] == 0.7
+
+    def test_rounds_to_three_decimals(self):
+        summ = default_summarization_data()
+        summ["offered"] = 3
+        summ["accepted"] = 1
+        update_summarization_rate(summ)
+        assert summ["acceptance_rate"] == 0.333
+
+    def test_handles_zero_offered(self):
+        summ = default_summarization_data()
+        summ["offered"] = 0
+        summ["accepted"] = 0
+        update_summarization_rate(summ)
+        assert summ["acceptance_rate"] == 0.0
+
+
+class TestAddToFilters:
+    def test_adds_tool(self):
+        filters = {}
+        add_to_filters(filters, tool="grep")
+        assert "grep" in filters.get("available_tools", [])
+
+    def test_adds_backend(self):
+        filters = {}
+        add_to_filters(filters, backend="claude")
+        assert "claude" in filters.get("available_backends", [])
+
+    def test_adds_session(self):
+        filters = {}
+        add_to_filters(filters, session="sess-123")
+        assert "sess-123" in filters.get("available_sessions", [])
+
+    def test_deduplicates_tools(self):
+        filters = {}
+        add_to_filters(filters, tool="grep")
+        add_to_filters(filters, tool="grep")
+        assert filters.get("available_tools", []).count("grep") == 1
+
+    def test_deduplicates_backends(self):
+        filters = {}
+        add_to_filters(filters, backend="claude")
+        add_to_filters(filters, backend="claude")
+        assert filters.get("available_backends", []).count("claude") == 1
+
+    def test_deduplicates_sessions(self):
+        filters = {}
+        add_to_filters(filters, session="sess-123")
+        add_to_filters(filters, session="sess-123")
+        assert filters.get("available_sessions", []).count("sess-123") == 1
+
+
+class TestMergeTokens:
+    def test_merges_token_counts(self):
+        target = default_token_data()
+        source = default_token_data()
+        source["input"] = 100
+        source["output"] = 50
+        merge_tokens(target, source)
+        assert target["input"] == 100
+        assert target["output"] == 50
+
+    def test_merges_cache_counts(self):
+        target = default_token_data()
+        source = default_token_data()
+        source["cache_read"] = 10
+        source["cache_creation"] = 5
+        merge_tokens(target, source)
+        assert target["cache_read"] == 10
+        assert target["cache_creation"] == 5
+
+    def test_prefers_jsonl_source(self):
+        target = default_token_data(source="estimated")
+        source = default_token_data(source="jsonl")
+        merge_tokens(target, source)
+        assert target["source"] == "jsonl"
+
+
+class TestMergeCalls:
+    def test_merges_total_calls(self):
+        target = default_call_data()
+        source = default_call_data()
+        source["total"] = 100
+        merge_calls(target, source)
+        assert target["total"] == 100
+
+    def test_merges_by_tool(self):
+        target = default_call_data()
+        source = default_call_data()
+        source["by_tool"] = {"grep": 10, "find": 5}
+        merge_calls(target, source)
+        assert target["by_tool"]["grep"] == 10
+        assert target["by_tool"]["find"] == 5
+
+    def test_merges_by_backend(self):
+        target = default_call_data()
+        source = default_call_data()
+        source["by_backend"] = {"claude": 20, "gpt": 30}
+        merge_calls(target, source)
+        assert target["by_backend"]["claude"] == 20
+        assert target["by_backend"]["gpt"] == 30
+
+    def test_accumulates_different_tools(self):
+        target = default_call_data()
+        target["by_tool"] = {"grep": 10}
+        source = default_call_data()
+        source["by_tool"] = {"find": 5}
+        merge_calls(target, source)
+        assert target["by_tool"]["grep"] == 10
+        assert target["by_tool"]["find"] == 5
+
+
+class TestRecomputeAggregates:
+    def test_computes_all_time(self):
+        tel = default_telemetry_v2()
+        day1 = ensure_day(tel, "2026-06-08")
+        day1["tokens"]["input"] = 100
+        day1["calls"]["total"] = 10
+        day2 = ensure_day(tel, "2026-06-09")
+        day2["tokens"]["input"] = 50
+        day2["calls"]["total"] = 5
+        recompute_aggregates(tel)
+        all_time = tel["aggregates"]["all_time"]
+        assert all_time["tokens"]["input"] == 150
+        assert all_time["calls"]["total"] == 15
+
+    def test_computes_last_7_days(self):
+        tel = default_telemetry_v2()
+        today = date.today()
+        day_recent = ensure_day(tel, today.isoformat())
+        day_recent["tokens"]["input"] = 100
+        day_old = ensure_day(tel, "2026-01-01")
+        day_old["tokens"]["input"] = 1000
+        recompute_aggregates(tel)
+        last_7 = tel["aggregates"]["last_7_days"]
+        assert last_7["tokens"]["input"] == 100
+
+
+class TestUpdateFilterOptions:
+    def test_extracts_tools_from_days(self):
+        tel = default_telemetry_v2()
+        day = ensure_day(tel, "2026-06-10")
+        day["calls"]["by_tool"] = {"grep": 5, "find": 3}
+        update_filter_options(tel)
+        filters = tel.get("filters", {})
+        tools = filters.get("available_tools", [])
+        assert "grep" in tools
+        assert "find" in tools
+
+    def test_extracts_backends_from_days(self):
+        tel = default_telemetry_v2()
+        day = ensure_day(tel, "2026-06-10")
+        day["calls"]["by_backend"] = {"claude": 5, "gpt": 3}
+        update_filter_options(tel)
+        filters = tel.get("filters", {})
+        backends = filters.get("available_backends", [])
+        assert "claude" in backends
+        assert "gpt" in backends
+
+
+class TestLoadTelemetryV2:
+    def test_returns_default_for_missing_file(self, tmp_path):
+        path = tmp_path / "missing.json"
+        result = load_telemetry_v2(path)
+        assert result["version"] == "2.0"
+        assert isinstance(result.get("days", {}), dict)
+
+    def test_returns_default_for_invalid_json(self, tmp_path):
+        path = tmp_path / "corrupt.json"
+        path.write_text("{invalid json")
+        result = load_telemetry_v2(path)
+        assert result["version"] == "2.0"
+
+    def test_returns_default_for_wrong_version(self, tmp_path):
+        path = tmp_path / "v1.json"
+        path.write_text(json.dumps({"version": "1.0", "data": "old"}))
+        result = load_telemetry_v2(path)
+        assert result["version"] == "2.0"
+
+    def test_loads_valid_v2_telemetry(self, tmp_path):
+        path = tmp_path / "valid.json"
+        original = default_telemetry_v2()
+        original["custom_field"] = "test_value"
+        path.write_text(json.dumps(original))
+        result = load_telemetry_v2(path)
+        assert result["version"] == "2.0"
+        assert result["custom_field"] == "test_value"
+
+
+class TestSaveTelemetryV2:
+    def test_saves_telemetry_to_file(self, tmp_path):
+        path = tmp_path / "saved.json"
+        tel = default_telemetry_v2()
+        tel["test_key"] = "test_value"
+        save_telemetry_v2(tel, path)
+        assert path.exists()
+        loaded = json.loads(path.read_text())
+        assert loaded["test_key"] == "test_value"
+
+    def test_sets_last_updated(self, tmp_path):
+        path = tmp_path / "saved.json"
+        tel = default_telemetry_v2()
+        save_telemetry_v2(tel, path)
+        loaded = json.loads(path.read_text())
+        assert "last_updated" in loaded
+        datetime.fromisoformat(loaded["last_updated"])
+
+    def test_creates_parent_directory(self, tmp_path):
+        path = tmp_path / "subdir" / "nested" / "saved.json"
+        tel = default_telemetry_v2()
+        save_telemetry_v2(tel, path)
+        assert path.exists()
+        assert path.parent.exists()
+
+    def test_round_trip(self, tmp_path):
+        path = tmp_path / "roundtrip.json"
+        original = default_telemetry_v2()
+        original["custom"] = "data"
+        day = ensure_day(original, "2026-06-10")
+        day["tokens"]["input"] = 123
+        save_telemetry_v2(original, path)
+        loaded = load_telemetry_v2(path)
+        assert loaded["custom"] == "data"
+        assert loaded["days"]["2026-06-10"]["tokens"]["input"] == 123
+        assert "last_updated" in loaded


### PR DESCRIPTION
## Summary
- Adds characterization test suites for four previously untested lib modules: `telemetry_schema_v2` (45 tests), `jsonl_extractor` (34), `mcp_native` (49), `connection_pool` (13) — 141 tests, all hermetic (tmp_path only).
- Produced by the first live run of the delegate workflow (Fable decomposed the manifest; tiered haiku/sonnet workers wrote the suites in parallel worktrees; coherence-review pass normalized import conventions).
- Two latent findings documented in-test rather than fixed: `lib/connection_pool.py`'s `from config import BackendConfig` resolves against the root `config/` namespace package outside the daemon context (tests stub it), and `extract_tokens_from_message` crashes on non-dict usage (pinned with a possible-bug note).

## Test plan
- [x] `pytest tests/backfill/ -q` — 141 passed on this branch (origin/master + these commits)
- [x] Full suite green on the integration tree (1660 passed)