### PR TITLE
fix(telemetry): C5 collection correctness — double-recording + honest success/error status

### DIFF
--- a/lib/controller.py
+++ b/lib/controller.py
@@ -63,6 +63,22 @@ def _is_protected_key(key: str) -> bool:
     )
 
 
+def _call_status(raw_result: Any) -> tuple[str, str]:
+    """Classify a completed tool call for telemetry: ``(status, error_type)``.
+
+    A call is an error when it timed out or the tool reported failure
+    (``isError``). A non-zero shell ``exit_code`` alone is NOT an error -- many
+    commands (grep with no match, a failing test run) exit non-zero as normal
+    output -- so it does not flip the status.
+    """
+    if isinstance(raw_result, dict):
+        if raw_result.get("timed_out"):
+            return "error", "Timeout"
+        if raw_result.get("isError"):
+            return "error", str(raw_result.get("error_type") or "ToolError")
+    return "success", ""
+
+
 # --- Bash file-I/O lockdown ---------------------------------------------------
 
 
@@ -243,12 +259,16 @@ class Controller:
                 raw_result, content_id, original_size
             )
 
-        # Record success telemetry
+        # Record telemetry. A returned result can still represent a failed call
+        # (a bash timeout, a tool-level isError), so classify the outcome rather
+        # than assume success just because no exception propagated.
         duration_ms = int((time.monotonic() - start_time) * 1000)
+        status, error_type = _call_status(raw_result)
         self.data.record_event({
             "tool": tool,
             "backend": prefix,
-            "status": "success",
+            "status": status,
+            "error_type": error_type,
             "duration_ms": duration_ms,
             "original_size": original_size,
             "summary_size": len(str(result)) if was_summarized else None,
@@ -295,11 +315,9 @@ class Controller:
         if content is None:
             return {"error": "Content not found or expired", "isError": True}
 
-        self.data.record_event({
-            "tool": "router__get_full",
-            "backend": "router",
-            "status": "success",
-        })
+        # No telemetry here: handle_call already records one attributed row for
+        # the router__get_full call. Recording again produced a duplicate,
+        # unattributed row (C5 double-recording).
         return content
 
     def list_backend_tools(self) -> list[dict]:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -111,6 +111,54 @@ def ctrl_with_config(tmp_path):
 # --- Native operations ---
 
 
+class TestCallStatus:
+    """_call_status classifies a tool call's outcome for telemetry."""
+
+    def test_success_dict(self):
+        from lib.controller import _call_status
+        assert _call_status({"exit_code": 0, "stdout": "ok"}) == ("success", "")
+
+    def test_timed_out_is_error(self):
+        from lib.controller import _call_status
+        assert _call_status({"timed_out": True, "exit_code": -1}) == ("error", "Timeout")
+
+    def test_tool_iserror_is_error(self):
+        from lib.controller import _call_status
+        status, etype = _call_status({"isError": True, "error": "not found"})
+        assert status == "error"
+        assert etype
+
+    def test_nonzero_exit_is_not_an_error(self):
+        # A command exiting non-zero (grep no-match, pytest failures) is a
+        # successful tool call; only timeouts / tool errors flip status.
+        from lib.controller import _call_status
+        assert _call_status({"exit_code": 1, "stdout": ""}) == ("success", "")
+
+    def test_non_dict_result_is_success(self):
+        from lib.controller import _call_status
+        assert _call_status("some string result") == ("success", "")
+
+
+class TestTelemetryIntegrity:
+    """Collection-correctness of recorded events (C5)."""
+
+    def test_get_full_records_single_event(self, ctrl):
+        # Regression: get_full was recorded twice -- once by handle_call's outer
+        # path and once inside get_full_content (unattributed) -- inflating
+        # counts. Exactly one row per call.
+        ctrl.cache.store("cabc123def456", {"some": "data"})
+        ctrl.handle_call("router__get_full", {"content_id": "cabc123def456"})
+        events = ctrl.data.query_events(tool="router__get_full")
+        assert len(events) == 1
+
+    def test_tool_error_recorded_as_error_status(self, ctrl):
+        # A tool-level failure (missing file returns isError, does not raise)
+        # must be recorded as status='error', not inflate the success count.
+        ctrl.handle_call("native__read_file", {"file_path": "/nonexistent/xyz"})
+        events = ctrl.data.query_events(tool="native__read_file")
+        assert events[-1].status == "error"
+
+
 class TestNativeReadFile:
     def test_read_existing_file(self, ctrl, tmp_path):
         f = tmp_path / "test.txt"


### PR DESCRIPTION
Implements the two verified, plugin-repo **collection-correctness** bugs from **C5 (Telemetry integrity)** in the re-graded remediation plan, grounded against the live store.

## Fixes

### Double-recording (C5 #2)
`router__get_full` was recorded **twice** — once by `handle_call`'s attributed outer path, and again inside `get_full_content` as an unattributed inner row. This inflated call counts and split attribution across incomplete rows. Removed the inner `record_event`; `handle_call` is the single recorder.

### Success inflation (C5 #3)
`handle_call` hardcoded `status="success"` for every result that didn't raise — so a **600s bash timeout** or a tool-level `isError` (e.g. missing file) was logged as a success. Error-rate metrics were fiction (~0.5% all-time).
- New `_call_status(raw_result)` classifies the outcome: `timed_out` or `isError` → `status="error"` (with `error_type`).
- A non-zero shell `exit_code` **alone** stays `success` — `grep` with no match and failing test runs exit non-zero as normal output, so flipping status on that would inflate errors the other way. Exit-code-as-error needs a per-code policy (127 vs 1) and is **deferred**.

## Grounding notes (corrections to the plan's assumptions)
- **`dashboard/import.py` is LIVE**, not dead: `run_dashboard_import()` loads it via importlib every import cycle. So C5 #1 (import-freeze — `is_already_imported` lacks an mtime/size check) is a **real live bug**, tracked as remaining work.
- `run_dashboard_import()` already catches and logs its own failures, so C5 #7's "silent failure" gap is smaller than stated (the fully-scrapeable pipeline-health signal is exporter-side).
- The exporter bugs (C5 #6: `events_recent` `'T' > ' '` window artifact; `*_total` Gauges vs `rate()`) and stack supervision (#8/#10) live in the **separate logos-otel repo**.

## Remaining C5 (not in this PR)
Import-freeze (#1, live — own PR), sub-ms duration flooring (#5), exporter/infra bugs (#6/#8/#10, logos-otel repo).

## Verification
TDD throughout (RED → GREEN). **+7 tests**, full suite **1643 passed / 275 skipped / 0 failed** (purely additive). Branched cleanly off master (independent of the C3 PR #160).

https://claude.ai/code/session_01UsWsdz52Gv61jMXBQvftvw