### PR TITLE
C2: fix briefing-gate deny + govern pr_comment/debug phases

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -137,30 +137,66 @@ workflows:
   # Debug workflow
   debug:
     triage:
-      allowed: [native__read_file, native__glob, native__grep, native__bash(pytest*), serena__*]
-      blocked: [native__write_file, native__edit_file]
+      allowed: [native__read_file, native__glob, native__grep, native__web_fetch, native__web_search, serena__read_file, serena__find_file, serena__search_for_pattern, serena__list_dir, serena__get_symbols_overview, serena__find_symbol, workflow__*]
+      blocked: [native__write_file, native__edit_file, native__bash, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
 
-    investigate:
-      allowed: [native__read_file, native__glob, native__grep, native__bash(pytest*), native__bash(python*), serena__*]
-      blocked: [native__write_file, native__edit_file]
+    reproduce:
+      allowed: [native__write_file, native__edit_file, native__read_file, native__glob, native__grep, native__bash, serena__*, workflow__*]
+      blocked: []
+
+    hypothesize:
+      allowed: [native__read_file, native__glob, native__grep, serena__read_file, serena__find_file, serena__search_for_pattern, serena__list_dir, serena__get_symbols_overview, serena__find_symbol, workflow__*]
+      blocked: [native__write_file, native__edit_file, native__bash, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
+
+    prove:
+      allowed: [native__read_file, native__glob, native__grep, native__bash(pytest*), native__bash(python*), native__bash(ruff*), native__bash(mypy*), serena__read_file, serena__find_file, serena__search_for_pattern, workflow__*]
+      blocked: [native__write_file, native__edit_file, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
 
     fix:
-      allowed: [native__write_file, native__edit_file, native__read_file, native__glob, native__grep, native__bash(pytest*), serena__*]
+      allowed: [native__write_file, native__edit_file, native__read_file, native__glob, native__grep, native__bash, serena__*, workflow__*]
       blocked: []
 
     verify:
-      allowed: [native__read_file, native__bash(pytest*)]
-      blocked: [native__write_file, native__edit_file]
+      allowed: [native__read_file, native__glob, native__grep, native__bash(pytest*), native__bash(python*), native__bash(ruff*), native__bash(mypy*), serena__read_file, serena__find_file, serena__search_for_pattern, workflow__*]
+      blocked: [native__write_file, native__edit_file, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
 
-  # PR review workflow
-  pr_review:
-    analyze:
-      allowed: [native__read_file, native__glob, native__grep, native__bash(gh pr*), serena__*]
-      blocked: [native__write_file, native__edit_file, native__bash]
+    push:
+      allowed: [native__read_file, native__bash(git*), native__bash(gh*), workflow__*]
+      blocked: [native__write_file, native__edit_file, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
 
-    comment:
-      allowed: [native__read_file, native__bash(gh pr comment*), native__bash(gh pr review*)]
-      blocked: [native__write_file, native__edit_file]
+    check_status:
+      allowed: [native__read_file, native__bash(git*), native__bash(gh*), workflow__*]
+      blocked: [native__write_file, native__edit_file, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
+
+    done:
+      allowed: []
+      blocked: []
+
+  # PR-comment workflow (understand before fixing)
+  pr_comment:
+    understand:
+      allowed: [native__read_file, native__glob, native__grep, serena__read_file, serena__find_file, serena__search_for_pattern, serena__list_dir, serena__get_symbols_overview, serena__find_symbol, workflow__*]
+      blocked: [native__write_file, native__edit_file, native__bash, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
+
+    fix:
+      allowed: [native__write_file, native__edit_file, native__read_file, native__glob, native__grep, native__bash, serena__*, workflow__*]
+      blocked: []
+
+    verify:
+      allowed: [native__read_file, native__glob, native__grep, native__bash(pytest*), native__bash(python*), native__bash(ruff*), native__bash(mypy*), serena__read_file, serena__find_file, serena__search_for_pattern, workflow__*]
+      blocked: [native__write_file, native__edit_file, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
+
+    push:
+      allowed: [native__read_file, native__bash(git*), native__bash(gh*), workflow__*]
+      blocked: [native__write_file, native__edit_file, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
+
+    check_reviews:
+      allowed: [native__read_file, native__glob, native__grep, native__bash(gh*), native__bash(git*), workflow__*]
+      blocked: [native__write_file, native__edit_file, serena__create_text_file, serena__replace_content, serena__replace_symbol_body]
+
+    done:
+      allowed: []
+      blocked: []
 
   # Develop workflow (PR-based SE team)
   develop:

--- a/hooks/agent-dispatch.py
+++ b/hooks/agent-dispatch.py
@@ -71,8 +71,14 @@ def allow(reason: str = "", additional_context: str = "") -> dict:
 
 
 def block(reason: str) -> dict:
-    """Return block decision."""
-    return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "block", "permissionDecisionReason": reason}}
+    """Return a deny decision.
+
+    PreToolUse honors only "allow" | "deny" | "ask" for permissionDecision;
+    the earlier "block" value was silently ignored, so an unbriefed spawn was
+    never actually stopped. "deny" blocks the Task call and surfaces the
+    reason (the briefing to prepend) back to the caller.
+    """
+    return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}
 
 
 def main():

--- a/tests/test_agent_dispatch_hook.py
+++ b/tests/test_agent_dispatch_hook.py
@@ -170,7 +170,7 @@ def test_unbriefed_default_blocks_with_agent_id_and_marker():
         env={"AGENT_SWARM_BRIEFING_ENFORCE": "block"},
     )
     hso = decision["hookSpecificOutput"]
-    assert hso["permissionDecision"] == "block"
+    assert hso["permissionDecision"] == "deny"
     reason = hso["permissionDecisionReason"]
     assert "## Your Agent Identity" in reason
     assert "sub-test" in reason
@@ -186,7 +186,7 @@ def test_unbriefed_default_env_absent_blocks():
         env={"AGENT_SWARM_BRIEFING_ENFORCE": None},  # ensure absent
     )
     hso = decision["hookSpecificOutput"]
-    assert hso["permissionDecision"] == "block"
+    assert hso["permissionDecision"] == "deny"
 
 
 def test_unbriefed_warn_allows_with_warning():
@@ -245,7 +245,7 @@ def test_none_prompt_does_not_crash():
         env={"AGENT_SWARM_BRIEFING_ENFORCE": "block"},
     )
     hso = decision["hookSpecificOutput"]
-    assert hso["permissionDecision"] == "block"
+    assert hso["permissionDecision"] == "deny"
 
 
 def test_briefed_prompt_does_not_reregister():
@@ -276,5 +276,25 @@ def test_unrecognized_enforce_value_treated_as_block():
         env={"AGENT_SWARM_BRIEFING_ENFORCE": "enabled"},
     )
     hso = decision["hookSpecificOutput"]
-    assert hso["permissionDecision"] == "block"
+    assert hso["permissionDecision"] == "deny"
+
+
+def test_block_decision_value_is_deny_not_block():
+    """Regression: the enforce decision must be the API-valid 'deny'.
+
+    PreToolUse honors only allow|deny|ask. The hook previously emitted 'block',
+    which Claude Code ignored, so unbriefed spawns were never actually stopped.
+    Pin the emitted value to 'deny' explicitly so this can't regress to a value
+    the harness silently drops.
+    """
+    _, decision = _run_with_decision(
+        {
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "implementer", "prompt": _UNBRIEFED_PROMPT, "description": "d"},
+        },
+        env={"AGENT_SWARM_BRIEFING_ENFORCE": "block"},
+    )
+    hso = decision["hookSpecificOutput"]
+    assert hso["permissionDecision"] in ("allow", "deny", "ask")
+    assert hso["permissionDecision"] == "deny"
 

--- a/tests/test_conformance_static.py
+++ b/tests/test_conformance_static.py
@@ -8,10 +8,10 @@ deliberate baseline update either way. Complements the live driver
 (test_conformance_live.py), which exercises one workflow end-to-end.
 
 Current known gaps are tracked in #106 (and surfaced by `python3 -m lib.conformance`):
-  - pr_comment: no workflows['pr_comment'] block in permissions.yaml -> L1 skipped.
   - develop:    phase 'complete' declared in YAML but absent at L1.
   - experiment: phase 'done' declared in YAML but absent at L1.
   - debug:      in _KNOWN_WORKFLOWS but has no workflow YAML (phantom).
+  (pr_comment was fixed: its 6 phases are now governed at L1.)
 """
 
 import pytest
@@ -21,7 +21,7 @@ from lib.conformance import analyze
 # Workflows whose declared phases are NOT fully governed at L1 today. Each is a
 # known, tracked gap (#106). A workflow entering or leaving this set should fail
 # the matrix test below, so the baseline is updated deliberately.
-KNOWN_FAIL_OPEN = {"develop", "experiment", "pr_comment"}
+KNOWN_FAIL_OPEN = {"develop", "experiment"}
 
 # _KNOWN_WORKFLOWS entries that have no workflow YAML.
 KNOWN_PHANTOM = {"debug"}

--- a/tests/test_pr_comment_lifecycle.py
+++ b/tests/test_pr_comment_lifecycle.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""End-to-end phase-lifecycle enforcement for the pr_comment workflow.
+
+Drives a realistic "address a PR review comment" scenario through the real
+PermissionChecker (loaded from config/permissions.yaml) across the full phase
+sequence understand -> fix -> verify -> push -> check_reviews -> done, and
+asserts the gate enforces the right thing at each phase.
+
+Guards the C2 migration: pr_comment previously had no L1 block (keyed as the
+stale "pr_review"), so the read-only understand phase fell through to the
+implementer role and could edit files. test_understand_would_leak_without_gate
+pins that contrast so a regression to an ungoverned pr_comment is caught.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from lib.permissions import PermissionChecker
+
+_PERMISSIONS = Path(__file__).parent.parent / "config" / "permissions.yaml"
+
+
+@pytest.fixture
+def gate():
+    pc = PermissionChecker(_PERMISSIONS)
+    pc.register_agent("pr-worker", agent_type="implementer", roles=["implementer"])
+
+    def can(phase, tool, args=None):
+        pc.update_agent_phase("pr-worker", "pr_comment", phase)
+        return pc.check(tool, args or {}, pc._agents["pr-worker"])[0]
+
+    return can
+
+
+def test_understand_is_read_only(gate):
+    assert gate("understand", "native__read_file") is True
+    assert gate("understand", "native__grep") is True
+    assert gate("understand", "native__edit_file") is False
+    assert gate("understand", "native__write_file") is False
+    # serena write path must also be closed, not just the native one
+    assert gate("understand", "serena__replace_content") is False
+    assert gate("understand", "native__bash", {"command": "python x.py"}) is False
+
+
+def test_fix_allows_edits_and_tests(gate):
+    assert gate("fix", "native__edit_file") is True
+    assert gate("fix", "native__write_file") is True
+    assert gate("fix", "native__bash", {"command": "pytest -q"}) is True
+
+
+def test_verify_runs_tests_but_no_edits(gate):
+    assert gate("verify", "native__bash", {"command": "pytest -q"}) is True
+    assert gate("verify", "native__edit_file") is False
+    assert gate("verify", "native__write_file") is False
+
+
+def test_push_allows_git_gh_not_edits(gate):
+    assert gate("push", "native__bash", {"command": "git push"}) is True
+    assert gate("push", "native__bash", {"command": "gh pr comment 42 -b done"}) is True
+    assert gate("push", "native__edit_file") is False
+
+
+def test_check_reviews_reads_and_polls_no_edits(gate):
+    assert gate("check_reviews", "native__bash", {"command": "gh pr view 42"}) is True
+    assert gate("check_reviews", "native__read_file") is True
+    assert gate("check_reviews", "native__edit_file") is False
+
+
+def test_understand_would_leak_without_gate(gate):
+    """Contrast: an ungoverned phase (as pr_comment was, keyed 'pr_review')
+    falls through to the implementer role, which allows edits. This is the
+    hole the C2 migration closed; if pr_comment's understand block regresses
+    to absent, test_understand_is_read_only flips and this stays green."""
+    pc = PermissionChecker(_PERMISSIONS)
+    pc.register_agent("x", agent_type="implementer", roles=["implementer"])
+    pc.update_agent_phase("x", "pr_review", "analyze")  # a base_wf with no block
+    assert pc.check("native__edit_file", {}, pc._agents["x"])[0] is True

--- a/tests/test_simple_changes.py
+++ b/tests/test_simple_changes.py
@@ -37,7 +37,7 @@ class TestPermissionsAdditive:
         with open(PERMISSIONS_YAML) as f:
             data = yaml.safe_load(f)
         wfs = data["workflows"]
-        for name in ("iterate", "debug", "pr_review", "develop", "experiment"):
+        for name in ("iterate", "debug", "pr_comment", "develop", "experiment"):
             assert name in wfs, f"pre-existing workflow {name!r} removed"
 
     def test_simple_plan_blocks_writes(self):


### PR DESCRIPTION
## C2 — Enforcement correctness + phase-gate migration

Second cluster of the 2026-08-11 remediation plan. Two independent fixes to the enforcement layer.

### 1. Briefing gate emitted an ignored decision value (universal)
`hooks/agent-dispatch.py` returned `permissionDecision: "block"`, but PreToolUse honors only `allow`/`deny`/`ask` — Claude Code silently dropped it, so unbriefed Task/Agent spawns were **never actually stopped** (verified live: 8 unbriefed spawns sailed through). Now emits `"deny"`, which blocks the call and surfaces the briefing reason for the caller to prepend.

Four existing tests had pinned the buggy `"block"` value → updated to `"deny"`, plus `test_block_decision_value_is_deny_not_block` as an explicit regression guard against a value the harness would ignore.

### 2. `pr_comment` and `debug` were never migrated onto the phase gate
`permissions.yaml` is the authority for tool permissions. These two workflows predate the phase-gate layer:
- **`pr_comment`**: the live block was keyed `pr_review` with an older workflow's phases (`analyze`/`comment`), so `base_wf "pr_comment"` was never found and the **entire L1 phase gate was skipped** — a fall-through to the implementer role let the read-only `understand` phase write files. Replaced with a `pr_comment` block covering all 6 real phases.
- **`debug`**: block had a phantom `investigate` phase and covered only 4 of the engine's 9 phases. Replaced with the full 9-phase block.

Rules follow the `simple`-workflow convention: read-only phases whitelist specific serena reads and **explicitly block serena write tools** (not just native write/edit), full phases allow unscoped bash + `serena__*`, verify phases allow scoped test bash, push phases allow git/gh, `done` is empty (role-governed).

### Verification
- Against the **real `PermissionChecker`**: `understand`/`triage`/`hypothesize` deny writes + edits + serena-writes + bash; `fix`/`reproduce` allow writes; `verify`/`prove` block edits but allow scoped test bash; `push` allows git/gh only.
- End-to-end phase-sequence walkthrough of the `pr_comment` workflow (see PR thread).
- `lib.conformance` baseline (#106) updated: `pr_comment` leaves `KNOWN_FAIL_OPEN` (now governed).
- Full suite: **1650 passed / 275 skipped / 0 failed**.

### Scope boundaries (not regressions)
- Live end-to-end confirmation of the deny fix awaits the C1 marketplace cutover (this session's hooks still load the old cached `block` version).
- `develop`/`experiment` remain in the fail-open baseline — their only gap is a terminal `done`/`complete` phase that gates nothing (tracked #106).
- `debug` has no workflow YAML, so conformance tracks it as phantom; its block is enforced via `permissions.yaml` regardless.
