### PR TITLE
feat: spawn integrity — briefing enforcement + stale spawn-doc fixes

### DIFF
--- a/hooks/agent-dispatch.py
+++ b/hooks/agent-dispatch.py
@@ -8,6 +8,7 @@ additionalContext so the subagent starts with its identity and protocol.
 """
 
 import json
+import os
 import socket
 import sys
 
@@ -99,18 +100,62 @@ def main():
     })
 
     if result and result.get("success"):
-        # Return full dispatch state as JSON in additionalContext
-        dispatch_state = json.dumps({
-            "agent_id": result.get("agent_id"),
-            "briefing": result.get("briefing", ""),
-            "agent_type": result.get("agent_type", agent_type),
-        })
-        print(json.dumps(allow(
-            reason=f"Agent {result.get('agent_id', '?')} registered via prepare_dispatch",
-            additional_context=dispatch_state,
-        )))
+        agent_id = result.get("agent_id", "?")
+        briefing = result.get("briefing", "")
+        agent_type_result = result.get("agent_type", agent_type)
+
+        # Enforce briefing delivery
+        briefing_marker = "## Your Agent Identity"
+        enforce = os.environ.get("AGENT_SWARM_BRIEFING_ENFORCE", "block")
+
+        if briefing_marker in prompt:
+            # Prompt already contains the briefing -- allow as-is
+            dispatch_state = json.dumps({
+                "agent_id": agent_id,
+                "briefing": briefing,
+                "agent_type": agent_type_result,
+            })
+            print(json.dumps(allow(
+                reason=f"Agent {agent_id} registered via prepare_dispatch",
+                additional_context=dispatch_state,
+            )))
+        elif enforce == "off":
+            # Legacy passthrough -- no enforcement
+            dispatch_state = json.dumps({
+                "agent_id": agent_id,
+                "briefing": briefing,
+                "agent_type": agent_type_result,
+            })
+            print(json.dumps(allow(
+                reason=f"Agent {agent_id} registered via prepare_dispatch",
+                additional_context=dispatch_state,
+            )))
+        elif enforce == "warn":
+            dispatch_state = json.dumps({
+                "agent_id": agent_id,
+                "briefing": briefing,
+                "agent_type": agent_type_result,
+            })
+            warning = (
+                f"WARNING: spawn prompt is unbriefed (missing {briefing_marker!r}). "
+                f"agent_id={agent_id}. "
+            )
+            print(json.dumps(allow(
+                reason=f"Agent {agent_id} registered via prepare_dispatch (unbriefed, warned)",
+                additional_context=warning + dispatch_state,
+            )))
+        else:
+            # Default: block and tell the spawner what to prepend
+            reason = (
+                f"Spawn blocked: prompt is missing the briefing marker {briefing_marker!r}. "
+                f"Prepend the following briefing to the prompt and re-spawn:\n"
+                f"agent_id: {agent_id}\n"
+                f"{briefing_marker}\n"
+                f"{briefing}"
+            )
+            print(json.dumps(block(reason)))
     else:
-        # Graceful degradation — don't break spawning if daemon is down
+        # Graceful degradation -- don't break spawning if daemon is down
         print(json.dumps(allow("prepare_dispatch unavailable, allowing through")))
 
 

--- a/hooks/agent-dispatch.py
+++ b/hooks/agent-dispatch.py
@@ -131,18 +131,19 @@ def main():
                 additional_context=dispatch_state,
             )))
         elif enforce == "warn":
+            warning = (
+                f"WARNING: spawn prompt is unbriefed (missing {briefing_marker!r}). "
+                f"agent_id={agent_id}."
+            )
             dispatch_state = json.dumps({
                 "agent_id": agent_id,
                 "briefing": briefing,
                 "agent_type": agent_type_result,
+                "warning": warning,
             })
-            warning = (
-                f"WARNING: spawn prompt is unbriefed (missing {briefing_marker!r}). "
-                f"agent_id={agent_id}. "
-            )
             print(json.dumps(allow(
                 reason=f"Agent {agent_id} registered via prepare_dispatch (unbriefed, warned)",
-                additional_context=warning + dispatch_state,
+                additional_context=dispatch_state,
             )))
         else:
             # Default: block and tell the spawner what to prepend

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -100,13 +100,18 @@ workflow__advance_phase(wf_id, "dispatch")
 python3 ${AGENT_SWARM_ROOT}/lib/orchestrator.py pending .delegate/<slug>.yaml --json
 ```
 
-For each entry, spawn a worker with the **Agent tool**:
+For each entry, register the worker, then spawn it with the **Agent
+tool** (the spawn protocol — see `skills/spawn/SKILL.md`):
 
-- `subagent_type: "general-purpose"` (same as parallel-orchestrate)
-- `model: <entry.model>` — **this is the tiering lever; never omit it**
-- `prompt`: the `prompt` field verbatim
-- Spawn all pending tasks **in parallel** — worktrees isolate them
-
+1. `reg = router__register_agent(agent_id="<task_name>-w<n>", agent_type="implementer", roles=["editor", "shell_full"])`
+2. Spawn:
+   - `subagent_type: "implementer"` — never a native type
+     (`general-purpose`/`Explore`/`Plan`): native types have no router
+     access and will flail
+   - `model: <entry.model>` — **this is the tiering lever; never omit it**
+   - `prompt`: `reg["briefing"] + "\n\n" +` the entry's `prompt` field
+     verbatim — the briefing carries the worker's identity/caller-id
+   - Spawn all pending tasks **in parallel** — worktrees isolate them
 Record each spawn, then advance:
 
 ```bash

--- a/skills/parallel-orchestrate/SKILL.md
+++ b/skills/parallel-orchestrate/SKILL.md
@@ -28,7 +28,7 @@ The `start` command creates a git worktree per task under `{project_dir}/.worktr
 ```
 LOAD → START → SPAWN → MONITOR → MERGE → VERIFY → COMPLETE → STOP
                  ↑         |                |
-                 └─ RETRY ─┘          (fail: fix/rollback/continue)
+                 └── RETRY ─┘          (fail: fix/rollback/continue)
          (blocked tasks wait for dependencies)
 ```
 
@@ -39,10 +39,18 @@ Get pending tasks:
 python3 lib/orchestrator.py pending <manifest.yaml> --json
 ```
 
-This returns a JSON array. For each entry, spawn a subagent using the **Agent tool**:
+This returns a JSON array. For each entry, register the worker, then
+spawn it using the **Agent tool** (the spawn protocol — see
+`skills/spawn/SKILL.md`):
 
-- Use `subagent_type: "general-purpose"`
-- Pass the `prompt` field verbatim — it already contains worktree paths and "do NOT switch branches" instructions
+- `reg = router__register_agent(agent_id="<task_name>-w<n>", agent_type="implementer", roles=["editor", "shell_full"])`
+- Use `subagent_type: "implementer"` — never a native type
+  (`general-purpose`/`Explore`/`Plan`): native types have no router
+  access and will flail
+- `prompt`: `reg["briefing"] + "\n\n" +` the `prompt` field verbatim —
+  the briefing carries the worker's identity/caller-id; the prompt
+  already contains worktree paths and "do NOT switch branches"
+  instructions
 - The `worktree_dir` field tells you where the subagent will work (for your reference)
 - Run subagents **in parallel** — worktrees give each one an isolated directory
 

--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -99,6 +99,7 @@ Ask the user: **Proceed to orchestration / Edit the manifest first / Stop**
 Invoke `agent-swarm:parallel-orchestrate` with the manifest path.
 
 The orchestrator handles everything from here: spawning subagents, monitoring, merging, verification, and branch completion.
+Subagent spawning in that skill follows the mandatory register+prepend protocol; see `skills/spawn/SKILL.md` for the full contract.
 
 ---
 

--- a/skills/teams-develop/SKILL.md
+++ b/skills/teams-develop/SKILL.md
@@ -20,7 +20,10 @@ INTAKE → RESEARCH → DESIGN → IMPLEMENT → REVIEW → INTEGRATE → COMPLE
 
 Kickbacks: REVIEW → IMPLEMENT (code issues), INTEGRATE → IMPLEMENT (merge conflicts / test failures).
 
+<!-- spawn-conformance: native-teams-exempt -->
 ## Agent Lifecycle
+
+These agents run as native Claude Code team members via `Agent()` / `TeamCreate()` / `SendMessage()` and do not route through the router; they cannot use `mcp-call` and do not need `register_agent` or a briefing prepend.
 
 | Role | Phase | Agent Type | Model | Isolation | Writes? |
 |------|-------|------------|-------|-----------|---------|
@@ -104,6 +107,7 @@ Create feature branch, create tasks per subtask, spawn implementers in isolated 
    TaskUpdate(taskId=<id>, addBlockedBy=[<dependency-ids>])
    ```
 3. For each unblocked task, spawn an implementer:
+<!-- spawn-conformance: native-teams-exempt -->
    ```
    Agent(
      team_name="td-<slug>",

--- a/tests/test_agent_dispatch_hook.py
+++ b/tests/test_agent_dispatch_hook.py
@@ -201,7 +201,8 @@ def test_unbriefed_warn_allows_with_warning():
     hso = decision["hookSpecificOutput"]
     assert hso["permissionDecision"] == "allow"
     ctx = hso.get("additionalContext", "")
-    assert "WARNING" in ctx
+    parsed = json.loads(ctx)  # payload must remain valid JSON for consumers
+    assert "WARNING" in parsed["warning"]
 
 
 def test_unbriefed_off_allows_no_warning():

--- a/tests/test_agent_dispatch_hook.py
+++ b/tests/test_agent_dispatch_hook.py
@@ -10,6 +10,7 @@ from both directions (the fix had zero coverage; surfaced by adversarial review)
 import importlib.util
 import io
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -79,3 +80,155 @@ def test_camelcase_payload_is_not_dispatched():
 def test_non_dispatch_tool_is_passthrough():
     calls = _run({"tool_name": "Read", "tool_input": {"file_path": "/x"}})
     assert calls == []
+
+
+
+# ---------------------------------------------------------------------------
+# Helper for enforcement tests -- captures stdout decision as parsed dict
+# ---------------------------------------------------------------------------
+
+
+
+
+def _run_with_decision(payload, *, briefing="B", router_success=True, env=None):
+    """Run main() and return (calls, decision_dict).
+
+    `briefing` is the text returned by fake_call_router so tests can
+    put it into the prompt to simulate a briefed spawn.
+    `router_success` controls whether the fake router returns success.
+    `env` is an optional dict of extra os.environ overrides.
+    """
+    mod = _load_hook()
+    calls = []
+    stdout_buf = io.StringIO()
+
+    def fake_call_router(tool_name, args=None, timeout=5.0):
+        calls.append((tool_name, args or {}))
+        if not router_success:
+            return None
+        return {
+            "success": True,
+            "agent_id": "sub-test",
+            "briefing": briefing,
+            "agent_type": (args or {}).get("agent_type"),
+        }
+
+    env_overrides = env or {}
+    orig_env = {k: os.environ.get(k) for k in env_overrides}
+    try:
+        for k, v in env_overrides.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        with patch.object(mod, "call_router", fake_call_router), \
+                patch("sys.stdin", io.StringIO(json.dumps(payload))), \
+                patch("sys.stdout", stdout_buf):
+            mod.main()
+    finally:
+        for k, v in orig_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    raw = stdout_buf.getvalue()
+    decision = json.loads(raw) if raw.strip() else {}
+    return calls, decision
+
+
+BRIEFING_MARKER = "## Your Agent Identity"
+_BRIEFED_PROMPT = BRIEFING_MARKER + chr(10) + "Agent ID: sub-test" + chr(10) + "some briefing text"
+_UNBRIEFED_PROMPT = "do something without briefing"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement tests (6 required)
+# ---------------------------------------------------------------------------
+
+
+def test_briefed_prompt_allows():
+    """When the spawn prompt contains the briefing marker, the hook allows."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _BRIEFED_PROMPT, "description": "d"},
+        }
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+
+
+def test_unbriefed_default_blocks_with_agent_id_and_marker():
+    """Unbriefed prompt + default env (block) must block, with reason containing
+    the agent_id and the briefing marker so the spawner can comply."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "block"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "block"
+    reason = hso["permissionDecisionReason"]
+    assert "## Your Agent Identity" in reason
+    assert "sub-test" in reason
+
+
+def test_unbriefed_default_env_absent_blocks():
+    """Default behavior (env var absent) must also block -- same as explicit 'block'."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Task",
+            "tool_input": {"subagent_type": "reviewer", "prompt": _UNBRIEFED_PROMPT},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": None},  # ensure absent
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "block"
+
+
+def test_unbriefed_warn_allows_with_warning():
+    """AGENT_SWARM_BRIEFING_ENFORCE=warn must allow but put a WARNING in additionalContext."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "warn"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+    ctx = hso.get("additionalContext", "")
+    assert "WARNING" in ctx
+
+
+def test_unbriefed_off_allows_no_warning():
+    """AGENT_SWARM_BRIEFING_ENFORCE=off is today's behavior -- allow with no warning."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "off"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+    ctx = hso.get("additionalContext", "")
+    assert "WARNING" not in ctx
+
+
+def test_daemon_down_allows():
+    """When prepare_dispatch returns None (daemon down), the hook must always allow."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        router_success=False,
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "block"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+

--- a/tests/test_skill_spawn_conformance.py
+++ b/tests/test_skill_spawn_conformance.py
@@ -1,0 +1,176 @@
+"""Static conformance gate for skill spawn-protocol compliance.
+
+Pins the post-fix contract so that doc drift (prescribing native subagent
+types, dropping register_agent/briefing references) cannot silently
+re-enter any spawning skill.
+
+Rules enforced:
+  1. No spawning skill prescribes a native subagent type (general-purpose,
+     Explore, Plan) unless the file carries the exemption marker, is
+     skills/spawn/SKILL.md itself, or the matching line is a negative
+     instruction (contains "never", "NOT", or "Don't").
+  2. Every spawning skill references the dispatch protocol (register_agent,
+     briefing, or skills/spawn); exempt-marked files pass via marker.
+  3. The two fixed skills (delegate, parallel-orchestrate) each contain
+     register_agent AND reg["briefing"].
+  4. hooks/agent-dispatch.py contains "## Your Agent Identity".
+
+A spawning skill is any skills/*/SKILL.md containing "subagent_type".
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Repo root -- resolve from this file location (tests/ -> parent)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+HOOKS_DIR = REPO_ROOT / "hooks"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EXEMPTION_MARKER = "<!-- spawn-conformance: native-teams-exempt -->"
+
+# Prescription patterns -- positive prescription of a native subagent type.
+# Matches: subagent_type: "X", subagent_type: 'X', subagent_type = "X"
+_NATIVE_TYPES = ["general-purpose", "Explore", "Plan"]
+_PRESCRIPTION_RE = re.compile(
+    r"subagent_type\s*[:=]\s*[\"'](general-purpose|Explore|Plan)[\"']"
+)
+
+# Protocol reference: at least one must appear in a spawning skill.
+_PROTOCOL_REFS = ["register_agent", "briefing", "skills/spawn"]
+
+# The two skills pinned by test 3.
+_FIXED_SKILLS = ["delegate", "parallel-orchestrate"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _spawning_skills() -> list[Path]:
+    """Return all skills/*/SKILL.md paths containing subagent_type."""
+    candidates = sorted(SKILLS_DIR.glob("*/SKILL.md"))
+    return [p for p in candidates if "subagent_type" in p.read_text(encoding="utf-8")]
+
+
+def _is_negative_instruction(line: str) -> bool:
+    """Return True if the line is a prohibition or warning."""
+    return any(kw in line for kw in ("never", "NOT", "Don't"))
+
+
+def _offending_prescriptions(text: str, path: Path) -> list[str]:
+    """Return lines that positively prescribe a native subagent type.
+
+    A line is offending iff: it matches _PRESCRIPTION_RE AND the file is not
+    skills/spawn/SKILL.md AND the line is not a negative instruction.
+    """
+    if path.parent.name == "spawn":
+        return []
+    offending = []
+    for line in text.splitlines():
+        if _PRESCRIPTION_RE.search(line) and not _is_negative_instruction(line):
+            offending.append(line.strip())
+    return offending
+
+
+def _skill_id(path: Path) -> str:
+    return path.parent.name
+
+
+# ---------------------------------------------------------------------------
+# Test 1 -- No spawning skill prescribes a native type (unless exempt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_path", _spawning_skills(), ids=_skill_id)
+def test_no_native_type_prescription(skill_path: Path) -> None:
+    """A spawning skill must not positively prescribe a native subagent type.
+
+    Exempt: file carries the exemption marker; file is skills/spawn/SKILL.md;
+    or the matching line is a negative instruction.
+    """
+    text = skill_path.read_text(encoding="utf-8")
+    if EXEMPTION_MARKER in text:
+        return  # Exempt via marker -- pass.
+    offending = _offending_prescriptions(text, skill_path)
+    assert not offending, (
+        f"{skill_path.relative_to(REPO_ROOT)} positively prescribes a native "
+        f"subagent type on line(s): {offending!r}\n"
+        "Add register_agent+briefing pattern and remove or negate the "
+        f"prescription, or add the exemption marker {EXEMPTION_MARKER!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 -- Every spawning skill references the dispatch protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_path", _spawning_skills(), ids=_skill_id)
+def test_spawning_skill_references_protocol(skill_path: Path) -> None:
+    """A spawning skill must reference at least one of: register_agent,
+    briefing, or skills/spawn -- OR carry the exemption marker.
+    """
+    text = skill_path.read_text(encoding="utf-8")
+    if EXEMPTION_MARKER in text:
+        return  # Exempt via marker -- pass.
+    has_ref = any(ref in text for ref in _PROTOCOL_REFS)
+    assert has_ref, (
+        f"{skill_path.relative_to(REPO_ROOT)} contains subagent_type but "
+        f"references none of {_PROTOCOL_REFS!r}.\n"
+        "Add register_agent / briefing references per the spawn protocol, "
+        f"or add the exemption marker {EXEMPTION_MARKER!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 -- delegate and parallel-orchestrate contain protocol primitives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_name", _FIXED_SKILLS)
+def test_fixed_skills_contain_protocol_primitives(skill_name: str) -> None:
+    """Post-fix: delegate and parallel-orchestrate must contain
+    register_agent AND reg["briefing"].
+    """
+    skill_path = SKILLS_DIR / skill_name / "SKILL.md"
+    assert skill_path.exists(), f"Expected skill file not found: {skill_path}"
+    text = skill_path.read_text(encoding="utf-8")
+
+    assert "register_agent" in text, (
+        f"{skill_name}/SKILL.md missing 'register_agent'. "
+        "The doc-fix for this skill has not landed or was reverted."
+    )
+    assert 'reg["briefing"]' in text, (
+        f"{skill_name}/SKILL.md missing 'reg[\"briefing\"]' prepend pattern. "
+        "The doc-fix for this skill has not landed or was reverted."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 -- hooks/agent-dispatch.py contains the briefing marker
+# ---------------------------------------------------------------------------
+
+
+def test_agent_dispatch_contains_briefing_marker() -> None:
+    """hooks/agent-dispatch.py must contain "## Your Agent Identity".
+
+    Its absence means briefing injection is broken.
+    """
+    dispatch_path = HOOKS_DIR / "agent-dispatch.py"
+    assert dispatch_path.exists(), f"hooks/agent-dispatch.py not found at {dispatch_path}"
+    text = dispatch_path.read_text(encoding="utf-8")
+    assert "## Your Agent Identity" in text, (
+        "hooks/agent-dispatch.py does not contain '## Your Agent Identity'.\n"
+        "The doc-fix that moves the briefing header into the dispatch hook "
+        "has not landed or was reverted."
+    )


### PR DESCRIPTION
## Summary
Stacked on #150 (edits `skills/delegate/SKILL.md`). Findings from the delegate workflow's first live run: all four workers spawned unbriefed because the spawner-side briefing-prepend step was documented only in `skills/spawn`, while `delegate`/`parallel-orchestrate` prescribed unbriefed `general-purpose` spawns.

- `hooks/agent-dispatch.py` now enforces briefing delivery: unbriefed Task/Agent spawns are blocked by default (`AGENT_SWARM_BRIEFING_ENFORCE=block|warn|off`), with the block reason carrying the agent_id + full briefing so the spawner can prepend and re-spawn without a round-trip. Daemon-down path unchanged (allow). 10 new hook tests.
- `delegate` and `parallel-orchestrate` dispatch sections rewritten to the register→prepend protocol; `teams-develop` gets explicit `native-teams-exempt` markers (its general-purpose use is legitimate — native teams, no router dependency); `pipeline` gets a protocol pointer.
- New static gate `tests/test_skill_spawn_conformance.py` (15 tests) fails if the stale pattern returns.

## Known issue (follow-up, not addressed here)
In live testing, the hook's `prepare_dispatch` TCP call intermittently fails under the harness's hook execution environment (succeeds from a shell), falling through to the graceful-degradation allow path — so enforcement depends on daemon reachability. Daemon-side logging of prepare_dispatch arrivals would disambiguate; pairs with a future worker-health surface in the monitor phase.

## Test plan
- [x] `pytest tests/test_skill_spawn_conformance.py tests/test_agent_dispatch_hook.py -q` — 25 passed on this branch standalone (base `0153090`)
- [x] Full suite on the integration tree — 1660 passed, 0 failed
- [x] Hook verified to block/warn/allow correctly via direct stdin invocation