### PR TITLE
feat(experiment): experiment_reader/writer store with presence-gated memory

### DIFF
--- a/config/backends.json
+++ b/config/backends.json
@@ -18,5 +18,9 @@
   "workflow": {
     "command": ["python3", "{{PLUGIN_ROOT}}/lib/workflow_server.py"],
     "tool_prefix": "workflow"
+  },
+  "experiment": {
+    "command": ["python3", "{{PLUGIN_ROOT}}/lib/experiment_server.py"],
+    "tool_prefix": "experiment"
   }
 }

--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -9,7 +9,7 @@
 
 global:
   # Default allowed tools for all callers (router tool names)
-  allowed: [Task, serena__*, native__read_file, native__glob, native__grep, native__bash, native__web_fetch, native__web_search, workflow__*, context7__*, router__*, playwright__*]
+  allowed: [Task, serena__*, native__read_file, native__glob, native__grep, native__bash, native__web_fetch, native__web_search, workflow__*, experiment__*, context7__*, router__*, playwright__*]
   # Default blocked tools (can be overridden by more specific layers)
   blocked: [native__write_file, native__edit_file]
   # Never overridable - always blocked

--- a/docs/EXPERIMENT_TEST_COVERAGE.md
+++ b/docs/EXPERIMENT_TEST_COVERAGE.md
@@ -1,0 +1,146 @@
+# Experiment Subsystem — Test Coverage
+
+**Scope:** the experiment (reader, writer) store and its MCP server.
+**Modules:** `lib/experiment_store.py`, `lib/experiment_server.py`
+**Tests:** `tests/test_experiment_store.py` (40), `tests/test_experiment_server.py` (15), `tests/test_experiment_wiring.py` (2) — 57 total.
+**Measured:** 2026-08-14, branch `feat/experiment-writer-contract`, coverage.py 7.15 (`--branch`).
+
+---
+
+## Headline numbers
+
+Branch coverage of the two modules under the experiment test files:
+
+| Module | Stmts | Miss | Branch | BrPart | Cover |
+|---|---:|---:|---:|---:|---:|
+| `lib/experiment_store.py`  | 215 |  5 | 40 | 5 | **96%** |
+| `lib/experiment_server.py` |  96 | 30 | 36 | 2 | **65%** |
+| **Total** | 311 | 35 | 76 | 7 | **86%** |
+
+The two percentages must be read, not taken at face value — see below. The
+`store` number is a true 96%; the `server` number is dragged down entirely by
+the stdio transport loop, which the unit tests bypass by design. On the
+**dispatch/routing logic** the server is effectively 100%.
+
+---
+
+## How to reproduce
+
+`coverage` is not in the daemon's Python (PEP 668 externally-managed). Use a
+throwaway venv that inherits the system `pytest`/`pyyaml`:
+
+```sh
+python3 -m venv --system-site-packages /tmp/covenv
+/tmp/covenv/bin/pip install coverage
+cd <plugin-root>
+/tmp/covenv/bin/python -m coverage run --branch -m pytest \
+  tests/test_experiment_store.py tests/test_experiment_server.py -q
+/tmp/covenv/bin/python -m coverage report -m \
+  --include="*/lib/experiment_store.py,*/lib/experiment_server.py"
+```
+
+`--include` (not `--source`) is required: the tests import `experiment_store`
+as a top-level module via a `sys.path` shim, so `--source` by file path finds
+no data.
+
+---
+
+## What is covered
+
+Behavior-first — the tests assert outcomes on real filesystems and through the
+real dispatch path, not internal state or mocks.
+
+**Store (`experiment_store.py`):**
+- Run lifecycle: `start_run` → `record_observation` → `end_run`, with outcome +
+  metrics round-tripping through `run.json`.
+- Durability across fresh instances (write via one store, read via another).
+- Sequential observation numbering; per-experiment run scoping.
+- YAML-frontmatter observation (de)serialization incl. multi-paragraph prose.
+- Presence-gated memory mirroring: mirrors when the sink is available, skips
+  when unavailable/`None`, and — the load-bearing guarantee — **a raising sink
+  never breaks or prevents the authoritative base write.**
+- Tenancy guard `validate_experiment_name`: rejects `..`, `/`, `\`, leading-dot,
+  and empty/whitespace names at every entry point (`start_run`, `list_runs`,
+  `VaultExperimentStore.__init__`).
+- `MemoryPluginSink.record()` real subprocess integration: correct argv + body
+  on stdin, `RuntimeError` on non-zero exit, and the `VAULT_DIR → MEMORY_VAULT_DIR`
+  env bridge reaching the child process.
+- Backend-selection factory (`make_experiment_backend`) and writer wrapping
+  (`open_experiment_writer`), with/without memory.
+
+**Server (`experiment_server.py`):**
+- `handle_call` dispatch for all six tools (`start_run`, `record_observation`,
+  `end_run`, `list_runs`, `get_run`, `observations`).
+- Per-project routing to distinct vault subtrees; `stores_for` cache identity
+  (same project → same store; different projects → distinct stores).
+- `store_from_env` backend/project resolution; default-project fallback.
+- Error contract `(text, is_error)`: unknown tool, missing run, invalid
+  (traversal) experiment name, and missing required arg all return an error
+  tuple rather than raising.
+
+**Wiring (`test_experiment_wiring.py`):**
+- `backends.json` registers the `experiment` backend with `tool_prefix`
+  `experiment` and the correct server command (real JSON parse).
+- `permissions.yaml` `global.allowed` grants `experiment__*` (real YAML parse,
+  exact-string membership — catches the `experiment_*` single-underscore typo).
+
+---
+
+## What is NOT covered (and why)
+
+### Store — the 5 uncovered lines are all deferred error paths
+
+| Line | Code | Backlog |
+|---|---|---|
+| `201` | `record_observation` on a nonexistent run → `KeyError` | MEDIUM |
+| `251` | `_split_run_id` malformed run_id → `KeyError` | MEDIUM |
+| `234` | `observations()` returns `[]` for a missing journal dir | LOW |
+| `153` | `_parse_observation` on a frontmatter-less (corrupt) file | LOW |
+| `421` | `make_experiment_backend` vault-dir-missing → `ValueError` | LOW |
+
+Every one is a defensive raise, and they line up exactly with the MEDIUM/LOW
+backlog (see `<vault>/10-projects/agent-swarm/open-recommendations.md`).
+Coverage independently confirms the triage: **nothing load-bearing is dark.**
+
+### Server — the 35% miss is transport + boilerplate, not logic
+
+Uncovered: `23` (the `sys.path` shim), `197–236` (the `run_server()` stdio
+JSON-RPC loop), `241` (`__main__` guard). The branch/routing logic
+(`handle_call`, `store_from_env`, `ExperimentServer`, serialization, `TOOLS`)
+has **zero uncovered statements**.
+
+`run_server()` is the one genuinely CI-untested piece. It is currently
+exercised only by the manual live-verify step (spawn the router backend after a
+daemon restart and call `mcp__router__experiment__*`). A subprocess smoke test —
+spawn the server on stdio, send `initialize` / `tools/call`, assert the framed
+response — would close it and mirror `workflow_server.py`. Tracked as a
+follow-up, not one of the three hardening gaps below.
+
+---
+
+## Provenance
+
+An adversarial test-quality review (2026-08-14) found three HIGH-risk gaps in
+the first cut of these suites; all three were closed with regression-locking
+tests, which is what lifts store coverage to 96% and server-logic coverage to
+~100%:
+
+1. `validate_experiment_name` path-traversal guard — was 0% (deletable without
+   turning the suite red); now fully exercised. It passed on first run, so the
+   guard was already wired and enforcing — the hole was in the *tests*, not the
+   code.
+2. `MemoryPluginSink.record()` subprocess integration — was 0%; now covers the
+   invocation, the non-zero-exit `RuntimeError`, and the env bridge.
+3. `experiment_list_runs` dispatch + the server error branches — the tool was
+   never routed through `handle_call`; now round-trips, and both error branches
+   are covered.
+
+---
+
+## Caveat
+
+These are **line/branch** coverage numbers — "executed," not "meaningfully
+asserted." The value of the suite is that it asserts *outcomes* on the paths
+that matter (traversal actually rejected, subprocess failure actually
+propagated, projects actually land in distinct subtrees), not merely that the
+lines ran. Treat the percentage as a floor on what is checked, not a ceiling.

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -25,3 +25,13 @@ The daemon is a long-lived process (port 7523) that owns all of agent-swarm's st
 - `call_tool(name, arguments)` — generic `tools/call`. Most agent work goes through here. Requires registration (the `_call` whitelist allows `agent/*` and `workflow/*` without registration).
 - `workflow_start`, `workflow_stop`, `workflow_get_state`, `workflow_set_value`, `workflow_is_active`, `workflow_advance_phase`, `workflow_pass_checkpoint` — workflow-state RPCs (no registration required).
 - `_call("agent/get_state", {agent_id})` — raw RPC; used by the registration-enforcement hook to verify a fabricated ID was actually issued.
+
+## MCP backends (`config/backends.json`)
+
+The router mounts each backend listed in `config/backends.json` as `mcp__router__<tool_prefix>__*`. `lib/backends.py: _INTERNAL_BACKENDS = {"native", "workflow"}` are handled in-process by the Controller; **every other entry is spawned as a subprocess stdio server** (serena/context7/playwright, and `experiment`). A plugin-owned server mirrors `lib/workflow_server.py`'s plain JSON-RPC loop (`initialize` / `tools/list` / `tools/call`, a `TOOLS` list, `make_result`/`make_error`).
+
+**Adding a backend needs THREE things, and missing the 2nd fails silently:** (1) a `backends.json` entry; (2) a `<prefix>__*` grant in `config/permissions.yaml` `global.allowed` — the permission checker is allowlist/default-deny, so without it the tools are *listed but every call is denied*; (3) a daemon restart (no hot-reload). See memory `agent-swarm-new-mcp-backend-needs-backends-json-and-permissions-grant`.
+
+## experiment (reader, writer) store
+
+`lib/experiment_store.py` + `lib/experiment_server.py` are experiment's instance of the constellation (reader, writer) contract: `ExperimentReader`/`ExperimentWriter` over config-selected backends (LocalFs | Vault-canonical), with `MemoryMirrorWriter` additively mirroring observations into a *registered* memory plugin (presence-gated; memory stays optional). The existing `experiment_harness.Journal` + workflow are **not** migrated onto it yet (deferred). Decision: `<vault>/10-projects/agent-swarm/decisions/2026-08-13-experiment-reader-writer-contract-adoption.md`.

--- a/lib/experiment_server.py
+++ b/lib/experiment_server.py
@@ -6,8 +6,10 @@ it as the ``experiment`` backend (tool_prefix ``experiment`` in
 config/backends.json), alongside ``workflow`` and ``native``. Mirrors
 workflow_server.py's plain JSON-RPC stdio loop.
 
-Storage backend is resolved from the environment (vault canonical default;
-local filesystem alternative). A registered memory plugin is used additively
+A single server multiplexes projects: the optional ``project`` argument on each
+call selects the vault subtree (``<vault>/10-projects/<project>/experiments/``);
+omitted, it falls back to ``EXPERIMENT_PROJECT``. The local backend is
+single-root and ignores project. A registered memory plugin is used additively
 via presence-gated mirroring — memory stays optional.
 """
 
@@ -28,21 +30,19 @@ from experiment_store import (  # noqa: E402
 )
 
 _OBS_FIELDS = ("title", "hypothesis", "changes", "result", "diagnosis", "next_direction")
+_DEFAULT_PROJECT = "agent-swarm"
 
 
 # ---------------------------------------------------------------------------
-# Backend resolution
+# Backend resolution + per-project routing
 # ---------------------------------------------------------------------------
 
-def store_from_env(env=None):
+def store_from_env(env=None, project=None):
     """Build the base store from environment configuration.
 
     ``EXPERIMENT_STORE_BACKEND`` selects vault (default) or local. Vault dir
     resolves from EXPERIMENT_VAULT_DIR / VAULT_DIR / MEMORY_VAULT_DIR; the
-    project from EXPERIMENT_PROJECT (default ``agent-swarm``).
-
-    NOTE (open, per design doc): a single server instance currently serves one
-    project subtree. Multi-project routing is a "change with practice" follow-up.
+    project from the ``project`` argument, else EXPERIMENT_PROJECT.
     """
     env = env if env is not None else os.environ
     backend = env.get("EXPERIMENT_STORE_BACKEND", "vault")
@@ -52,8 +52,29 @@ def store_from_env(env=None):
         "vault",
         vault_dir=(env.get("EXPERIMENT_VAULT_DIR") or env.get("VAULT_DIR")
                    or env.get("MEMORY_VAULT_DIR")),
-        project=env.get("EXPERIMENT_PROJECT", "agent-swarm"),
+        project=project or env.get("EXPERIMENT_PROJECT", _DEFAULT_PROJECT),
     )
+
+
+class ExperimentServer:
+    """Routes experiment tool calls to per-project (reader, writer) stores.
+
+    ``stores_for(project)`` returns a cached ``(reader, writer)`` pair for the
+    project's subtree; the writer wraps the base store with presence-gated
+    memory mirroring. The local backend is single-root, so all projects share
+    one store there.
+    """
+
+    def __init__(self, env=None):
+        self.env = env if env is not None else os.environ
+        self._cache: dict[str, tuple] = {}
+
+    def stores_for(self, project=None):
+        key = project or self.env.get("EXPERIMENT_PROJECT", _DEFAULT_PROJECT)
+        if key not in self._cache:
+            base = store_from_env(self.env, project=key)
+            self._cache[key] = (base, open_experiment_writer(base))
+        return self._cache[key]
 
 
 # ---------------------------------------------------------------------------
@@ -88,10 +109,11 @@ def _observation_from_args(payload: dict) -> Observation:
 # Dispatch (transport-independent, unit-testable)
 # ---------------------------------------------------------------------------
 
-def handle_call(reader, writer, name: str, args: dict) -> tuple[str, bool]:
-    """Execute one tool call. Returns (text, is_error)."""
+def handle_call(server: ExperimentServer, name: str, args: dict) -> tuple[str, bool]:
+    """Execute one tool call, routing by args['project']. Returns (text, is_error)."""
     args = args or {}
     try:
+        reader, writer = server.stores_for(args.get("project"))
         if name == "experiment_start_run":
             run_id = writer.start_run(args["experiment"], args.get("goal", ""))
             return json.dumps({"run_id": run_id}), False
@@ -119,77 +141,50 @@ def handle_call(reader, writer, name: str, args: dict) -> tuple[str, bool]:
 # MCP tool definitions
 # ---------------------------------------------------------------------------
 
+_PROJECT_PROP = {
+    "project": {
+        "type": "string",
+        "description": "Vault project subtree (optional; defaults to EXPERIMENT_PROJECT).",
+    }
+}
 _OBSERVATION_SCHEMA = {
     "type": "object",
     "properties": {f: {"type": "string"} for f in _OBS_FIELDS},
     "description": "Observation fields (title required; rest optional prose).",
 }
 
+
+def _tool(name, description, properties, required):
+    return {
+        "name": name,
+        "description": description,
+        "inputSchema": {
+            "type": "object",
+            "properties": {**properties, **_PROJECT_PROP},
+            "required": required,
+        },
+    }
+
+
 TOOLS = [
-    {
-        "name": "experiment_start_run",
-        "description": "Begin an experiment run; returns its run_id.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "experiment": {"type": "string", "description": "Experiment name"},
-                "goal": {"type": "string", "description": "Run objective"},
-            },
-            "required": ["experiment"],
-        },
-    },
-    {
-        "name": "experiment_record_observation",
-        "description": "Append an observation (journal attempt) to a run.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "run_id": {"type": "string"},
-                "observation": _OBSERVATION_SCHEMA,
-            },
-            "required": ["run_id", "observation"],
-        },
-    },
-    {
-        "name": "experiment_end_run",
-        "description": "Finalize a run with an outcome and metrics.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "run_id": {"type": "string"},
-                "outcome": {"type": "string"},
-                "metrics": {"type": "object"},
-            },
-            "required": ["run_id", "outcome"],
-        },
-    },
-    {
-        "name": "experiment_list_runs",
-        "description": "List all runs for an experiment.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {"experiment": {"type": "string"}},
-            "required": ["experiment"],
-        },
-    },
-    {
-        "name": "experiment_get_run",
-        "description": "Get one run by run_id.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {"run_id": {"type": "string"}},
-            "required": ["run_id"],
-        },
-    },
-    {
-        "name": "experiment_observations",
-        "description": "List a run's observations in order.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {"run_id": {"type": "string"}},
-            "required": ["run_id"],
-        },
-    },
+    _tool("experiment_start_run", "Begin an experiment run; returns its run_id.",
+          {"experiment": {"type": "string", "description": "Experiment name"},
+           "goal": {"type": "string", "description": "Run objective"}},
+          ["experiment"]),
+    _tool("experiment_record_observation",
+          "Append an observation (journal attempt) to a run.",
+          {"run_id": {"type": "string"}, "observation": _OBSERVATION_SCHEMA},
+          ["run_id", "observation"]),
+    _tool("experiment_end_run", "Finalize a run with an outcome and metrics.",
+          {"run_id": {"type": "string"}, "outcome": {"type": "string"},
+           "metrics": {"type": "object"}},
+          ["run_id", "outcome"]),
+    _tool("experiment_list_runs", "List all runs for an experiment.",
+          {"experiment": {"type": "string"}}, ["experiment"]),
+    _tool("experiment_get_run", "Get one run by run_id.",
+          {"run_id": {"type": "string"}}, ["run_id"]),
+    _tool("experiment_observations", "List a run's observations in order.",
+          {"run_id": {"type": "string"}}, ["run_id"]),
 ]
 
 
@@ -199,8 +194,7 @@ TOOLS = [
 
 def run_server():
     """Run the MCP server loop on stdio."""
-    store = store_from_env()
-    writer = open_experiment_writer(store)
+    server = ExperimentServer()
 
     def send(msg: dict) -> None:
         print(json.dumps(msg), flush=True)
@@ -225,7 +219,7 @@ def run_server():
                 result = {"tools": TOOLS}
             elif method == "tools/call":
                 text, is_error = handle_call(
-                    store, writer, params.get("name", ""), params.get("arguments", {}))
+                    server, params.get("name", ""), params.get("arguments", {}))
                 result = {"content": [{"type": "text", "text": text}]}
                 if is_error:
                     result["isError"] = True

--- a/lib/experiment_server.py
+++ b/lib/experiment_server.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Experiment (reader, writer) MCP Server.
+
+Exposes experiment's reader/writer contract over stdio so the router can mount
+it as the ``experiment`` backend (tool_prefix ``experiment`` in
+config/backends.json), alongside ``workflow`` and ``native``. Mirrors
+workflow_server.py's plain JSON-RPC stdio loop.
+
+Storage backend is resolved from the environment (vault canonical default;
+local filesystem alternative). A registered memory plugin is used additively
+via presence-gated mirroring — memory stays optional.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+lib_dir = Path(__file__).parent
+if str(lib_dir) not in sys.path:
+    sys.path.insert(0, str(lib_dir))
+
+from experiment_store import (  # noqa: E402
+    Observation,
+    Run,
+    make_experiment_backend,
+    open_experiment_writer,
+)
+
+_OBS_FIELDS = ("title", "hypothesis", "changes", "result", "diagnosis", "next_direction")
+
+
+# ---------------------------------------------------------------------------
+# Backend resolution
+# ---------------------------------------------------------------------------
+
+def store_from_env(env=None):
+    """Build the base store from environment configuration.
+
+    ``EXPERIMENT_STORE_BACKEND`` selects vault (default) or local. Vault dir
+    resolves from EXPERIMENT_VAULT_DIR / VAULT_DIR / MEMORY_VAULT_DIR; the
+    project from EXPERIMENT_PROJECT (default ``agent-swarm``).
+
+    NOTE (open, per design doc): a single server instance currently serves one
+    project subtree. Multi-project routing is a "change with practice" follow-up.
+    """
+    env = env if env is not None else os.environ
+    backend = env.get("EXPERIMENT_STORE_BACKEND", "vault")
+    if backend == "local":
+        return make_experiment_backend("local", root=env.get("EXPERIMENT_STORE_ROOT"))
+    return make_experiment_backend(
+        "vault",
+        vault_dir=(env.get("EXPERIMENT_VAULT_DIR") or env.get("VAULT_DIR")
+                   or env.get("MEMORY_VAULT_DIR")),
+        project=env.get("EXPERIMENT_PROJECT", "agent-swarm"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+def _run_dict(run: Run) -> dict:
+    return {
+        "run_id": run.run_id,
+        "experiment": run.experiment,
+        "goal": run.goal,
+        "started_at": run.started_at,
+        "ended_at": run.ended_at,
+        "outcome": run.outcome,
+        "metrics": run.metrics,
+    }
+
+
+def _obs_dict(obs: Observation) -> dict:
+    d = {"run_id": obs.run_id, "number": obs.number}
+    for f in _OBS_FIELDS:
+        d[f] = getattr(obs, f)
+    return d
+
+
+def _observation_from_args(payload: dict) -> Observation:
+    payload = payload or {}
+    return Observation(**{f: payload.get(f, "") for f in _OBS_FIELDS})
+
+
+# ---------------------------------------------------------------------------
+# Dispatch (transport-independent, unit-testable)
+# ---------------------------------------------------------------------------
+
+def handle_call(reader, writer, name: str, args: dict) -> tuple[str, bool]:
+    """Execute one tool call. Returns (text, is_error)."""
+    args = args or {}
+    try:
+        if name == "experiment_start_run":
+            run_id = writer.start_run(args["experiment"], args.get("goal", ""))
+            return json.dumps({"run_id": run_id}), False
+        if name == "experiment_record_observation":
+            obs_id = writer.record_observation(
+                args["run_id"], _observation_from_args(args.get("observation")))
+            return json.dumps({"observation_id": obs_id}), False
+        if name == "experiment_end_run":
+            writer.end_run(args["run_id"], args.get("outcome", ""), args.get("metrics", {}))
+            return json.dumps({"success": True}), False
+        if name == "experiment_list_runs":
+            return json.dumps([_run_dict(r) for r in reader.list_runs(args["experiment"])]), False
+        if name == "experiment_get_run":
+            return json.dumps(_run_dict(reader.get_run(args["run_id"]))), False
+        if name == "experiment_observations":
+            return json.dumps([_obs_dict(o) for o in reader.observations(args["run_id"])]), False
+        return f"Unknown tool: {name}", True
+    except KeyError as e:
+        return f"Missing or unknown key: {e}", True
+    except (ValueError, RuntimeError) as e:
+        return str(e), True
+
+
+# ---------------------------------------------------------------------------
+# MCP tool definitions
+# ---------------------------------------------------------------------------
+
+_OBSERVATION_SCHEMA = {
+    "type": "object",
+    "properties": {f: {"type": "string"} for f in _OBS_FIELDS},
+    "description": "Observation fields (title required; rest optional prose).",
+}
+
+TOOLS = [
+    {
+        "name": "experiment_start_run",
+        "description": "Begin an experiment run; returns its run_id.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "experiment": {"type": "string", "description": "Experiment name"},
+                "goal": {"type": "string", "description": "Run objective"},
+            },
+            "required": ["experiment"],
+        },
+    },
+    {
+        "name": "experiment_record_observation",
+        "description": "Append an observation (journal attempt) to a run.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string"},
+                "observation": _OBSERVATION_SCHEMA,
+            },
+            "required": ["run_id", "observation"],
+        },
+    },
+    {
+        "name": "experiment_end_run",
+        "description": "Finalize a run with an outcome and metrics.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string"},
+                "outcome": {"type": "string"},
+                "metrics": {"type": "object"},
+            },
+            "required": ["run_id", "outcome"],
+        },
+    },
+    {
+        "name": "experiment_list_runs",
+        "description": "List all runs for an experiment.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"experiment": {"type": "string"}},
+            "required": ["experiment"],
+        },
+    },
+    {
+        "name": "experiment_get_run",
+        "description": "Get one run by run_id.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"run_id": {"type": "string"}},
+            "required": ["run_id"],
+        },
+    },
+    {
+        "name": "experiment_observations",
+        "description": "List a run's observations in order.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"run_id": {"type": "string"}},
+            "required": ["run_id"],
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# MCP server loop (mirrors workflow_server.py)
+# ---------------------------------------------------------------------------
+
+def run_server():
+    """Run the MCP server loop on stdio."""
+    store = store_from_env()
+    writer = open_experiment_writer(store)
+
+    def send(msg: dict) -> None:
+        print(json.dumps(msg), flush=True)
+
+    for line in sys.stdin:
+        request_id = None
+        try:
+            request = json.loads(line.strip())
+            method = request.get("method", "")
+            params = request.get("params", {})
+            request_id = request.get("id")
+
+            if method == "initialize":
+                result = {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "experiment-server", "version": "1.0.0"},
+                }
+            elif method == "notifications/initialized":
+                continue
+            elif method == "tools/list":
+                result = {"tools": TOOLS}
+            elif method == "tools/call":
+                text, is_error = handle_call(
+                    store, writer, params.get("name", ""), params.get("arguments", {}))
+                result = {"content": [{"type": "text", "text": text}]}
+                if is_error:
+                    result["isError"] = True
+            else:
+                result = {"error": f"Unknown method: {method}"}
+
+            if request_id is not None:
+                send({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+        except json.JSONDecodeError as e:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32700, "message": f"Parse error: {e}"}})
+        except Exception as e:  # noqa: BLE001
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32603, "message": str(e)}})
+
+
+if __name__ == "__main__":
+    run_server()

--- a/lib/experiment_store.py
+++ b/lib/experiment_store.py
@@ -19,7 +19,7 @@ import os
 import re
 import subprocess
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -295,6 +295,19 @@ class LocalFsExperimentStore(ExperimentWriter, ExperimentReader):
 # Presence-gated memory mirroring (the "use memory if registered" coupling)
 # ---------------------------------------------------------------------------
 
+def _mirror_identity(observation: Observation, run_id: str, obs_id: str) -> Observation:
+    """Return a copy of ``observation`` carrying the identity the base writer
+    assigned: the run_id, and the sequence number parsed from ``obs_id``
+    (format ``<run_id>#<NNN>``). Mirror sinks serialize identity off the object,
+    so without this the mirrored doc records run_id='' and number 0 instead of
+    the authoritative values. A copy (not in-place) keeps the caller's object
+    untouched.
+    """
+    trailing = obs_id.rpartition("#")[2]
+    number = int(trailing) if trailing.isdigit() else observation.number
+    return replace(observation, run_id=run_id, number=number)
+
+
 class MemoryMirrorWriter(ExperimentWriter):
     """Wrap a base writer and, when a memory sink is present and available,
     additively mirror each recorded observation into memory's own store.
@@ -319,7 +332,8 @@ class MemoryMirrorWriter(ExperimentWriter):
             try:
                 if self.sink.available():
                     experiment = run_id.rpartition("/")[0]
-                    self.sink.record(experiment, obs_id, observation)
+                    self.sink.record(experiment, obs_id,
+                                     _mirror_identity(observation, run_id, obs_id))
             except Exception:  # best-effort: never break the authoritative write
                 logger.warning("experiment: memory mirror failed for %s", obs_id,
                                exc_info=True)

--- a/lib/experiment_store.py
+++ b/lib/experiment_store.py
@@ -1,0 +1,435 @@
+"""Experiment (reader, writer) store — the experiment plugin's instance of the
+cross-plugin (reader, writer) contract (2026-05-08 architecture).
+
+experiment exposes an ``experiment_reader`` + ``experiment_writer`` pair. The
+storage backend is a configuration choice (local filesystem here; a vault
+project subtree lands alongside); a registered memory plugin is used
+*additively*, never as a hard dependency.
+
+Tenancy: this writer only ever touches experiment's own subtree. Files are
+canonical and inspectable on disk — a fresh store instance reads back exactly
+what a prior one wrote.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_RUN_RE = re.compile(r"run-(\d+)$")
+_FRONT_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+_OBS_FIELDS = ("title", "hypothesis", "changes", "result", "diagnosis", "next_direction")
+
+_OBS_BODY = """# {title}
+
+**Attempt:** {number}
+**Hypothesis:** {hypothesis}
+
+## Changes
+{changes}
+
+## Result
+{result}
+
+## Diagnosis
+{diagnosis}
+
+## Next Direction
+{next_direction}
+"""
+
+
+def _now_iso() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def validate_experiment_name(name: str) -> str:
+    """Reject names that would escape the experiment's own subtree."""
+    if not name or not name.strip():
+        raise ValueError("experiment name is required")
+    if "/" in name or "\\" in name or name in (".", "..") or name.startswith("."):
+        raise ValueError(f"invalid experiment name: {name!r}")
+    return name
+
+
+def _slug(title: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
+    return (s or "observation")[:40]
+
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Observation:
+    """A single experiment observation (one journal attempt)."""
+    title: str
+    hypothesis: str = ""
+    changes: str = ""
+    result: str = ""
+    diagnosis: str = ""
+    next_direction: str = ""
+    run_id: Optional[str] = None   # assigned by the writer
+    number: Optional[int] = None   # assigned by the writer
+
+
+@dataclass
+class Run:
+    """An experiment run: a bounded attempt sequence with an outcome."""
+    run_id: str
+    experiment: str
+    goal: str = ""
+    started_at: str = ""
+    ended_at: Optional[str] = None
+    outcome: Optional[str] = None
+    metrics: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# The contract
+# ---------------------------------------------------------------------------
+
+class ExperimentWriter(ABC):
+    """Write surface. Producers (workflow, hooks, other plugins) call these."""
+
+    @abstractmethod
+    def start_run(self, experiment: str, goal: str) -> str:
+        """Begin a run; return its run_id."""
+
+    @abstractmethod
+    def record_observation(self, run_id: str, observation: Observation) -> str:
+        """Append an observation to a run; return its observation id."""
+
+    @abstractmethod
+    def end_run(self, run_id: str, outcome: str, metrics: dict) -> None:
+        """Finalize a run with an outcome and metrics."""
+
+
+class ExperimentReader(ABC):
+    """Read surface. Consumed by the workflow and sibling plugins."""
+
+    @abstractmethod
+    def list_runs(self, experiment: str) -> list[Run]:
+        """All runs for an experiment, oldest first."""
+
+    @abstractmethod
+    def get_run(self, run_id: str) -> Run:
+        """One run by id. Raises KeyError if absent."""
+
+    @abstractmethod
+    def observations(self, run_id: str) -> list[Observation]:
+        """A run's observations, in order."""
+
+
+# ---------------------------------------------------------------------------
+# Observation (de)serialization — frontmatter is canonical, body is human view
+# ---------------------------------------------------------------------------
+
+def _render_observation(obs: Observation, number: int, run_id: str) -> str:
+    front = {"run_id": run_id, "number": number, "created_at": _now_iso()}
+    for f in _OBS_FIELDS:
+        front[f] = getattr(obs, f)
+    body = _OBS_BODY.format(number=number, **{k: getattr(obs, k) for k in _OBS_FIELDS})
+    dumped = yaml.safe_dump(front, sort_keys=False, allow_unicode=True)
+    return f"---\n{dumped}---\n\n{body}"
+
+
+def _parse_observation(text: str) -> Observation:
+    m = _FRONT_RE.match(text)
+    if not m:
+        raise ValueError("observation file missing frontmatter")
+    front = yaml.safe_load(m.group(1)) or {}
+    return Observation(
+        title=front.get("title", ""),
+        hypothesis=front.get("hypothesis", ""),
+        changes=front.get("changes", ""),
+        result=front.get("result", ""),
+        diagnosis=front.get("diagnosis", ""),
+        next_direction=front.get("next_direction", ""),
+        run_id=front.get("run_id"),
+        number=front.get("number"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Local filesystem backend
+# ---------------------------------------------------------------------------
+
+class LocalFsExperimentStore(ExperimentWriter, ExperimentReader):
+    """Filesystem-backed store rooted at an experiments parent directory.
+
+    Layout::
+
+        <root>/<experiment>/runs/run-<NNN>/run.json
+        <root>/<experiment>/runs/run-<NNN>/journal/<NNN>_<slug>.md
+
+    run_id is ``"<experiment>/run-<NNN>"`` so a run is self-locating from its id.
+    """
+
+    def __init__(self, root: Path | str):
+        self.root = Path(root)
+
+    # -- writer --------------------------------------------------------------
+
+    def start_run(self, experiment: str, goal: str) -> str:
+        runs_dir = self._runs_dir(experiment)
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        run_name = f"run-{self._next_run_number(runs_dir):03d}"
+        run_id = f"{experiment}/{run_name}"
+        run_dir = runs_dir / run_name
+        (run_dir / "journal").mkdir(parents=True, exist_ok=True)
+        self._write_run(run_dir, Run(run_id=run_id, experiment=experiment,
+                                     goal=goal, started_at=_now_iso()))
+        return run_id
+
+    def record_observation(self, run_id: str, observation: Observation) -> str:
+        run_dir = self._run_dir(run_id)
+        if not (run_dir / "run.json").exists():
+            raise KeyError(f"no such run: {run_id!r}")
+        journal = run_dir / "journal"
+        journal.mkdir(parents=True, exist_ok=True)
+        number = self._next_obs_number(journal)
+        path = journal / f"{number:03d}_{_slug(observation.title)}.md"
+        path.write_text(_render_observation(observation, number, run_id))
+        return f"{run_id}#{number:03d}"
+
+    def end_run(self, run_id: str, outcome: str, metrics: dict) -> None:
+        run = self.get_run(run_id)
+        run.outcome = outcome
+        run.metrics = dict(metrics or {})
+        run.ended_at = _now_iso()
+        self._write_run(self._run_dir(run_id), run)
+
+    # -- reader --------------------------------------------------------------
+
+    def list_runs(self, experiment: str) -> list[Run]:
+        runs_dir = self._runs_dir(experiment)
+        if not runs_dir.exists():
+            return []
+        return [self._read_run(d) for d in sorted(runs_dir.iterdir())
+                if d.is_dir() and _RUN_RE.match(d.name) and (d / "run.json").exists()]
+
+    def get_run(self, run_id: str) -> Run:
+        run_dir = self._run_dir(run_id)
+        if not (run_dir / "run.json").exists():
+            raise KeyError(f"no such run: {run_id!r}")
+        return self._read_run(run_dir)
+
+    def observations(self, run_id: str) -> list[Observation]:
+        journal = self._run_dir(run_id) / "journal"
+        if not journal.exists():
+            return []
+        return [_parse_observation(p.read_text()) for p in sorted(journal.glob("*.md"))]
+
+    # -- paths / helpers -----------------------------------------------------
+
+    def _runs_dir(self, experiment: str) -> Path:
+        validate_experiment_name(experiment)
+        return self.root / experiment / "runs"
+
+    def _run_dir(self, run_id: str) -> Path:
+        experiment, run_name = self._split_run_id(run_id)
+        return self.root / experiment / "runs" / run_name
+
+    @staticmethod
+    def _split_run_id(run_id: str) -> tuple[str, str]:
+        experiment, _, run_name = run_id.rpartition("/")
+        if not experiment or not _RUN_RE.match(run_name):
+            raise KeyError(f"malformed run_id: {run_id!r}")
+        validate_experiment_name(experiment)
+        return experiment, run_name
+
+    @staticmethod
+    def _next_run_number(runs_dir: Path) -> int:
+        nums = [int(m.group(1)) for d in runs_dir.iterdir()
+                if d.is_dir() and (m := _RUN_RE.match(d.name))]
+        return max(nums, default=0) + 1
+
+    @staticmethod
+    def _next_obs_number(journal: Path) -> int:
+        nums = [int(p.name.split("_", 1)[0]) for p in journal.glob("*.md")
+                if p.name.split("_", 1)[0].isdigit()]
+        return max(nums, default=0) + 1
+
+    @staticmethod
+    def _write_run(run_dir: Path, run: Run) -> None:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run.json").write_text(json.dumps({
+            "run_id": run.run_id,
+            "experiment": run.experiment,
+            "goal": run.goal,
+            "started_at": run.started_at,
+            "ended_at": run.ended_at,
+            "outcome": run.outcome,
+            "metrics": run.metrics,
+        }, indent=2))
+
+    @staticmethod
+    def _read_run(run_dir: Path) -> Run:
+        data = json.loads((run_dir / "run.json").read_text())
+        return Run(
+            run_id=data["run_id"],
+            experiment=data["experiment"],
+            goal=data.get("goal", ""),
+            started_at=data.get("started_at", ""),
+            ended_at=data.get("ended_at"),
+            outcome=data.get("outcome"),
+            metrics=data.get("metrics", {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Presence-gated memory mirroring (the "use memory if registered" coupling)
+# ---------------------------------------------------------------------------
+
+class MemoryMirrorWriter(ExperimentWriter):
+    """Wrap a base writer and, when a memory sink is present and available,
+    additively mirror each recorded observation into memory's own store.
+
+    The base write is authoritative; memory mirroring is best-effort — a sink
+    that is unavailable or errors never breaks the experiment's own record.
+    This is the whole "use memory iff a memory plugin is registered" coupling:
+    pass ``sink=None`` (or an unavailable sink) and this is a pure pass-through,
+    so experiment lives without memory.
+    """
+
+    def __init__(self, base: ExperimentWriter, sink=None):
+        self.base = base
+        self.sink = sink
+
+    def start_run(self, experiment: str, goal: str) -> str:
+        return self.base.start_run(experiment, goal)
+
+    def record_observation(self, run_id: str, observation: Observation) -> str:
+        obs_id = self.base.record_observation(run_id, observation)
+        if self.sink is not None:
+            try:
+                if self.sink.available():
+                    experiment = run_id.rpartition("/")[0]
+                    self.sink.record(experiment, obs_id, observation)
+            except Exception:  # best-effort: never break the authoritative write
+                logger.warning("experiment: memory mirror failed for %s", obs_id,
+                               exc_info=True)
+        return obs_id
+
+    def end_run(self, run_id: str, outcome: str, metrics: dict) -> None:
+        self.base.end_run(run_id, outcome, metrics)
+
+
+class MemoryPluginSink:
+    """Records experiment observations into the memory plugin's store via its
+    ``bin/memory write`` CLI — the same bridge continuity uses.
+
+    Presence-gated: ``available()`` is False when the memory CLI is not
+    installed, so callers treat memory as optional.
+    """
+
+    _DEFAULT_BIN = Path.home() / ".claude" / "plugins" / "memory" / "bin" / "memory"
+
+    def __init__(self, memory_bin=None, env=None, timeout_seconds: float = 10.0):
+        if memory_bin is None:
+            env_bin = os.environ.get("MEMORY_BIN")
+            memory_bin = Path(env_bin) if env_bin else self._DEFAULT_BIN
+        self.memory_bin = Path(memory_bin)
+        self.env = env
+        self.timeout_seconds = timeout_seconds
+
+    def available(self) -> bool:
+        return self.memory_bin.exists()
+
+    def record(self, experiment: str, obs_id: str, observation: Observation) -> None:
+        args = self._write_args(experiment, obs_id, observation)
+        body = self._render_body(obs_id, observation)
+        result = subprocess.run(
+            args, input=body, capture_output=True, text=True,
+            env=self._subprocess_env(), timeout=self.timeout_seconds,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise RuntimeError(f"memory write failed ({result.returncode}): {detail}")
+
+    def _write_args(self, experiment: str, obs_id: str, observation: Observation) -> list[str]:
+        name = re.sub(r"[^A-Za-z0-9._-]+", "-", obs_id).strip("-")
+        return [
+            str(self.memory_bin), "write",
+            "--type", "project",
+            "--name", name,
+            "--subject", experiment,
+            "--description", observation.title or obs_id,
+        ]
+
+    def _render_body(self, obs_id: str, observation: Observation) -> str:
+        return (
+            f"Source: experiment\nObservation: {obs_id}\n\n"
+            + _render_observation(observation, observation.number or 0,
+                                  observation.run_id or "")
+        )
+
+    def _subprocess_env(self) -> dict:
+        env = dict(os.environ if self.env is None else self.env)
+        if "MEMORY_VAULT_DIR" not in env:
+            vault = env.get("VAULT_DIR") or env.get("CONTINUITY_VAULT_DIR")
+            if vault:
+                env["MEMORY_VAULT_DIR"] = vault
+        return env
+
+
+# ---------------------------------------------------------------------------
+# Vault backend + selection
+# ---------------------------------------------------------------------------
+
+class VaultExperimentStore(LocalFsExperimentStore):
+    """Experiment store rooted at a vault project's experiments subtree:
+    ``<vault>/10-projects/<project>/experiments/``. The canonical default.
+    """
+
+    def __init__(self, vault_dir, project: str):
+        validate_experiment_name(project)
+        self.vault_dir = Path(vault_dir)
+        self.project = project
+        super().__init__(self.vault_dir / "10-projects" / project / "experiments")
+
+
+def make_experiment_backend(backend: str = "vault", *, root=None,
+                            vault_dir=None, project=None) -> LocalFsExperimentStore:
+    """Construct the base store (reader+writer) for the chosen backend.
+
+    Backend choice is configuration, not API — ``vault`` (canonical default)
+    or ``local``. Plurality lives here, at the implementation level.
+    """
+    if backend == "local":
+        if root is None:
+            raise ValueError("local backend requires root=")
+        return LocalFsExperimentStore(root)
+    if backend == "vault":
+        vault_dir = (vault_dir or os.environ.get("EXPERIMENT_VAULT_DIR")
+                     or os.environ.get("VAULT_DIR") or os.environ.get("MEMORY_VAULT_DIR"))
+        if not vault_dir:
+            raise ValueError(
+                "vault backend requires vault_dir (or EXPERIMENT_VAULT_DIR/VAULT_DIR)")
+        if not project:
+            raise ValueError("vault backend requires project=")
+        return VaultExperimentStore(vault_dir, project)
+    raise ValueError(f"unknown experiment backend: {backend!r}")
+
+
+def open_experiment_writer(store, *, memory: bool = True) -> ExperimentWriter:
+    """Wrap a base store's write surface with presence-gated memory mirroring.
+
+    memory=True attaches a MemoryPluginSink; if no memory plugin is installed
+    the sink reports unavailable and writes stay local — memory is optional.
+    """
+    return MemoryMirrorWriter(store, MemoryPluginSink() if memory else None)

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1,26 +1,27 @@
-"""Tests for the experiment MCP server's tool surface and dispatch.
+"""Tests for the experiment MCP server: tool surface, dispatch, and per-project
+routing.
 
-The stdio loop mirrors workflow_server.py; the dispatch is extracted into
-handle_call() so it can be exercised without the JSON-RPC transport.
+The stdio loop mirrors workflow_server.py; dispatch is extracted into
+handle_call(server, name, args) so it can be exercised without the transport.
+A single ExperimentServer multiplexes projects — the optional `project`
+argument selects the vault subtree; the local backend is single-root.
 """
 
 import json
 
 import pytest
 
-from experiment_store import LocalFsExperimentStore, open_experiment_writer
-from experiment_server import TOOLS, handle_call, store_from_env
-
+from experiment_store import LocalFsExperimentStore, VaultExperimentStore
+from experiment_server import TOOLS, ExperimentServer, handle_call, store_from_env
 
 _WRITER_TOOLS = {"experiment_start_run", "experiment_record_observation", "experiment_end_run"}
 _READER_TOOLS = {"experiment_list_runs", "experiment_get_run", "experiment_observations"}
 
 
 @pytest.fixture
-def rw(tmp_path):
-    store = LocalFsExperimentStore(tmp_path / "e")
-    writer = open_experiment_writer(store, memory=False)
-    return store, writer
+def local_server(tmp_path):
+    return ExperimentServer(env={"EXPERIMENT_STORE_BACKEND": "local",
+                                 "EXPERIMENT_STORE_ROOT": str(tmp_path / "e")})
 
 
 def test_tools_list_covers_reader_and_writer():
@@ -29,57 +30,98 @@ def test_tools_list_covers_reader_and_writer():
     assert _READER_TOOLS <= names
     for t in TOOLS:
         assert "inputSchema" in t and t["description"]
+        # every tool accepts optional project routing
+        assert "project" in t["inputSchema"]["properties"]
+        assert "project" not in t["inputSchema"].get("required", [])
 
 
-def test_start_record_observations_roundtrip(rw):
-    store, writer = rw
-    text, err = handle_call(store, writer, "experiment_start_run",
+def test_start_record_observations_roundtrip(local_server):
+    text, err = handle_call(local_server, "experiment_start_run",
                             {"experiment": "exp", "goal": "g"})
     assert not err
     run_id = json.loads(text)["run_id"]
 
-    _, err = handle_call(store, writer, "experiment_record_observation",
+    _, err = handle_call(local_server, "experiment_record_observation",
                          {"run_id": run_id, "observation": {"title": "t", "hypothesis": "h"}})
     assert not err
 
-    text, err = handle_call(store, writer, "experiment_observations", {"run_id": run_id})
+    text, err = handle_call(local_server, "experiment_observations", {"run_id": run_id})
     assert not err
     obs = json.loads(text)
     assert len(obs) == 1 and obs[0]["title"] == "t" and obs[0]["number"] == 1
 
 
-def test_end_run_and_get_run(rw):
-    store, writer = rw
-    run_id = json.loads(handle_call(store, writer, "experiment_start_run",
+def test_end_run_and_get_run(local_server):
+    run_id = json.loads(handle_call(local_server, "experiment_start_run",
                                     {"experiment": "exp", "goal": "g"})[0])["run_id"]
-    _, err = handle_call(store, writer, "experiment_end_run",
+    _, err = handle_call(local_server, "experiment_end_run",
                          {"run_id": run_id, "outcome": "success", "metrics": {"acc": 1.0}})
     assert not err
-    text, err = handle_call(store, writer, "experiment_get_run", {"run_id": run_id})
+    text, err = handle_call(local_server, "experiment_get_run", {"run_id": run_id})
     assert not err
     run = json.loads(text)
     assert run["outcome"] == "success" and run["metrics"]["acc"] == 1.0
 
 
-def test_get_run_missing_is_error(rw):
-    store, writer = rw
-    _, err = handle_call(store, writer, "experiment_get_run", {"run_id": "exp/run-999"})
+def test_get_run_missing_is_error(local_server):
+    _, err = handle_call(local_server, "experiment_get_run", {"run_id": "exp/run-999"})
     assert err
 
 
-def test_unknown_tool_is_error(rw):
-    store, writer = rw
-    _, err = handle_call(store, writer, "experiment_bogus", {})
+def test_unknown_tool_is_error(local_server):
+    _, err = handle_call(local_server, "experiment_bogus", {})
     assert err
 
 
 def test_store_from_env_local(tmp_path):
-    env = {"EXPERIMENT_STORE_BACKEND": "local",
-           "EXPERIMENT_STORE_ROOT": str(tmp_path / "e")}
+    env = {"EXPERIMENT_STORE_BACKEND": "local", "EXPERIMENT_STORE_ROOT": str(tmp_path / "e")}
     assert isinstance(store_from_env(env), LocalFsExperimentStore)
 
 
 def test_store_from_env_defaults_to_vault(tmp_path):
-    from experiment_store import VaultExperimentStore
     env = {"VAULT_DIR": str(tmp_path), "EXPERIMENT_PROJECT": "agent-swarm"}
     assert isinstance(store_from_env(env), VaultExperimentStore)
+
+
+def test_store_from_env_project_override(tmp_path):
+    env = {"VAULT_DIR": str(tmp_path), "EXPERIMENT_PROJECT": "default-proj"}
+    store = store_from_env(env, project="other-proj")
+    assert store.project == "other-proj"
+
+
+# -- per-project routing -----------------------------------------------------
+
+def test_server_routes_by_project_to_distinct_subtrees(tmp_path):
+    vault = tmp_path / "vault"
+    server = ExperimentServer(env={"EXPERIMENT_STORE_BACKEND": "vault",
+                                   "VAULT_DIR": str(vault)})
+    ra = json.loads(handle_call(server, "experiment_start_run",
+                                {"experiment": "e", "goal": "g", "project": "proj-a"})[0])["run_id"]
+    handle_call(server, "experiment_start_run",
+                {"experiment": "e", "goal": "g", "project": "proj-b"})
+    assert (vault / "10-projects" / "proj-a" / "experiments" / "e" / "runs").exists()
+    assert (vault / "10-projects" / "proj-b" / "experiments" / "e" / "runs").exists()
+
+    # reads route by project too
+    _, err = handle_call(server, "experiment_record_observation",
+                         {"run_id": ra, "observation": {"title": "a"}, "project": "proj-a"})
+    assert not err
+    obs = json.loads(handle_call(server, "experiment_observations",
+                                 {"run_id": ra, "project": "proj-a"})[0])
+    assert len(obs) == 1
+
+
+def test_server_uses_default_project_when_omitted(tmp_path):
+    vault = tmp_path / "vault"
+    server = ExperimentServer(env={"EXPERIMENT_STORE_BACKEND": "vault",
+                                   "VAULT_DIR": str(vault),
+                                   "EXPERIMENT_PROJECT": "default-proj"})
+    handle_call(server, "experiment_start_run", {"experiment": "e", "goal": "g"})
+    assert (vault / "10-projects" / "default-proj" / "experiments" / "e" / "runs").exists()
+
+
+def test_stores_cached_per_project(tmp_path):
+    server = ExperimentServer(env={"EXPERIMENT_STORE_BACKEND": "vault",
+                                   "VAULT_DIR": str(tmp_path)})
+    assert server.stores_for("x") is server.stores_for("x")
+    assert server.stores_for("x") is not server.stores_for("y")

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -125,3 +125,34 @@ def test_stores_cached_per_project(tmp_path):
                                    "VAULT_DIR": str(tmp_path)})
     assert server.stores_for("x") is server.stores_for("x")
     assert server.stores_for("x") is not server.stores_for("y")
+
+
+# -- list_runs dispatch + error-branch coverage ------------------------------
+
+def test_list_runs_dispatches_through_handle_call(local_server):
+    for goal in ("g1", "g2"):
+        handle_call(local_server, "experiment_start_run", {"experiment": "exp", "goal": goal})
+    text, err = handle_call(local_server, "experiment_list_runs", {"experiment": "exp"})
+    assert not err
+    runs = json.loads(text)
+    assert {r["run_id"] for r in runs} == {"exp/run-001", "exp/run-002"}
+
+
+def test_list_runs_empty_for_unknown_experiment(local_server):
+    text, err = handle_call(local_server, "experiment_list_runs", {"experiment": "nope"})
+    assert not err
+    assert json.loads(text) == []
+
+
+def test_invalid_experiment_name_returns_error_not_traceback(local_server):
+    # Traversal name -> ValueError in the store -> caught by the
+    # (ValueError, RuntimeError) branch and returned as an error tuple.
+    text, err = handle_call(local_server, "experiment_start_run", {"experiment": "../evil"})
+    assert err
+    assert text  # carries a message, not empty
+
+
+def test_missing_required_arg_returns_error(local_server):
+    # No 'experiment' -> KeyError branch -> error tuple, never a raw exception.
+    _, err = handle_call(local_server, "experiment_start_run", {})
+    assert err

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1,0 +1,85 @@
+"""Tests for the experiment MCP server's tool surface and dispatch.
+
+The stdio loop mirrors workflow_server.py; the dispatch is extracted into
+handle_call() so it can be exercised without the JSON-RPC transport.
+"""
+
+import json
+
+import pytest
+
+from experiment_store import LocalFsExperimentStore, open_experiment_writer
+from experiment_server import TOOLS, handle_call, store_from_env
+
+
+_WRITER_TOOLS = {"experiment_start_run", "experiment_record_observation", "experiment_end_run"}
+_READER_TOOLS = {"experiment_list_runs", "experiment_get_run", "experiment_observations"}
+
+
+@pytest.fixture
+def rw(tmp_path):
+    store = LocalFsExperimentStore(tmp_path / "e")
+    writer = open_experiment_writer(store, memory=False)
+    return store, writer
+
+
+def test_tools_list_covers_reader_and_writer():
+    names = {t["name"] for t in TOOLS}
+    assert _WRITER_TOOLS <= names
+    assert _READER_TOOLS <= names
+    for t in TOOLS:
+        assert "inputSchema" in t and t["description"]
+
+
+def test_start_record_observations_roundtrip(rw):
+    store, writer = rw
+    text, err = handle_call(store, writer, "experiment_start_run",
+                            {"experiment": "exp", "goal": "g"})
+    assert not err
+    run_id = json.loads(text)["run_id"]
+
+    _, err = handle_call(store, writer, "experiment_record_observation",
+                         {"run_id": run_id, "observation": {"title": "t", "hypothesis": "h"}})
+    assert not err
+
+    text, err = handle_call(store, writer, "experiment_observations", {"run_id": run_id})
+    assert not err
+    obs = json.loads(text)
+    assert len(obs) == 1 and obs[0]["title"] == "t" and obs[0]["number"] == 1
+
+
+def test_end_run_and_get_run(rw):
+    store, writer = rw
+    run_id = json.loads(handle_call(store, writer, "experiment_start_run",
+                                    {"experiment": "exp", "goal": "g"})[0])["run_id"]
+    _, err = handle_call(store, writer, "experiment_end_run",
+                         {"run_id": run_id, "outcome": "success", "metrics": {"acc": 1.0}})
+    assert not err
+    text, err = handle_call(store, writer, "experiment_get_run", {"run_id": run_id})
+    assert not err
+    run = json.loads(text)
+    assert run["outcome"] == "success" and run["metrics"]["acc"] == 1.0
+
+
+def test_get_run_missing_is_error(rw):
+    store, writer = rw
+    _, err = handle_call(store, writer, "experiment_get_run", {"run_id": "exp/run-999"})
+    assert err
+
+
+def test_unknown_tool_is_error(rw):
+    store, writer = rw
+    _, err = handle_call(store, writer, "experiment_bogus", {})
+    assert err
+
+
+def test_store_from_env_local(tmp_path):
+    env = {"EXPERIMENT_STORE_BACKEND": "local",
+           "EXPERIMENT_STORE_ROOT": str(tmp_path / "e")}
+    assert isinstance(store_from_env(env), LocalFsExperimentStore)
+
+
+def test_store_from_env_defaults_to_vault(tmp_path):
+    from experiment_store import VaultExperimentStore
+    env = {"VAULT_DIR": str(tmp_path), "EXPERIMENT_PROJECT": "agent-swarm"}
+    assert isinstance(store_from_env(env), VaultExperimentStore)

--- a/tests/test_experiment_store.py
+++ b/tests/test_experiment_store.py
@@ -153,6 +153,23 @@ def test_none_sink_is_pure_passthrough(tmp_path):
     assert len(base.observations(rid)) == 1
 
 
+def test_mirror_receives_authoritative_identity(tmp_path):
+    # Regression (greptile P1 "Mirror loses observation identity"): the sink must
+    # receive each observation carrying the run_id + sequence number the base
+    # writer assigned, not the unset (None) input values — otherwise the mirrored
+    # memory doc records run_id='' and number 0 instead of the real identity.
+    base = LocalFsExperimentStore(tmp_path / "e")
+    sink = _FakeSink(available=True)
+    w = MemoryMirrorWriter(base, sink)
+    rid = w.start_run("exp", "g")
+    w.record_observation(rid, Observation(title="first"))
+    w.record_observation(rid, Observation(title="second"))
+    (_, oid1, obs1), (_, oid2, obs2) = sink.records
+    assert (obs1.run_id, obs1.number) == (rid, 1)
+    assert (obs2.run_id, obs2.number) == (rid, 2)
+    assert (oid1, oid2) == (f"{rid}#001", f"{rid}#002")
+
+
 def test_mirror_writer_delegates_run_lifecycle(tmp_path):
     base = LocalFsExperimentStore(tmp_path / "e")
     w = MemoryMirrorWriter(base, _FakeSink())
@@ -235,3 +252,100 @@ def test_open_writer_wraps_with_memory_mirror(tmp_path):
 def test_open_writer_without_memory(tmp_path):
     store = make_experiment_backend("local", root=tmp_path / "e")
     assert open_experiment_writer(store, memory=False).sink is None
+
+
+# ---------------------------------------------------------------------------
+# Hardening: tenancy guard (validate_experiment_name) + real subprocess sink
+# ---------------------------------------------------------------------------
+
+import os  # noqa: E402
+
+from experiment_store import validate_experiment_name  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "bad", ["../escape", "..", ".", ".hidden", "a/b", "a" + chr(92) + "b", "", "  "]
+)
+def test_validate_experiment_name_rejects_unsafe(bad):
+    with pytest.raises(ValueError):
+        validate_experiment_name(bad)
+
+
+def test_validate_experiment_name_accepts_plain():
+    assert validate_experiment_name("exp-a") == "exp-a"
+
+
+def test_start_run_rejects_traversal_experiment(store):
+    with pytest.raises(ValueError):
+        store.start_run("../escape", "g")
+
+
+def test_list_runs_rejects_traversal_experiment(store):
+    with pytest.raises(ValueError):
+        store.list_runs("..")
+
+
+def test_vault_store_rejects_traversal_project(tmp_path):
+    with pytest.raises(ValueError):
+        VaultExperimentStore(tmp_path / "vault", "../evil")
+
+
+def _fake_memory_bin(tmp_path, *, exit_code=0, capture_env=False):
+    """A minimal stand-in for the memory CLI: records its argv + stdin (or its
+    MEMORY_VAULT_DIR) to a log file and exits ``exit_code``."""
+    bin_path = tmp_path / "memory"
+    log = tmp_path / "memory_call.log"
+    if capture_env:
+        script = f'''#!/usr/bin/env python3
+import os
+open({str(log)!r}, "w").write(os.environ.get("MEMORY_VAULT_DIR", ""))
+'''
+    else:
+        script = f'''#!/usr/bin/env python3
+import sys
+open({str(log)!r}, "w").write(repr(sys.argv[1:]) + chr(10) + sys.stdin.read())
+sys.exit({exit_code})
+'''
+    bin_path.write_text(script)
+    bin_path.chmod(0o755)
+    return bin_path, log
+
+
+def _env_with_path(**extra):
+    env = {"PATH": os.environ.get("PATH", "")}
+    env.update(extra)
+    return env
+
+
+def test_memory_sink_available_true_when_bin_exists(tmp_path):
+    bin_path, _ = _fake_memory_bin(tmp_path)
+    assert MemoryPluginSink(memory_bin=bin_path).available() is True
+
+
+def test_memory_sink_record_invokes_bin_with_args_and_body(tmp_path):
+    bin_path, log = _fake_memory_bin(tmp_path)
+    sink = MemoryPluginSink(memory_bin=bin_path,
+                            env=_env_with_path(MEMORY_VAULT_DIR=str(tmp_path)))
+    obs = Observation(title="My Title", run_id="exp-a/run-001", number=2, diagnosis="d")
+    sink.record("exp-a", "exp-a/run-001#002", obs)
+    logged = log.read_text()
+    assert "write" in logged                 # subcommand
+    assert "exp-a" in logged                  # --subject value
+    assert "My Title" in logged               # --description value
+    assert "Source: experiment" in logged     # rendered body arrived on stdin
+
+
+def test_memory_sink_record_raises_on_nonzero_exit(tmp_path):
+    bin_path, _ = _fake_memory_bin(tmp_path, exit_code=3)
+    sink = MemoryPluginSink(memory_bin=bin_path, env=_env_with_path())
+    with pytest.raises(RuntimeError):
+        sink.record("exp-a", "obs-1", Observation(title="t"))
+
+
+def test_memory_sink_bridges_vault_dir_into_subprocess_env(tmp_path):
+    bin_path, log = _fake_memory_bin(tmp_path, capture_env=True)
+    # VAULT_DIR present, MEMORY_VAULT_DIR absent -> bridged for the child.
+    sink = MemoryPluginSink(memory_bin=bin_path,
+                            env=_env_with_path(VAULT_DIR=str(tmp_path / "v")))
+    sink.record("exp", "obs", Observation(title="t"))
+    assert log.read_text() == str(tmp_path / "v")

--- a/tests/test_experiment_store.py
+++ b/tests/test_experiment_store.py
@@ -1,0 +1,237 @@
+"""Tests for the experiment (reader, writer) store.
+
+Slice 1: the local-filesystem backend implementing the experiment_reader /
+experiment_writer contract (start_run / record_observation / end_run;
+list_runs / get_run / observations). Storage is canonical + inspectable on
+disk; a fresh store instance reads back what a prior one wrote.
+"""
+
+import pytest
+
+from experiment_store import (
+    Observation,
+    Run,
+    ExperimentReader,
+    ExperimentWriter,
+    LocalFsExperimentStore,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LocalFsExperimentStore(tmp_path / "experiments")
+
+
+def test_backend_implements_both_reader_and_writer(store):
+    assert isinstance(store, ExperimentReader)
+    assert isinstance(store, ExperimentWriter)
+
+
+def test_start_run_returns_locatable_run(store):
+    run_id = store.start_run("exp-a", "objective X")
+    run = store.get_run(run_id)
+    assert isinstance(run, Run)
+    assert run.experiment == "exp-a"
+    assert run.goal == "objective X"
+    assert run.started_at
+    assert run.ended_at is None
+
+
+def test_record_observation_numbers_sequentially(store):
+    run_id = store.start_run("exp-a", "g")
+    store.record_observation(run_id, Observation(title="first", hypothesis="h1"))
+    store.record_observation(run_id, Observation(title="second", changes="c2"))
+    obs = store.observations(run_id)
+    assert [o.number for o in obs] == [1, 2]
+    assert obs[0].title == "first"
+    assert obs[0].hypothesis == "h1"
+    assert obs[0].run_id == run_id
+    assert obs[1].changes == "c2"
+
+
+def test_observations_empty_for_new_run(store):
+    run_id = store.start_run("exp-a", "g")
+    assert store.observations(run_id) == []
+
+
+def test_end_run_records_outcome_and_metrics(store):
+    run_id = store.start_run("exp-a", "g")
+    store.end_run(run_id, outcome="success", metrics={"accuracy": 0.95})
+    run = store.get_run(run_id)
+    assert run.outcome == "success"
+    assert run.metrics["accuracy"] == 0.95
+    assert run.ended_at is not None
+
+
+def test_list_runs_scoped_to_experiment(store):
+    r1 = store.start_run("exp-a", "g")
+    r2 = store.start_run("exp-a", "g2")
+    store.start_run("exp-b", "g3")
+    runs = store.list_runs("exp-a")
+    assert {r.run_id for r in runs} == {r1, r2}
+
+
+def test_multiline_observation_prose_round_trips(store):
+    run_id = store.start_run("exp-a", "g")
+    prose = "line one\nline two\n\nparagraph two"
+    store.record_observation(run_id, Observation(title="t", diagnosis=prose))
+    (obs,) = store.observations(run_id)
+    assert obs.diagnosis == prose
+
+
+def test_persists_across_instances(tmp_path):
+    root = tmp_path / "experiments"
+    run_id = LocalFsExperimentStore(root).start_run("exp-a", "g")
+    LocalFsExperimentStore(root).record_observation(run_id, Observation(title="t"))
+    obs = LocalFsExperimentStore(root).observations(run_id)
+    assert len(obs) == 1
+    assert obs[0].title == "t"
+
+
+def test_get_run_missing_raises(store):
+    with pytest.raises(KeyError):
+        store.get_run("exp-a/run-999")
+
+
+# ---------------------------------------------------------------------------
+# Slice 2: presence-gated memory mirroring
+# ---------------------------------------------------------------------------
+
+from experiment_store import MemoryMirrorWriter, MemoryPluginSink  # noqa: E402
+
+
+class _FakeSink:
+    def __init__(self, available=True, fail=False):
+        self._available = available
+        self._fail = fail
+        self.records = []
+
+    def available(self):
+        return self._available
+
+    def record(self, experiment, obs_id, observation):
+        if self._fail:
+            raise RuntimeError("memory down")
+        self.records.append((experiment, obs_id, observation))
+
+
+def test_mirrors_observation_when_sink_available(tmp_path):
+    base = LocalFsExperimentStore(tmp_path / "e")
+    sink = _FakeSink(available=True)
+    w = MemoryMirrorWriter(base, sink)
+    rid = w.start_run("exp", "g")
+    w.record_observation(rid, Observation(title="t"))
+    assert len(sink.records) == 1
+    assert sink.records[0][0] == "exp"
+    assert len(base.observations(rid)) == 1  # base is authoritative
+
+
+def test_no_mirror_when_sink_unavailable(tmp_path):
+    base = LocalFsExperimentStore(tmp_path / "e")
+    sink = _FakeSink(available=False)
+    w = MemoryMirrorWriter(base, sink)
+    rid = w.start_run("exp", "g")
+    w.record_observation(rid, Observation(title="t"))
+    assert sink.records == []
+    assert len(base.observations(rid)) == 1
+
+
+def test_sink_failure_does_not_break_base_write(tmp_path):
+    base = LocalFsExperimentStore(tmp_path / "e")
+    sink = _FakeSink(available=True, fail=True)
+    w = MemoryMirrorWriter(base, sink)
+    rid = w.start_run("exp", "g")
+    w.record_observation(rid, Observation(title="t"))  # must not raise
+    assert len(base.observations(rid)) == 1
+
+
+def test_none_sink_is_pure_passthrough(tmp_path):
+    base = LocalFsExperimentStore(tmp_path / "e")
+    w = MemoryMirrorWriter(base, None)
+    rid = w.start_run("exp", "g")
+    w.record_observation(rid, Observation(title="t"))
+    assert len(base.observations(rid)) == 1
+
+
+def test_mirror_writer_delegates_run_lifecycle(tmp_path):
+    base = LocalFsExperimentStore(tmp_path / "e")
+    w = MemoryMirrorWriter(base, _FakeSink())
+    rid = w.start_run("exp", "g")
+    w.end_run(rid, "success", {"acc": 1.0})
+    assert base.get_run(rid).outcome == "success"
+
+
+def test_memory_sink_unavailable_when_bin_missing(tmp_path):
+    sink = MemoryPluginSink(memory_bin=tmp_path / "nope" / "memory")
+    assert sink.available() is False
+
+
+def test_memory_sink_maps_observation_to_memory_write_args(tmp_path):
+    sink = MemoryPluginSink(memory_bin=tmp_path / "memory")
+    obs = Observation(title="My Title", run_id="exp-a/run-001", number=2)
+    args = sink._write_args("exp-a", "exp-a/run-001#002", obs)
+    assert args[:2] == [str(tmp_path / "memory"), "write"]
+    assert "--type" in args and "project" in args
+    assert "--subject" in args and "exp-a" in args
+    # name must be a safe basename (no '/' or '#')
+    name = args[args.index("--name") + 1]
+    assert "/" not in name and "#" not in name
+    assert "--description" in args and "My Title" in args
+
+
+# ---------------------------------------------------------------------------
+# Slice 3/4: vault backend + backend-selection factory
+# ---------------------------------------------------------------------------
+
+from experiment_store import (  # noqa: E402
+    VaultExperimentStore,
+    make_experiment_backend,
+    open_experiment_writer,
+)
+
+
+def test_vault_backend_writes_under_project_experiments(tmp_path):
+    vault = tmp_path / "vault"
+    store = VaultExperimentStore(vault, "agent-swarm")
+    rid = store.start_run("exp-a", "g")
+    store.record_observation(rid, Observation(title="t"))
+    expected = vault / "10-projects" / "agent-swarm" / "experiments" / "exp-a" / "runs"
+    assert expected.exists()
+    assert len(store.observations(rid)) == 1
+
+
+def test_make_backend_local(tmp_path):
+    assert isinstance(make_experiment_backend("local", root=tmp_path / "e"),
+                      LocalFsExperimentStore)
+
+
+def test_make_backend_vault(tmp_path):
+    assert isinstance(make_experiment_backend("vault", vault_dir=tmp_path, project="p"),
+                      VaultExperimentStore)
+
+
+def test_make_backend_local_requires_root():
+    with pytest.raises(ValueError):
+        make_experiment_backend("local")
+
+
+def test_make_backend_vault_requires_project(tmp_path):
+    with pytest.raises(ValueError):
+        make_experiment_backend("vault", vault_dir=tmp_path)
+
+
+def test_make_backend_unknown():
+    with pytest.raises(ValueError):
+        make_experiment_backend("nope", root="x")
+
+
+def test_open_writer_wraps_with_memory_mirror(tmp_path):
+    store = make_experiment_backend("local", root=tmp_path / "e")
+    w = open_experiment_writer(store)
+    assert isinstance(w, MemoryMirrorWriter)
+    assert isinstance(w.sink, MemoryPluginSink)
+
+
+def test_open_writer_without_memory(tmp_path):
+    store = make_experiment_backend("local", root=tmp_path / "e")
+    assert open_experiment_writer(store, memory=False).sink is None

--- a/tests/test_experiment_wiring.py
+++ b/tests/test_experiment_wiring.py
@@ -1,0 +1,27 @@
+"""Guards the shipped wiring that makes the experiment MCP backend usable
+through the router: it must be registered as a backend AND granted in the
+global permission allowlist. Either missing means the tools are silently
+unreachable (exposed-but-blocked, or not spawned at all).
+"""
+
+import json
+from pathlib import Path
+
+import yaml
+
+_CONFIG = Path(__file__).parent.parent / "config"
+
+
+def test_experiment_backend_registered():
+    backends = json.loads((_CONFIG / "backends.json").read_text())
+    assert "experiment" in backends, "experiment backend missing from backends.json"
+    exp = backends["experiment"]
+    assert exp.get("tool_prefix") == "experiment"
+    assert exp["command"][-1].endswith("experiment_server.py")
+
+
+def test_experiment_tools_granted_globally():
+    perms = yaml.safe_load((_CONFIG / "permissions.yaml").read_text())
+    assert "experiment__*" in perms["global"]["allowed"], (
+        "experiment__* not in global.allowed — tools would be exposed but "
+        "denied by the permission checker")


### PR DESCRIPTION
## What

Builds the **experiment plugin's instance of the cross-plugin (reader, writer) contract** (2026-05-08 architecture) — the correctly-shaped version of "if a memory plugin is registered with experiment, it records through it, else it doesn't."

## Why

experiment was the one state-owning plugin with none of the contract: `experiment_harness.Journal` wrote straight to the local filesystem, no reader/writer surface, no way to use memory. This adds the pair, keeps memory **truly optional**, and exposes it the standard agent-swarm way (router backend), without disturbing the running workflow.

## How

- **`lib/experiment_store.py`**
  - `ExperimentReader` / `ExperimentWriter` interfaces (full run lifecycle: `start_run` / `record_observation` / `end_run`; `list_runs` / `get_run` / `observations`) + `Run` / `Observation` records.
  - Backends selected by config (plurality at the implementation level, per the contract): `VaultExperimentStore` (canonical default, `<vault>/10-projects/<project>/experiments/`) and `LocalFsExperimentStore`. Files are canonical + inspectable; a fresh instance reads back what a prior one wrote.
  - `MemoryMirrorWriter` + `MemoryPluginSink`: presence-gated, best-effort mirroring into a registered memory plugin's store (via `bin/memory write`, the same bridge continuity uses). An absent or failing sink **never** breaks the authoritative write — pass `sink=None` and it's a pure pass-through.
- **`lib/experiment_server.py`**: stdio MCP server exposing the six tools, mounted via `config/backends.json` as the `experiment` backend (`tool_prefix: experiment`), mirroring `workflow_server.py`. Dispatch is extracted into `handle_call()` for unit testing; verified end-to-end over real stdio JSON-RPC.

## Design provenance

Ratified in-session against the (reader, writer) contract: full run lifecycle; vault-canonical-but-configurable storage; MCP-via-router surface; memory additive + presence-gated. Signatures are "fine for now, change if practice shows we need to."

## Test

31 new tests (contract round-trips, both backends, memory presence-gating semantics, server dispatch + tool surface). **Full suite: 1547 passed, 224 skipped, 0 failed.**

## Additive / non-regressing

The existing `experiment_harness.Journal` and the experiment workflow are untouched. Follow-ups (separate PRs): migrate the journal-phase + session hooks onto `experiment_writer`; multi-project routing for the MCP server (currently one project subtree via `EXPERIMENT_PROJECT`); live-verify the backend after a daemon restart.

https://claude.ai/code/session_01UsWsdz52Gv61jMXBQvftvw