### PR TITLE
fix(telemetry): C5 #5 — record fractional-ms durations (stop flooring sub-ms to 0)

### DIFF
--- a/lib/controller.py
+++ b/lib/controller.py
@@ -293,7 +293,7 @@ class Controller:
         # Record telemetry. A returned result can still represent a failed call
         # (a bash timeout, a tool-level isError), so classify the outcome rather
         # than assume success just because no exception propagated.
-        duration_ms = int((time.monotonic() - start_time) * 1000)
+        duration_ms = round((time.monotonic() - start_time) * 1000, 3)
         status, error_type = _call_status(raw_result)
         self.data.record_event({
             "tool": tool,
@@ -325,7 +325,7 @@ class Controller:
         target: str = "",
     ) -> None:
         """Record a failed tool call in the event store."""
-        duration_ms = int((time.monotonic() - start_time) * 1000)
+        duration_ms = round((time.monotonic() - start_time) * 1000, 3)
         try:
             self.data.record_event({
                 "tool": tool,

--- a/lib/datastore.py
+++ b/lib/datastore.py
@@ -22,7 +22,7 @@ class EventRecord:
     tool: str
     backend: str
     status: str  # "success" | "error"
-    duration_ms: int = 0
+    duration_ms: float = 0.0
     session_id: str = ""
     agent_id: str = ""
     agent_type: str = ""
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS events (
     tool TEXT NOT NULL,
     backend TEXT NOT NULL,
     status TEXT NOT NULL,
-    duration_ms INTEGER DEFAULT 0,
+    duration_ms REAL DEFAULT 0,
     session_id TEXT DEFAULT '',
     agent_id TEXT DEFAULT '',
     agent_type TEXT DEFAULT '',

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -237,6 +237,29 @@ class TestMutationTarget:
         assert events[-1].target == str(f)
 
 
+class TestDurationPrecision:
+    """Sub-millisecond calls record their real duration, not floor to 0 (C5 #5)."""
+
+    def test_sub_millisecond_call_records_fractional_duration(self, ctrl, tmp_path, monkeypatch):
+        import lib.controller as controller_mod
+
+        f = tmp_path / "r.txt"
+        f.write_text("hi")
+        # First monotonic() reading is the start; every later reading returns the
+        # end, so elapsed is a fixed 0.4 ms regardless of how many times
+        # handle_call reads the clock. int(0.4) == 0 was the bug.
+        clock = [1000.0, 1000.0004]
+
+        def fake_monotonic():
+            return clock.pop(0) if len(clock) > 1 else clock[0]
+
+        monkeypatch.setattr(controller_mod.time, "monotonic", fake_monotonic)
+        ctrl.handle_call("native__read_file", {"file_path": str(f)})
+        events = ctrl.data.query_events(tool="native__read_file")
+        assert events
+        assert events[-1].duration_ms == pytest.approx(0.4)
+
+
 class TestNativeReadFile:
     def test_read_existing_file(self, ctrl, tmp_path):
         f = tmp_path / "test.txt"

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -57,6 +57,12 @@ class TestRecordAndQuery:
         events = store.get_session_events("sess-1")
         assert events[0].target == ""
 
+    def test_fractional_duration_preserved(self, store):
+        # Durations are fractional milliseconds so sub-ms calls aren't lost.
+        store.record_event(_make_event(duration_ms=0.4))
+        events = store.get_session_events("sess-1")
+        assert events[0].duration_ms == 0.4
+
     def test_defaults(self, store):
         store.record_event({"tool": "x", "backend": "y", "status": "success"})
         events = store.query_events(tool="x")


### PR DESCRIPTION
Fixes **C5 #5 (sub-ms duration flooring)** from the re-graded plan.

## Bug
`handle_call` computed `duration_ms = int((monotonic() - start) * 1000)`, so any call faster than 1 ms floored to **0**. On the live store, **64% of rows (10,934 / 17,075) have `duration_ms = 0`** — duration analytics are fiction for the common fast calls.

## Fix
Record `round((...) * 1000, 3)` (microsecond resolution) at both the success and error record sites. Declare the datastore `duration_ms` column `REAL` and `EventRecord.duration_ms` `float` to make the "fractional ms" intent explicit.

SQLite already stored fractional values fine (dynamic typing) — confirmed by a datastore round-trip test that passed *before* the code change — so the actual fix is purely the controller's `int()`. Consumers already treat duration as a number (`get_daily_summary` `AVG`, `run_scorer` `SUM`).

## Scope
Only the sub-ms precision half of #5. **#5b** (bucket events by *start* timestamp rather than completion time, so stall windows don't hollow out) is a larger time-series semantic change that touches the exporter — tracked separately, not here.

## Verification
TDD: a controller test with a fixed fake clock (0.4 ms elapsed) asserted `0.4`, failing `0 == 0.4` before the fix. Full suite **1675 passed / 275 skipped / 0 regressions** (+2 tests). Branched off master.

https://claude.ai/code/session_01UsWsdz52Gv61jMXBQvftvw