### PR TITLE
Delegate workflow, lib characterization tests, and spawn-protocol enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ logs/*.log
 .ruff_cache/
 .mypy_cache/
 .DS_Store
+
+# Playwright MCP session artifacts (console/page snapshots)
+.playwright-mcp/
+
+# Delegate skill run manifests (local orchestration state)
+.delegate/

--- a/hooks/agent-dispatch.py
+++ b/hooks/agent-dispatch.py
@@ -8,6 +8,7 @@ additionalContext so the subagent starts with its identity and protocol.
 """
 
 import json
+import os
 import socket
 import sys
 
@@ -99,18 +100,62 @@ def main():
     })
 
     if result and result.get("success"):
-        # Return full dispatch state as JSON in additionalContext
-        dispatch_state = json.dumps({
-            "agent_id": result.get("agent_id"),
-            "briefing": result.get("briefing", ""),
-            "agent_type": result.get("agent_type", agent_type),
-        })
-        print(json.dumps(allow(
-            reason=f"Agent {result.get('agent_id', '?')} registered via prepare_dispatch",
-            additional_context=dispatch_state,
-        )))
+        agent_id = result.get("agent_id", "?")
+        briefing = result.get("briefing", "")
+        agent_type_result = result.get("agent_type", agent_type)
+
+        # Enforce briefing delivery
+        briefing_marker = "## Your Agent Identity"
+        enforce = os.environ.get("AGENT_SWARM_BRIEFING_ENFORCE", "block")
+
+        if briefing_marker in prompt:
+            # Prompt already contains the briefing -- allow as-is
+            dispatch_state = json.dumps({
+                "agent_id": agent_id,
+                "briefing": briefing,
+                "agent_type": agent_type_result,
+            })
+            print(json.dumps(allow(
+                reason=f"Agent {agent_id} registered via prepare_dispatch",
+                additional_context=dispatch_state,
+            )))
+        elif enforce == "off":
+            # Legacy passthrough -- no enforcement
+            dispatch_state = json.dumps({
+                "agent_id": agent_id,
+                "briefing": briefing,
+                "agent_type": agent_type_result,
+            })
+            print(json.dumps(allow(
+                reason=f"Agent {agent_id} registered via prepare_dispatch",
+                additional_context=dispatch_state,
+            )))
+        elif enforce == "warn":
+            dispatch_state = json.dumps({
+                "agent_id": agent_id,
+                "briefing": briefing,
+                "agent_type": agent_type_result,
+            })
+            warning = (
+                f"WARNING: spawn prompt is unbriefed (missing {briefing_marker!r}). "
+                f"agent_id={agent_id}. "
+            )
+            print(json.dumps(allow(
+                reason=f"Agent {agent_id} registered via prepare_dispatch (unbriefed, warned)",
+                additional_context=warning + dispatch_state,
+            )))
+        else:
+            # Default: block and tell the spawner what to prepend
+            reason = (
+                f"Spawn blocked: prompt is missing the briefing marker {briefing_marker!r}. "
+                f"Prepend the following briefing to the prompt and re-spawn:\n"
+                f"agent_id: {agent_id}\n"
+                f"{briefing_marker}\n"
+                f"{briefing}"
+            )
+            print(json.dumps(block(reason)))
     else:
-        # Graceful degradation — don't break spawning if daemon is down
+        # Graceful degradation -- don't break spawning if daemon is down
         print(json.dumps(allow("prepare_dispatch unavailable, allowing through")))
 
 

--- a/hooks/agent-dispatch.py
+++ b/hooks/agent-dispatch.py
@@ -9,6 +9,7 @@ additionalContext so the subagent starts with its identity and protocol.
 
 import json
 import os
+import re
 import socket
 import sys
 
@@ -92,7 +93,28 @@ def main():
     prompt = tool_input.get("prompt", "")
     description = tool_input.get("description", "")
 
-    # Call prepare_dispatch on the controller
+    briefing_marker = "## Your Agent Identity"
+
+    # A prompt that already carries the briefing marker was prepared by an earlier
+    # register_agent / prepare_dispatch call -- either the register+prepend spawn
+    # protocol, or a prior block the spawner has now satisfied. prepare_dispatch
+    # mints a fresh agent_id on every call, so calling it again would register a
+    # SECOND identity and leave the first as a ghost in the daemon registry. Reuse
+    # the agent_id already embedded in the briefing and allow without re-registering.
+    if prompt and briefing_marker in prompt:
+        m = re.search(r"Agent ID:\s*`?([^\s`]+)", prompt)
+        agent_id = m.group(1) if m else "?"
+        print(json.dumps(allow(
+            reason=f"Agent {agent_id} already briefed; allowed without re-registration",
+            additional_context=json.dumps({
+                "agent_id": agent_id,
+                "briefing": "",
+                "agent_type": agent_type,
+            }),
+        )))
+        return
+
+    # Unbriefed: register the agent and assemble its briefing, then decide.
     result = call_router("prepare_dispatch", {
         "agent_type": agent_type,
         "prompt": prompt,
@@ -104,9 +126,14 @@ def main():
         briefing = result.get("briefing", "")
         agent_type_result = result.get("agent_type", agent_type)
 
-        # Enforce briefing delivery
-        briefing_marker = "## Your Agent Identity"
         enforce = os.environ.get("AGENT_SWARM_BRIEFING_ENFORCE", "block")
+        if enforce not in ("block", "warn", "off"):
+            print(
+                f"WARNING: unrecognized AGENT_SWARM_BRIEFING_ENFORCE={enforce!r}; "
+                f"treating as 'block'",
+                file=sys.stderr,
+            )
+            enforce = "block"
 
         # Single source of truth for the dispatch state, serialized at point of use.
         dispatch_data = {
@@ -115,13 +142,7 @@ def main():
             "agent_type": agent_type_result,
         }
 
-        if prompt and briefing_marker in prompt:
-            # Prompt already contains the briefing -- allow as-is
-            print(json.dumps(allow(
-                reason=f"Agent {agent_id} registered via prepare_dispatch",
-                additional_context=json.dumps(dispatch_data),
-            )))
-        elif enforce == "off":
+        if enforce == "off":
             # Legacy passthrough -- no enforcement
             print(json.dumps(allow(
                 reason=f"Agent {agent_id} registered via prepare_dispatch",

--- a/hooks/agent-dispatch.py
+++ b/hooks/agent-dispatch.py
@@ -108,42 +108,33 @@ def main():
         briefing_marker = "## Your Agent Identity"
         enforce = os.environ.get("AGENT_SWARM_BRIEFING_ENFORCE", "block")
 
-        if briefing_marker in prompt:
+        # Single source of truth for the dispatch state, serialized at point of use.
+        dispatch_data = {
+            "agent_id": agent_id,
+            "briefing": briefing,
+            "agent_type": agent_type_result,
+        }
+
+        if prompt and briefing_marker in prompt:
             # Prompt already contains the briefing -- allow as-is
-            dispatch_state = json.dumps({
-                "agent_id": agent_id,
-                "briefing": briefing,
-                "agent_type": agent_type_result,
-            })
             print(json.dumps(allow(
                 reason=f"Agent {agent_id} registered via prepare_dispatch",
-                additional_context=dispatch_state,
+                additional_context=json.dumps(dispatch_data),
             )))
         elif enforce == "off":
             # Legacy passthrough -- no enforcement
-            dispatch_state = json.dumps({
-                "agent_id": agent_id,
-                "briefing": briefing,
-                "agent_type": agent_type_result,
-            })
             print(json.dumps(allow(
                 reason=f"Agent {agent_id} registered via prepare_dispatch",
-                additional_context=dispatch_state,
+                additional_context=json.dumps(dispatch_data),
             )))
         elif enforce == "warn":
             warning = (
                 f"WARNING: spawn prompt is unbriefed (missing {briefing_marker!r}). "
                 f"agent_id={agent_id}."
             )
-            dispatch_state = json.dumps({
-                "agent_id": agent_id,
-                "briefing": briefing,
-                "agent_type": agent_type_result,
-                "warning": warning,
-            })
             print(json.dumps(allow(
                 reason=f"Agent {agent_id} registered via prepare_dispatch (unbriefed, warned)",
-                additional_context=dispatch_state,
+                additional_context=json.dumps({**dispatch_data, "warning": warning}),
             )))
         else:
             # Default: block and tell the spawner what to prepend

--- a/hooks/agent-dispatch.py
+++ b/hooks/agent-dispatch.py
@@ -131,18 +131,19 @@ def main():
                 additional_context=dispatch_state,
             )))
         elif enforce == "warn":
+            warning = (
+                f"WARNING: spawn prompt is unbriefed (missing {briefing_marker!r}). "
+                f"agent_id={agent_id}."
+            )
             dispatch_state = json.dumps({
                 "agent_id": agent_id,
                 "briefing": briefing,
                 "agent_type": agent_type_result,
+                "warning": warning,
             })
-            warning = (
-                f"WARNING: spawn prompt is unbriefed (missing {briefing_marker!r}). "
-                f"agent_id={agent_id}. "
-            )
             print(json.dumps(allow(
                 reason=f"Agent {agent_id} registered via prepare_dispatch (unbriefed, warned)",
-                additional_context=warning + dispatch_state,
+                additional_context=dispatch_state,
             )))
         else:
             # Default: block and tell the spawner what to prepend

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -100,13 +100,18 @@ workflow__advance_phase(wf_id, "dispatch")
 python3 ${AGENT_SWARM_ROOT}/lib/orchestrator.py pending .delegate/<slug>.yaml --json
 ```
 
-For each entry, spawn a worker with the **Agent tool**:
+For each entry, register the worker, then spawn it with the **Agent
+tool** (the spawn protocol — see `skills/spawn/SKILL.md`):
 
-- `subagent_type: "general-purpose"` (same as parallel-orchestrate)
-- `model: <entry.model>` — **this is the tiering lever; never omit it**
-- `prompt`: the `prompt` field verbatim
-- Spawn all pending tasks **in parallel** — worktrees isolate them
-
+1. `reg = router__register_agent(agent_id="<task_name>-w<n>", agent_type="implementer", roles=["editor", "shell_full"])`
+2. Spawn:
+   - `subagent_type: "implementer"` — never a native type
+     (`general-purpose`/`Explore`/`Plan`): native types have no router
+     access and will flail
+   - `model: <entry.model>` — **this is the tiering lever; never omit it**
+   - `prompt`: `reg["briefing"] + "\n\n" +` the entry's `prompt` field
+     verbatim — the briefing carries the worker's identity/caller-id
+   - Spawn all pending tasks **in parallel** — worktrees isolate them
 Record each spawn, then advance:
 
 ```bash

--- a/skills/parallel-orchestrate/SKILL.md
+++ b/skills/parallel-orchestrate/SKILL.md
@@ -28,7 +28,7 @@ The `start` command creates a git worktree per task under `{project_dir}/.worktr
 ```
 LOAD → START → SPAWN → MONITOR → MERGE → VERIFY → COMPLETE → STOP
                  ↑         |                |
-                 └─ RETRY ─┘          (fail: fix/rollback/continue)
+                 └── RETRY ─┘          (fail: fix/rollback/continue)
          (blocked tasks wait for dependencies)
 ```
 
@@ -39,10 +39,18 @@ Get pending tasks:
 python3 lib/orchestrator.py pending <manifest.yaml> --json
 ```
 
-This returns a JSON array. For each entry, spawn a subagent using the **Agent tool**:
+This returns a JSON array. For each entry, register the worker, then
+spawn it using the **Agent tool** (the spawn protocol — see
+`skills/spawn/SKILL.md`):
 
-- Use `subagent_type: "general-purpose"`
-- Pass the `prompt` field verbatim — it already contains worktree paths and "do NOT switch branches" instructions
+- `reg = router__register_agent(agent_id="<task_name>-w<n>", agent_type="implementer", roles=["editor", "shell_full"])`
+- Use `subagent_type: "implementer"` — never a native type
+  (`general-purpose`/`Explore`/`Plan`): native types have no router
+  access and will flail
+- `prompt`: `reg["briefing"] + "\n\n" +` the `prompt` field verbatim —
+  the briefing carries the worker's identity/caller-id; the prompt
+  already contains worktree paths and "do NOT switch branches"
+  instructions
 - The `worktree_dir` field tells you where the subagent will work (for your reference)
 - Run subagents **in parallel** — worktrees give each one an isolated directory
 

--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -99,6 +99,7 @@ Ask the user: **Proceed to orchestration / Edit the manifest first / Stop**
 Invoke `agent-swarm:parallel-orchestrate` with the manifest path.
 
 The orchestrator handles everything from here: spawning subagents, monitoring, merging, verification, and branch completion.
+Subagent spawning in that skill follows the mandatory register+prepend protocol; see `skills/spawn/SKILL.md` for the full contract.
 
 ---
 

--- a/skills/teams-develop/SKILL.md
+++ b/skills/teams-develop/SKILL.md
@@ -20,7 +20,10 @@ INTAKE → RESEARCH → DESIGN → IMPLEMENT → REVIEW → INTEGRATE → COMPLE
 
 Kickbacks: REVIEW → IMPLEMENT (code issues), INTEGRATE → IMPLEMENT (merge conflicts / test failures).
 
+<!-- spawn-conformance: native-teams-exempt -->
 ## Agent Lifecycle
+
+These agents run as native Claude Code team members via `Agent()` / `TeamCreate()` / `SendMessage()` and do not route through the router; they cannot use `mcp-call` and do not need `register_agent` or a briefing prepend.
 
 | Role | Phase | Agent Type | Model | Isolation | Writes? |
 |------|-------|------------|-------|-----------|---------|
@@ -104,6 +107,7 @@ Create feature branch, create tasks per subtask, spawn implementers in isolated 
    TaskUpdate(taskId=<id>, addBlockedBy=[<dependency-ids>])
    ```
 3. For each unblocked task, spawn an implementer:
+<!-- spawn-conformance: native-teams-exempt -->
    ```
    Agent(
      team_name="td-<slug>",

--- a/tests/test_agent_dispatch_hook.py
+++ b/tests/test_agent_dispatch_hook.py
@@ -201,7 +201,8 @@ def test_unbriefed_warn_allows_with_warning():
     hso = decision["hookSpecificOutput"]
     assert hso["permissionDecision"] == "allow"
     ctx = hso.get("additionalContext", "")
-    assert "WARNING" in ctx
+    parsed = json.loads(ctx)  # payload must remain valid JSON for consumers
+    assert "WARNING" in parsed["warning"]
 
 
 def test_unbriefed_off_allows_no_warning():

--- a/tests/test_agent_dispatch_hook.py
+++ b/tests/test_agent_dispatch_hook.py
@@ -233,3 +233,17 @@ def test_daemon_down_allows():
     hso = decision["hookSpecificOutput"]
     assert hso["permissionDecision"] == "allow"
 
+
+def test_none_prompt_does_not_crash():
+    """A null prompt must not raise TypeError on the briefing-marker check.
+    With no briefing present it falls through to the default block path."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": None, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "block"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "block"
+

--- a/tests/test_agent_dispatch_hook.py
+++ b/tests/test_agent_dispatch_hook.py
@@ -247,3 +247,34 @@ def test_none_prompt_does_not_crash():
     hso = decision["hookSpecificOutput"]
     assert hso["permissionDecision"] == "block"
 
+
+def test_briefed_prompt_does_not_reregister():
+    """A briefed prompt must NOT call prepare_dispatch again. prepare_dispatch mints
+    a fresh agent_id every call, so a second call would register a duplicate identity
+    and leave the first as a ghost. The hook reuses the agent_id from the briefing."""
+    calls, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _BRIEFED_PROMPT, "description": "d"},
+        },
+    )
+    assert [c[0] for c in calls] == []  # prepare_dispatch was never called
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+    ctx = json.loads(hso["additionalContext"])
+    assert ctx["agent_id"] == "sub-test"  # reused from the briefing, not freshly minted
+
+
+def test_unrecognized_enforce_value_treated_as_block():
+    """An unrecognized AGENT_SWARM_BRIEFING_ENFORCE value must fail safe to block,
+    not silently fall through to some other behavior."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "enabled"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "block"
+

--- a/tests/test_agent_dispatch_hook.py
+++ b/tests/test_agent_dispatch_hook.py
@@ -10,6 +10,7 @@ from both directions (the fix had zero coverage; surfaced by adversarial review)
 import importlib.util
 import io
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -79,3 +80,155 @@ def test_camelcase_payload_is_not_dispatched():
 def test_non_dispatch_tool_is_passthrough():
     calls = _run({"tool_name": "Read", "tool_input": {"file_path": "/x"}})
     assert calls == []
+
+
+
+# ---------------------------------------------------------------------------
+# Helper for enforcement tests -- captures stdout decision as parsed dict
+# ---------------------------------------------------------------------------
+
+
+
+
+def _run_with_decision(payload, *, briefing="B", router_success=True, env=None):
+    """Run main() and return (calls, decision_dict).
+
+    `briefing` is the text returned by fake_call_router so tests can
+    put it into the prompt to simulate a briefed spawn.
+    `router_success` controls whether the fake router returns success.
+    `env` is an optional dict of extra os.environ overrides.
+    """
+    mod = _load_hook()
+    calls = []
+    stdout_buf = io.StringIO()
+
+    def fake_call_router(tool_name, args=None, timeout=5.0):
+        calls.append((tool_name, args or {}))
+        if not router_success:
+            return None
+        return {
+            "success": True,
+            "agent_id": "sub-test",
+            "briefing": briefing,
+            "agent_type": (args or {}).get("agent_type"),
+        }
+
+    env_overrides = env or {}
+    orig_env = {k: os.environ.get(k) for k in env_overrides}
+    try:
+        for k, v in env_overrides.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        with patch.object(mod, "call_router", fake_call_router), \
+                patch("sys.stdin", io.StringIO(json.dumps(payload))), \
+                patch("sys.stdout", stdout_buf):
+            mod.main()
+    finally:
+        for k, v in orig_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    raw = stdout_buf.getvalue()
+    decision = json.loads(raw) if raw.strip() else {}
+    return calls, decision
+
+
+BRIEFING_MARKER = "## Your Agent Identity"
+_BRIEFED_PROMPT = BRIEFING_MARKER + chr(10) + "Agent ID: sub-test" + chr(10) + "some briefing text"
+_UNBRIEFED_PROMPT = "do something without briefing"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement tests (6 required)
+# ---------------------------------------------------------------------------
+
+
+def test_briefed_prompt_allows():
+    """When the spawn prompt contains the briefing marker, the hook allows."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _BRIEFED_PROMPT, "description": "d"},
+        }
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+
+
+def test_unbriefed_default_blocks_with_agent_id_and_marker():
+    """Unbriefed prompt + default env (block) must block, with reason containing
+    the agent_id and the briefing marker so the spawner can comply."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "block"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "block"
+    reason = hso["permissionDecisionReason"]
+    assert "## Your Agent Identity" in reason
+    assert "sub-test" in reason
+
+
+def test_unbriefed_default_env_absent_blocks():
+    """Default behavior (env var absent) must also block -- same as explicit 'block'."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Task",
+            "tool_input": {"subagent_type": "reviewer", "prompt": _UNBRIEFED_PROMPT},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": None},  # ensure absent
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "block"
+
+
+def test_unbriefed_warn_allows_with_warning():
+    """AGENT_SWARM_BRIEFING_ENFORCE=warn must allow but put a WARNING in additionalContext."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "warn"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+    ctx = hso.get("additionalContext", "")
+    assert "WARNING" in ctx
+
+
+def test_unbriefed_off_allows_no_warning():
+    """AGENT_SWARM_BRIEFING_ENFORCE=off is today's behavior -- allow with no warning."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "off"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+    ctx = hso.get("additionalContext", "")
+    assert "WARNING" not in ctx
+
+
+def test_daemon_down_allows():
+    """When prepare_dispatch returns None (daemon down), the hook must always allow."""
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        router_success=False,
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "block"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "allow"
+

--- a/tests/test_skill_spawn_conformance.py
+++ b/tests/test_skill_spawn_conformance.py
@@ -8,7 +8,7 @@ Rules enforced:
   1. No spawning skill prescribes a native subagent type (general-purpose,
      Explore, Plan) unless the file carries the exemption marker, is
      skills/spawn/SKILL.md itself, or the matching line is a negative
-     instruction (contains "never", "NOT", or "Don't").
+     instruction (contains "never", "not", or "don't", case-insensitive).
   2. Every spawning skill references the dispatch protocol (register_agent,
      briefing, or skills/spawn); exempt-marked files pass via marker.
   3. The two fixed skills (delegate, parallel-orchestrate) each contain
@@ -41,7 +41,7 @@ EXEMPTION_MARKER = "<!-- spawn-conformance: native-teams-exempt -->"
 # Matches: subagent_type: "X", subagent_type: 'X', subagent_type = "X"
 _NATIVE_TYPES = ["general-purpose", "Explore", "Plan"]
 _PRESCRIPTION_RE = re.compile(
-    r"subagent_type\s*[:=]\s*[\"'](general-purpose|Explore|Plan)[\"']"
+    r"subagent_type\s*[:=]\s*[\"'](" + "|".join(re.escape(t) for t in _NATIVE_TYPES) + r")[\"']"
 )
 
 # Protocol reference: at least one must appear in a spawning skill.
@@ -63,8 +63,9 @@ def _spawning_skills() -> list[Path]:
 
 
 def _is_negative_instruction(line: str) -> bool:
-    """Return True if the line is a prohibition or warning."""
-    return any(kw in line for kw in ("never", "NOT", "Don't"))
+    """Return True if the line is a prohibition or warning (case-insensitive)."""
+    line_lower = line.lower()
+    return any(kw in line_lower for kw in ("never", "not", "don't"))
 
 
 def _offending_prescriptions(text: str, path: Path) -> list[str]:

--- a/tests/test_skill_spawn_conformance.py
+++ b/tests/test_skill_spawn_conformance.py
@@ -1,0 +1,176 @@
+"""Static conformance gate for skill spawn-protocol compliance.
+
+Pins the post-fix contract so that doc drift (prescribing native subagent
+types, dropping register_agent/briefing references) cannot silently
+re-enter any spawning skill.
+
+Rules enforced:
+  1. No spawning skill prescribes a native subagent type (general-purpose,
+     Explore, Plan) unless the file carries the exemption marker, is
+     skills/spawn/SKILL.md itself, or the matching line is a negative
+     instruction (contains "never", "NOT", or "Don't").
+  2. Every spawning skill references the dispatch protocol (register_agent,
+     briefing, or skills/spawn); exempt-marked files pass via marker.
+  3. The two fixed skills (delegate, parallel-orchestrate) each contain
+     register_agent AND reg["briefing"].
+  4. hooks/agent-dispatch.py contains "## Your Agent Identity".
+
+A spawning skill is any skills/*/SKILL.md containing "subagent_type".
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Repo root -- resolve from this file location (tests/ -> parent)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+HOOKS_DIR = REPO_ROOT / "hooks"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EXEMPTION_MARKER = "<!-- spawn-conformance: native-teams-exempt -->"
+
+# Prescription patterns -- positive prescription of a native subagent type.
+# Matches: subagent_type: "X", subagent_type: 'X', subagent_type = "X"
+_NATIVE_TYPES = ["general-purpose", "Explore", "Plan"]
+_PRESCRIPTION_RE = re.compile(
+    r"subagent_type\s*[:=]\s*[\"'](general-purpose|Explore|Plan)[\"']"
+)
+
+# Protocol reference: at least one must appear in a spawning skill.
+_PROTOCOL_REFS = ["register_agent", "briefing", "skills/spawn"]
+
+# The two skills pinned by test 3.
+_FIXED_SKILLS = ["delegate", "parallel-orchestrate"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _spawning_skills() -> list[Path]:
+    """Return all skills/*/SKILL.md paths containing subagent_type."""
+    candidates = sorted(SKILLS_DIR.glob("*/SKILL.md"))
+    return [p for p in candidates if "subagent_type" in p.read_text(encoding="utf-8")]
+
+
+def _is_negative_instruction(line: str) -> bool:
+    """Return True if the line is a prohibition or warning."""
+    return any(kw in line for kw in ("never", "NOT", "Don't"))
+
+
+def _offending_prescriptions(text: str, path: Path) -> list[str]:
+    """Return lines that positively prescribe a native subagent type.
+
+    A line is offending iff: it matches _PRESCRIPTION_RE AND the file is not
+    skills/spawn/SKILL.md AND the line is not a negative instruction.
+    """
+    if path.parent.name == "spawn":
+        return []
+    offending = []
+    for line in text.splitlines():
+        if _PRESCRIPTION_RE.search(line) and not _is_negative_instruction(line):
+            offending.append(line.strip())
+    return offending
+
+
+def _skill_id(path: Path) -> str:
+    return path.parent.name
+
+
+# ---------------------------------------------------------------------------
+# Test 1 -- No spawning skill prescribes a native type (unless exempt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_path", _spawning_skills(), ids=_skill_id)
+def test_no_native_type_prescription(skill_path: Path) -> None:
+    """A spawning skill must not positively prescribe a native subagent type.
+
+    Exempt: file carries the exemption marker; file is skills/spawn/SKILL.md;
+    or the matching line is a negative instruction.
+    """
+    text = skill_path.read_text(encoding="utf-8")
+    if EXEMPTION_MARKER in text:
+        return  # Exempt via marker -- pass.
+    offending = _offending_prescriptions(text, skill_path)
+    assert not offending, (
+        f"{skill_path.relative_to(REPO_ROOT)} positively prescribes a native "
+        f"subagent type on line(s): {offending!r}\n"
+        "Add register_agent+briefing pattern and remove or negate the "
+        f"prescription, or add the exemption marker {EXEMPTION_MARKER!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 -- Every spawning skill references the dispatch protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_path", _spawning_skills(), ids=_skill_id)
+def test_spawning_skill_references_protocol(skill_path: Path) -> None:
+    """A spawning skill must reference at least one of: register_agent,
+    briefing, or skills/spawn -- OR carry the exemption marker.
+    """
+    text = skill_path.read_text(encoding="utf-8")
+    if EXEMPTION_MARKER in text:
+        return  # Exempt via marker -- pass.
+    has_ref = any(ref in text for ref in _PROTOCOL_REFS)
+    assert has_ref, (
+        f"{skill_path.relative_to(REPO_ROOT)} contains subagent_type but "
+        f"references none of {_PROTOCOL_REFS!r}.\n"
+        "Add register_agent / briefing references per the spawn protocol, "
+        f"or add the exemption marker {EXEMPTION_MARKER!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 -- delegate and parallel-orchestrate contain protocol primitives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_name", _FIXED_SKILLS)
+def test_fixed_skills_contain_protocol_primitives(skill_name: str) -> None:
+    """Post-fix: delegate and parallel-orchestrate must contain
+    register_agent AND reg["briefing"].
+    """
+    skill_path = SKILLS_DIR / skill_name / "SKILL.md"
+    assert skill_path.exists(), f"Expected skill file not found: {skill_path}"
+    text = skill_path.read_text(encoding="utf-8")
+
+    assert "register_agent" in text, (
+        f"{skill_name}/SKILL.md missing 'register_agent'. "
+        "The doc-fix for this skill has not landed or was reverted."
+    )
+    assert 'reg["briefing"]' in text, (
+        f"{skill_name}/SKILL.md missing 'reg[\"briefing\"]' prepend pattern. "
+        "The doc-fix for this skill has not landed or was reverted."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 -- hooks/agent-dispatch.py contains the briefing marker
+# ---------------------------------------------------------------------------
+
+
+def test_agent_dispatch_contains_briefing_marker() -> None:
+    """hooks/agent-dispatch.py must contain "## Your Agent Identity".
+
+    Its absence means briefing injection is broken.
+    """
+    dispatch_path = HOOKS_DIR / "agent-dispatch.py"
+    assert dispatch_path.exists(), f"hooks/agent-dispatch.py not found at {dispatch_path}"
+    text = dispatch_path.read_text(encoding="utf-8")
+    assert "## Your Agent Identity" in text, (
+        "hooks/agent-dispatch.py does not contain '## Your Agent Identity'.\n"
+        "The doc-fix that moves the briefing header into the dispatch hook "
+        "has not landed or was reverted."
+    )

--- a/tests/test_skill_spawn_conformance.py
+++ b/tests/test_skill_spawn_conformance.py
@@ -62,10 +62,16 @@ def _spawning_skills() -> list[Path]:
     return [p for p in candidates if "subagent_type" in p.read_text(encoding="utf-8")]
 
 
+_NEGATIVE_RE = re.compile(r"\b(?:never|not|don't)\b", re.IGNORECASE)
+
+
 def _is_negative_instruction(line: str) -> bool:
-    """Return True if the line is a prohibition or warning (case-insensitive)."""
-    line_lower = line.lower()
-    return any(kw in line_lower for kw in ("never", "not", "don't"))
+    """Return True if the line is a prohibition or warning.
+
+    Whole-word, case-insensitive match so 'Never'/'NOT'/'Don't' are caught but
+    substrings like 'cannot'/'annotation' (which contain 'not') are not.
+    """
+    return _NEGATIVE_RE.search(line) is not None
 
 
 def _offending_prescriptions(text: str, path: Path) -> list[str]:
@@ -175,3 +181,18 @@ def test_agent_dispatch_contains_briefing_marker() -> None:
         "The doc-fix that moves the briefing header into the dispatch hook "
         "has not landed or was reverted."
     )
+
+
+def test_negative_instruction_matches_whole_words_only() -> None:
+    """_is_negative_instruction must match whole words case-insensitively, so a
+    real prohibition is exempted but an incidental substring ('cannot',
+    'annotation') does not silently exempt a genuine prescription violation."""
+    # Genuine prohibitions -- exempt (case-insensitive).
+    assert _is_negative_instruction("Never use subagent_type: 'general-purpose'")
+    assert _is_negative_instruction("Do NOT prescribe subagent_type")
+    assert _is_negative_instruction("Don't use general-purpose")
+    # Substrings that merely contain 'not' must NOT be treated as negative.
+    assert not _is_negative_instruction("This annotation sets subagent_type: 'Plan'")
+    assert not _is_negative_instruction("cannot change subagent_type: 'Explore'")
+    # A plain prescription is not a negative instruction.
+    assert not _is_negative_instruction("use subagent_type: 'general-purpose'")


### PR DESCRIPTION
## Summary

Integration branch bundling several lines of work that have not yet landed on `master` (46 commits, ~36 files). Includes two already-merged feature PRs (#150 delegate workflow, #151 lib characterization tests) plus subsequent spawn-protocol alignment and a small gitignore cleanup.

## What's included

- **Delegate workflow** — phase-gated `delegate` skill with a decomposition contract and tier rubric, tiered demo manifest, `SpawnRequest`/model-tier plumbing, and supporting config/tests (`skills/delegate/SKILL.md`, `test_delegate_workflow_config.py`, `test_demo_delegate_manifest.py`, `test_manifest.py`).
- **Library characterization tests** — backfill suites for previously-untested `lib/` modules: connection pool, jsonl extractor, native MCP shim, telemetry schema v2 (`tests/backfill/*`).
- **Spawn protocol enforcement** — `agent-dispatch` hook blocks unbriefed spawns (env-staged); skills (`delegate`, `parallel-orchestrate`, `teams-develop`, `pipeline`) updated to the register+prepend-briefing spawn protocol; static + live conformance gates (`test_skill_spawn_conformance.py`, `test_conformance_static.py`, `test_agent_dispatch_hook.py`).
- **Cleanup** — gitignore `.playwright-mcp/` and `.delegate/` local run state.

## Notes

- Removes the legacy `test_develop_workflow.py` (-521 lines), superseded by the newer workflow/conformance suites.
- The merge commits for #150/#151 are part of this branch's history; opening this PR brings the full set onto `master` in one place.
