### PR TITLE
fix(hooks): honest ensure_otel_stack reporting + captured output (C5 #8)

### DIFF
--- a/hooks/session-start.py
+++ b/hooks/session-start.py
@@ -443,10 +443,11 @@ def get_agent_briefing() -> str:
         return ""
 
 
-def ensure_otel_stack() -> str | None:
+def ensure_otel_stack(otel_dir: Path | None = None) -> str | None:
     """Start OTEL stack if not running."""
     import subprocess
-    otel_dir = Path.home() / ".claude" / "infra" / "otel"
+    if otel_dir is None:
+        otel_dir = Path.home() / ".claude" / "infra" / "otel"
     compose_file = next(
         (otel_dir / name for name in ("docker-compose.yml", "docker-compose.yaml", "compose.yaml", "compose.yml")
          if (otel_dir / name).exists()),
@@ -461,12 +462,21 @@ def ensure_otel_stack() -> str | None:
         )
         if result.stdout.strip() == "true":
             return None
-        # Not running — fire-and-forget start (hook timeout is 10s, can't wait)
-        subprocess.Popen(
-            ["docker", "compose", "-f", str(compose_file), "up", "-d"],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        # Not running — best-effort background start (the hook budget is ~10s,
+        # too short to wait for `compose up -d`). Capture output to a log so a
+        # failed start leaves a trace instead of being silently discarded, and
+        # report honestly that startup is unconfirmed rather than claiming it
+        # started (a failed compose up would otherwise still print "starting").
+        start_log = otel_dir / ".last-start.log"
+        with open(start_log, "w") as log:
+            subprocess.Popen(
+                ["docker", "compose", "-f", str(compose_file), "up", "-d"],
+                stdout=log, stderr=subprocess.STDOUT,
+            )
+        return (
+            "OTEL stack was not running — attempted a background start "
+            f"(unconfirmed; see {start_log} or Grafana at http://localhost:3000)"
         )
-        return "OTEL stack starting from ~/.claude/infra/otel/"
     except Exception:
         return None
 

--- a/hooks/session-start.py
+++ b/hooks/session-start.py
@@ -468,14 +468,27 @@ def ensure_otel_stack(otel_dir: Path | None = None) -> str | None:
         # report honestly that startup is unconfirmed rather than claiming it
         # started (a failed compose up would otherwise still print "starting").
         start_log = otel_dir / ".last-start.log"
-        with open(start_log, "w") as log:
+        # Best-effort log capture: if the (externally managed) otel dir is not
+        # writable, fall back to DEVNULL rather than SKIPPING the start (opening
+        # the log inside the outer try would otherwise abort compose entirely).
+        # Append mode ('a') so concurrent session starts don't truncate each
+        # other's log.
+        try:
+            log_out = open(start_log, "a")
+        except OSError:
+            log_out, start_log = subprocess.DEVNULL, None
+        try:
             subprocess.Popen(
                 ["docker", "compose", "-f", str(compose_file), "up", "-d"],
-                stdout=log, stderr=subprocess.STDOUT,
+                stdout=log_out, stderr=subprocess.STDOUT,
             )
+        finally:
+            if log_out is not subprocess.DEVNULL:
+                log_out.close()
+        trace = f"see {start_log} or " if start_log else ""
         return (
             "OTEL stack was not running — attempted a background start "
-            f"(unconfirmed; see {start_log} or Grafana at http://localhost:3000)"
+            f"(unconfirmed; {trace}check Grafana at http://localhost:3000)"
         )
     except Exception:
         return None

--- a/tests/test_session_start_bootstrap.py
+++ b/tests/test_session_start_bootstrap.py
@@ -261,3 +261,54 @@ class TestRegisterMainAgentRetriesOnColdDaemon:
         ]
         assert reg_calls, "main agent was never registered"
         assert reg_calls[0].args[1]["agent_type"] == "main"
+
+
+class TestEnsureOtelStackHonestReporting:
+    """ensure_otel_stack must not claim success it can't confirm, and must not
+    discard the background start's output (C5 #8 supervision)."""
+
+    def _mod(self):
+        return _load_session_start("session_start_otel_stack")
+
+    def test_reports_unconfirmed_and_captures_output_when_not_running(self, tmp_path, monkeypatch):
+        import subprocess
+
+        mod = self._mod()
+        otel_dir = tmp_path / "otel"
+        otel_dir.mkdir()
+        (otel_dir / "docker-compose.yml").write_text("services: {}\n")
+
+        class _NotRunning:
+            stdout = "false"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _NotRunning())
+        captured = {}
+
+        def _fake_popen(*a, **k):
+            captured.update(k)
+            return object()
+
+        monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+
+        msg = mod.ensure_otel_stack(otel_dir=otel_dir)
+
+        # Honest: does not claim it "started"; flags startup as unconfirmed.
+        assert msg is not None
+        assert "unconfirmed" in msg.lower()
+        # Output captured to a log, not discarded to DEVNULL.
+        assert captured.get("stdout") is not subprocess.DEVNULL
+        assert (otel_dir / ".last-start.log").exists()
+
+    def test_returns_none_when_already_running(self, tmp_path, monkeypatch):
+        import subprocess
+
+        mod = self._mod()
+        otel_dir = tmp_path / "otel"
+        otel_dir.mkdir()
+        (otel_dir / "docker-compose.yml").write_text("services: {}\n")
+
+        class _Running:
+            stdout = "true"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Running())
+        assert mod.ensure_otel_stack(otel_dir=otel_dir) is None

--- a/tests/test_session_start_bootstrap.py
+++ b/tests/test_session_start_bootstrap.py
@@ -312,3 +312,35 @@ class TestEnsureOtelStackHonestReporting:
 
         monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Running())
         assert mod.ensure_otel_stack(otel_dir=otel_dir) is None
+
+    def test_start_attempted_even_if_log_unwritable(self, tmp_path, monkeypatch):
+        # A read-only otel dir must NOT skip the start -- the log capture falls
+        # back to DEVNULL and compose is still attempted (review PR #165).
+        import builtins
+        import subprocess
+
+        mod = self._mod()
+        otel_dir = tmp_path / "otel"
+        otel_dir.mkdir()
+        (otel_dir / "docker-compose.yml").write_text("services: {}\n")
+
+        class _NotRunning:
+            stdout = "false"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _NotRunning())
+
+        real_open = builtins.open
+
+        def _no_log_open(f, *a, **k):
+            if str(f).endswith(".last-start.log"):
+                raise PermissionError("read-only")
+            return real_open(f, *a, **k)
+
+        monkeypatch.setattr(builtins, "open", _no_log_open)
+
+        captured = {}
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: captured.update(k) or object())
+
+        msg = mod.ensure_otel_stack(otel_dir=otel_dir)
+        assert msg is not None                                # start still attempted
+        assert captured.get("stdout") is subprocess.DEVNULL   # fell back to DEVNULL


### PR DESCRIPTION
The agent-swarm half of **C5 #8** (stack supervision). Pairs with logos-otel PR #4 (the Prometheus alerting that actually detects a down stack).

## Problem
`session-start.py::ensure_otel_stack` started the OTEL stack with a fire-and-forget `docker compose up -d`, **discarding stdout/stderr to `DEVNULL`** and **unconditionally returning "OTEL stack starting"**. A failed `compose up` therefore printed success and left no trace — one reason a down stack went unnoticed for 26 days.

## Fix
- Capture the background start's output to `<otel_dir>/.last-start.log` (stderr merged) instead of `DEVNULL`, so a failed start leaves a trace.
- Return an honest **"attempted a background start (unconfirmed; see <log> or Grafana)"** rather than claiming it started (the hook's ~10s budget can't wait for `up -d`, so success genuinely is unconfirmed).
- Added an optional `otel_dir` param purely for testability.

Detection of an actually-down stack is the alerting's job (logos-otel PR #4: `OtelCollectorDown`, `AgentSwarmExporterScrapeStale`).

## Tests
New tests: honest message + output captured to a log (not `DEVNULL`) when the collector isn't running; `None` when already running. Full suite **1677 passed / 0 regressions**.

https://claude.ai/code/session_01UsWsdz52Gv61jMXBQvftvw