### PR TITLE
fix(telemetry): C5 import-freeze — re-import grown transcripts

### DIFF
--- a/dashboard/import.py
+++ b/dashboard/import.py
@@ -74,7 +74,9 @@ CREATE TABLE IF NOT EXISTS import_log (
     source_path TEXT NOT NULL,
     imported_at TEXT NOT NULL,
     events_inserted INTEGER DEFAULT 0,
-    events_skipped INTEGER DEFAULT 0
+    events_skipped INTEGER DEFAULT 0,
+    source_mtime REAL DEFAULT 0,
+    source_size INTEGER DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS session_files (
@@ -120,7 +122,18 @@ def init_db(db_path: str) -> sqlite3.Connection:
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.executescript(SCHEMA_SQL)
+    _migrate_import_log(conn)
     return conn
+
+
+def _migrate_import_log(conn: sqlite3.Connection) -> None:
+    """Add import_log change-detection columns to DBs created before them."""
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(import_log)")}
+    if "source_mtime" not in cols:
+        conn.execute("ALTER TABLE import_log ADD COLUMN source_mtime REAL DEFAULT 0")
+    if "source_size" not in cols:
+        conn.execute("ALTER TABLE import_log ADD COLUMN source_size INTEGER DEFAULT 0")
+    conn.commit()
 
 
 def derive_backend(tool_name: str) -> str:
@@ -161,11 +174,31 @@ def detect_error(content) -> tuple[bool, str]:
     return False, ""
 
 
-def is_already_imported(conn: sqlite3.Connection, source: str, source_path: str) -> bool:
-    """Check if a source file was already imported."""
+def is_already_imported(
+    conn: sqlite3.Connection,
+    source: str,
+    source_path: str,
+    source_mtime: float | None = None,
+    source_size: int | None = None,
+) -> bool:
+    """Check whether this version of a source file was already imported.
+
+    When mtime and size are given, the match requires them too, so a transcript
+    that has grown since its last import counts as not-yet-imported and gets
+    re-processed (per-event dedup then inserts only the new events). Without them
+    the check is path-only (backward-compatible for callers that don't stat the
+    source, e.g. the duckdb path).
+    """
+    if source_mtime is None or source_size is None:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM import_log WHERE source = ? AND source_path = ?",
+            (source, source_path),
+        ).fetchone()
+        return row[0] > 0
     row = conn.execute(
-        "SELECT COUNT(*) FROM import_log WHERE source = ? AND source_path = ?",
-        (source, source_path),
+        "SELECT COUNT(*) FROM import_log "
+        "WHERE source = ? AND source_path = ? AND source_mtime = ? AND source_size = ?",
+        (source, source_path, source_mtime, source_size),
     ).fetchone()
     return row[0] > 0
 
@@ -508,7 +541,11 @@ def import_claude_transcripts(
 
     def _import_file(filepath: Path) -> tuple[int, int]:
         source_path = str(filepath.resolve())
-        if not force and is_already_imported(conn, "claude_transcript", source_path):
+        st = filepath.stat()
+        source_mtime, source_size = st.st_mtime, st.st_size
+        if not force and is_already_imported(
+            conn, "claude_transcript", source_path, source_mtime, source_size
+        ):
             return 0, 0
 
         events = parse_jsonl_file(filepath, agent_type_map=agent_type_map)
@@ -553,8 +590,10 @@ def import_claude_transcripts(
 
         if not dry_run and (inserted > 0 or skipped > 0):
             conn.execute(
-                "INSERT INTO import_log (source, source_path, imported_at, events_inserted, events_skipped) VALUES (?, ?, ?, ?, ?)",
-                ("claude_transcript", source_path, datetime.now(timezone.utc).isoformat(), inserted, skipped),
+                "INSERT INTO import_log (source, source_path, imported_at, events_inserted, "
+                "events_skipped, source_mtime, source_size) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("claude_transcript", source_path, datetime.now(timezone.utc).isoformat(),
+                 inserted, skipped, source_mtime, source_size),
             )
             conn.commit()
 

--- a/tests/test_dashboard_import.py
+++ b/tests/test_dashboard_import.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Tests for dashboard/import.py transcript-import change detection (C5 import-freeze).
+
+The bug: `is_already_imported` matched only on (source, source_path), so a Claude
+transcript that grew after its first import was skipped forever -- the dashboard
+DB froze at the first import (e.g. 14 of 1,090+ calls recorded). The fix adds
+mtime/size change detection so a grown transcript is re-processed (per-event
+dedup then inserts only the new events).
+"""
+
+import importlib.util
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_IMPORT_PY = Path(__file__).parent.parent / "dashboard" / "import.py"
+_spec = importlib.util.spec_from_file_location("dashboard_import", _IMPORT_PY)
+dashboard_import = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dashboard_import)
+
+
+@pytest.fixture
+def conn(tmp_path):
+    c = dashboard_import.init_db(str(tmp_path / "dash.db"))
+    yield c
+    c.close()
+
+
+def _log_import(conn, path, mtime, size):
+    conn.execute(
+        "INSERT INTO import_log (source, source_path, imported_at, events_inserted, "
+        "events_skipped, source_mtime, source_size) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("claude_transcript", path, datetime.now(timezone.utc).isoformat(), 1, 0, mtime, size),
+    )
+    conn.commit()
+
+
+def _entry(tuid, ts="2026-08-13T10:00:00Z"):
+    return json.dumps({
+        "type": "assistant",
+        "timestamp": ts,
+        "sessionId": "sess-1",
+        "message": {"content": [{"type": "tool_use", "id": tuid, "name": "Bash"}], "usage": {}},
+    })
+
+
+class TestImportLogMigration:
+    def test_import_log_has_change_detection_columns(self, conn):
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(import_log)")}
+        assert "source_mtime" in cols
+        assert "source_size" in cols
+
+    def test_migration_adds_columns_to_legacy_import_log(self, tmp_path):
+        # A DB created before change detection existed must gain the columns
+        # idempotently when reopened via init_db.
+        db = str(tmp_path / "legacy.db")
+        c0 = sqlite3.connect(db)
+        c0.execute(
+            "CREATE TABLE import_log (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "source TEXT NOT NULL, source_path TEXT NOT NULL, imported_at TEXT NOT NULL, "
+            "events_inserted INTEGER DEFAULT 0, events_skipped INTEGER DEFAULT 0)"
+        )
+        c0.commit()
+        c0.close()
+        conn = dashboard_import.init_db(db)
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(import_log)")}
+        assert "source_mtime" in cols and "source_size" in cols
+        conn.close()
+
+
+class TestIsAlreadyImported:
+    def test_unchanged_file_is_already_imported(self, conn):
+        _log_import(conn, "/p/s.jsonl", 100.0, 500)
+        assert dashboard_import.is_already_imported(
+            conn, "claude_transcript", "/p/s.jsonl", 100.0, 500) is True
+
+    def test_grown_file_is_not_already_imported(self, conn):
+        # The freeze: a transcript whose size changed must count as not-imported.
+        _log_import(conn, "/p/s.jsonl", 100.0, 500)
+        assert dashboard_import.is_already_imported(
+            conn, "claude_transcript", "/p/s.jsonl", 100.0, 900) is False
+
+    def test_changed_mtime_is_not_already_imported(self, conn):
+        _log_import(conn, "/p/s.jsonl", 100.0, 500)
+        assert dashboard_import.is_already_imported(
+            conn, "claude_transcript", "/p/s.jsonl", 200.0, 500) is False
+
+    def test_path_only_check_is_backward_compatible(self, conn):
+        # Called without mtime/size (e.g. the duckdb path) -> path-only match.
+        _log_import(conn, "/p/s.jsonl", 100.0, 500)
+        assert dashboard_import.is_already_imported(
+            conn, "claude_transcript", "/p/s.jsonl") is True
+
+
+class TestReimportOnGrowth:
+    def test_grown_transcript_reimports_new_events(self, conn, tmp_path):
+        projects = tmp_path / "projects"
+        proj = projects / "myproj"
+        proj.mkdir(parents=True)
+        f = proj / "session.jsonl"
+        f.write_text(_entry("tu-1") + "\n")
+
+        r1 = dashboard_import.import_claude_transcripts(conn, str(projects))
+        assert r1["inserted"] == 1
+
+        # Transcript grows: a new tool call is appended (size changes).
+        f.write_text(_entry("tu-1") + "\n" + _entry("tu-2") + "\n")
+
+        r2 = dashboard_import.import_claude_transcripts(conn, str(projects))
+        assert r2["inserted"] == 1  # only the new event; tu-1 is deduped
+
+        total = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        assert total == 2


### PR DESCRIPTION
Fixes the **import-freeze bug (C5 #1)** — a live data-correctness bug I surfaced while grounding C5 (the earlier regrade wrongly assumed `dashboard/` was dead; `run_dashboard_import` loads `dashboard/import.py` via importlib every cycle).

## Bug
`is_already_imported()` matched only on `(source, source_path)`. Once a Claude transcript was imported, it was skipped **forever** — even as the session kept appending tool calls. The dashboard DB froze at the first import (the eval measured the main session as **14 of 1,090+ calls**).

## Fix
Change detection by **mtime + size**:
- `import_log` now stores `source_mtime` / `source_size` per imported file (idempotent migration adds them to existing DBs).
- `is_already_imported()` treats a file as not-yet-imported when its mtime **or** size changed, so a grown transcript is re-processed. mtime/size are optional args — the duckdb path stays path-only (unchanged).
- Re-import is safe because the existing **per-event dedup** (`dedup_check_jsonl`, 5-column key) skips already-inserted events and inserts only the new ones.

## Tests (first tests for `dashboard/import.py`)
- `is_already_imported` change detection (unchanged→True, grown/mtime-changed→False, path-only backward-compat).
- Idempotent migration on a legacy `import_log`.
- **End-to-end**: import a transcript, append a new tool call, re-import → only the new event is inserted. This reproduced the freeze as `0 == 1` before the fix.

Full suite **1666 passed / 275 skipped / 0 failed** (+7 tests). Branched off master (independent of #161).

## Note
`import_duckdb` uses the same path-only check (datastore.db would also freeze if that path were on the live loop — it isn't; `run_dashboard_import` only calls `import_claude_transcripts`). Left out of scope; flagged for a follow-up if the duckdb path is ever revived.

https://claude.ai/code/session_01UsWsdz52Gv61jMXBQvftvw